### PR TITLE
Use volume keys to navigate posts

### DIFF
--- a/app/src/main/java/ml/docilealligator/infinityforreddit/Activity/AccountPostsActivity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/Activity/AccountPostsActivity.java
@@ -5,6 +5,7 @@ import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.os.Build;
 import android.os.Bundle;
+import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -157,6 +158,11 @@ public class AccountPostsActivity extends BaseActivity implements SortTypeSelect
         } else {
             getCurrentAccountAndInitializeFragment();
         }
+    }
+
+    @Override
+    public boolean onKeyDown(int keyCode, KeyEvent event) {
+        return ((FragmentCommunicator) mFragment).handleKeyDown(keyCode) || super.onKeyDown(keyCode, event);
     }
 
     @Override

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/Activity/AccountSavedThingActivity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/Activity/AccountSavedThingActivity.java
@@ -5,6 +5,7 @@ import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.os.Build;
 import android.os.Bundle;
+import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -149,6 +150,11 @@ public class AccountSavedThingActivity extends BaseActivity {
         } else {
             getCurrentAccountAndInitializeViewPager();
         }
+    }
+
+    @Override
+    public boolean onKeyDown(int keyCode, KeyEvent event) {
+        return sectionsPagerAdapter.handleKeyDown(keyCode) || super.onKeyDown(keyCode, event);
     }
 
     @Override
@@ -337,6 +343,10 @@ public class AccountSavedThingActivity extends BaseActivity {
                     commentsListingFragment = (CommentsListingFragment) fragment;
             }
             return fragment;
+        }
+
+        public boolean handleKeyDown(int keyCode) {
+            return viewPager.getCurrentItem() == 0 && postFragment.handleKeyDown(keyCode);
         }
 
         public void refresh() {

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/Activity/FilteredThingActivity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/Activity/FilteredThingActivity.java
@@ -5,6 +5,7 @@ import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.os.Build;
 import android.os.Bundle;
+import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -174,6 +175,11 @@ public class FilteredThingActivity extends BaseActivity implements SortTypeSelec
         }
 
         postLayoutBottomSheetFragment = new PostLayoutBottomSheetFragment();
+    }
+
+    @Override
+    public boolean onKeyDown(int keyCode, KeyEvent event) {
+        return ((FragmentCommunicator) mFragment).handleKeyDown(keyCode) || super.onKeyDown(keyCode, event);
     }
 
     @Override

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/Activity/MainActivity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/Activity/MainActivity.java
@@ -8,6 +8,7 @@ import android.content.res.Resources;
 import android.os.Build;
 import android.os.Bundle;
 import android.util.TypedValue;
+import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -864,6 +865,11 @@ public class MainActivity extends BaseActivity implements SortTypeSelectionCallb
     }
 
     @Override
+    public boolean onKeyDown(int keyCode, KeyEvent event) {
+        return sectionsPagerAdapter.handleKeyDown(keyCode) || super.onKeyDown(keyCode, event);
+    }
+
+    @Override
     protected void onSaveInstanceState(@NonNull Bundle outState) {
         super.onSaveInstanceState(outState);
         outState.putBoolean(FETCH_USER_INFO_STATE, mFetchUserInfoSuccess);
@@ -1069,6 +1075,27 @@ public class MainActivity extends BaseActivity implements SortTypeSelectionCallb
                 }
             }
             return fragment;
+        }
+
+        boolean handleKeyDown(int keyCode) {
+            if (mAccessToken == null) {
+                switch (viewPager.getCurrentItem()) {
+                    case 0:
+                        return popularPostFragment.handleKeyDown(keyCode);
+                    case 1:
+                        return allPostFragment.handleKeyDown(keyCode);
+                }
+            } else {
+                switch (viewPager.getCurrentItem()) {
+                    case 0:
+                        return frontPagePostFragment.handleKeyDown(keyCode);
+                    case 1:
+                        return popularPostFragment.handleKeyDown(keyCode);
+                    case 2:
+                        return allPostFragment.handleKeyDown(keyCode);
+                }
+            }
+            return false;
         }
 
         boolean startLazyMode() {

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/Activity/SearchResultActivity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/Activity/SearchResultActivity.java
@@ -6,6 +6,7 @@ import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.os.Build;
 import android.os.Bundle;
+import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -168,6 +169,11 @@ public class SearchResultActivity extends BaseActivity implements SortTypeSelect
             mQuery = query;
             setTitle(query);
         }
+    }
+
+    @Override
+    public boolean onKeyDown(int keyCode, KeyEvent event) {
+        return sectionsPagerAdapter.handleKeyDown(keyCode) || super.onKeyDown(keyCode, event);
     }
 
     @Override
@@ -366,6 +372,10 @@ public class SearchResultActivity extends BaseActivity implements SortTypeSelect
                     break;
             }
             return fragment;
+        }
+
+        public boolean handleKeyDown(int keyCode) {
+            return viewPager.getCurrentItem() == 0 && postFragment.handleKeyDown(keyCode);
         }
 
         void changeSortType(SortType sortType) {

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/Activity/ViewSubredditDetailActivity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/Activity/ViewSubredditDetailActivity.java
@@ -7,6 +7,7 @@ import android.content.res.Resources;
 import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Bundle;
+import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -320,6 +321,11 @@ public class ViewSubredditDetailActivity extends BaseActivity implements SortTyp
 
             postTypeBottomSheetFragment.show(getSupportFragmentManager(), postTypeBottomSheetFragment.getTag());
         });
+    }
+
+    @Override
+    public boolean onKeyDown(int keyCode, KeyEvent event) {
+        return ((FragmentCommunicator)(mFragment)).handleKeyDown(keyCode) || super.onKeyDown(keyCode, event);
     }
 
     @Override

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/Activity/ViewUserDetailActivity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/Activity/ViewUserDetailActivity.java
@@ -8,6 +8,7 @@ import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Bundle;
 import android.util.TypedValue;
+import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -397,6 +398,11 @@ public class ViewUserDetailActivity extends BaseActivity implements SortTypeSele
     }
 
     @Override
+    public boolean onKeyDown(int keyCode, KeyEvent event) {
+        return sectionsPagerAdapter.handleKeyDown(keyCode) || super.onKeyDown(keyCode, event);
+    }
+
+    @Override
     public SharedPreferences getSharedPreferences() {
         return mSharedPreferences;
     }
@@ -739,6 +745,10 @@ public class ViewUserDetailActivity extends BaseActivity implements SortTypeSele
                     commentsListingFragment = (CommentsListingFragment) fragment;
             }
             return fragment;
+        }
+
+        public boolean handleKeyDown(int keyCode) {
+            return viewPager.getCurrentItem() == 0 && postFragment.handleKeyDown(keyCode);
         }
 
         public void refresh() {

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/Fragment/PostFragment.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/Fragment/PostFragment.java
@@ -122,7 +122,6 @@ public class PostFragment extends Fragment implements FragmentCommunicator {
     private CountDownTimer resumeLazyModeCountDownTimer;
     private float lazyModeInterval;
     private int postLayout;
-    private boolean mIsSmoothScrolling = false;
 
     public PostFragment() {
         // Required empty public constructor
@@ -140,7 +139,6 @@ public class PostFragment extends Fragment implements FragmentCommunicator {
     }
 
     private boolean scrollPostsByCount(int count) {
-        mIsSmoothScrolling = true;
         if (mLinearLayoutManager != null) {
             int pos = mLinearLayoutManager.findFirstVisibleItemPosition();
             int targetPosition = pos + count;
@@ -187,16 +185,6 @@ public class PostFragment extends Fragment implements FragmentCommunicator {
                 return LinearSmoothScroller.SNAP_TO_START;
             }
         };
-
-        mPostRecyclerView.clearOnScrollListeners();
-        mPostRecyclerView.addOnScrollListener(new RecyclerView.OnScrollListener() {
-            @Override
-            public void onScrollStateChanged(@NonNull RecyclerView recyclerView, int newState) {
-                if (newState == RecyclerView.SCROLL_STATE_IDLE) {
-                    mIsSmoothScrolling = false;
-                }
-            }
-        });
 
         window = activity.getWindow();
 
@@ -298,12 +286,10 @@ public class PostFragment extends Fragment implements FragmentCommunicator {
             mPostRecyclerView.addOnScrollListener(new RecyclerView.OnScrollListener() {
                 @Override
                 public void onScrolled(@NonNull RecyclerView recyclerView, int dx, int dy) {
-                    if (!mIsSmoothScrolling) {
-                        if (dy > 0) {
-                            ((MainActivity) activity).postScrollDown();
-                        } else if (dy < 0) {
-                            ((MainActivity) activity).postScrollUp();
-                        }
+                    if (dy > 0) {
+                        ((MainActivity) activity).postScrollDown();
+                    } else if (dy < 0) {
+                        ((MainActivity) activity).postScrollUp();
                     }
 
                 }

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/FragmentCommunicator.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/FragmentCommunicator.java
@@ -3,6 +3,8 @@ package ml.docilealligator.infinityforreddit;
 public interface FragmentCommunicator {
     void refresh();
 
+    default boolean handleKeyDown(int keyCode) { return false; }
+
     default void changeNSFW(boolean nsfw) {
     }
 

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/Utils/SharedPreferencesUtils.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/Utils/SharedPreferencesUtils.java
@@ -59,4 +59,5 @@ public class SharedPreferencesUtils {
     public static final String SHOW_ELAPSED_TIME_KEY = "show_elapsed_time";
     public static final String SWIPE_RIGHT_TO_GO_BACK_FROM_POST_DETAIL = "swipe_to_go_back_from_post_detail";
     public static final String VOLUME_KEYS_NAVIGATE_COMMENTS = "volume_keys_navigate_comments";
+    public static final String VOLUME_KEYS_NAVIGATE_POSTS = "volume_keys_navigate_posts";
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -291,6 +291,7 @@
     <string name="settings_immersive_interface_title">Immersive Interface</string>
     <string name="settings_vote_buttons_on_the_right_title">Vote Buttons on the Right</string>
     <string name="settings_volume_keys_navigate_comments_title">Use Volume Keys to Navigate Comments in Posts</string>
+    <string name="settings_volume_keys_navigate_posts_title">Use Volume Keys to Navigate Posts</string>
     <string name="settings_show_elapsed_time">Show Elpased Time in Posts and Comments</string>
     <string name="swipe_to_go_back_from_post_detail">Swipe Right to Go Back From Comments</string>
     <string name="settings_lazy_mode_interval_title">Lazy Mode Interval</string>

--- a/app/src/main/res/xml/main_preferences.xml
+++ b/app/src/main/res/xml/main_preferences.xml
@@ -46,6 +46,11 @@
         app:key="volume_keys_navigate_comments"
         app:title="@string/settings_volume_keys_navigate_comments_title" />
 
+    <SwitchPreference
+        app:defaultValue="false"
+        app:key="volume_keys_navigate_posts"
+        app:title="@string/settings_volume_keys_navigate_posts_title" />
+
     <Preference
         app:title="@string/settings_font_size_title"
         app:icon="@drawable/ic_font_size_24dp"


### PR DESCRIPTION
Similarly to how volume keys can already be used to scroll comments, this patch adds the option to also use volume keys to scroll posts. This patch only adds support for volume key scrolling for the single column (portrait) layout.