### PR TITLE
Add hidden comment toolbar feature.

### DIFF
--- a/app/src/main/java/ml/docilealligator/infinityforreddit/Activity/ViewPostDetailActivity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/Activity/ViewPostDetailActivity.java
@@ -177,6 +177,8 @@ public class ViewPostDetailActivity extends BaseActivity implements FlairBottomS
     private boolean mLockFab;
     private boolean mSwipeUpToHideFab;
     private boolean mExpandChildren;
+    private boolean mCommentToolbarHidden;
+    private boolean mCommentToolbarHideOnClick;
     private boolean mShowCommentDivider;
     private boolean mShowAbsoluteNumberOfVotes;
     private LinearLayoutManager mLinearLayoutManager;
@@ -243,6 +245,8 @@ public class ViewPostDetailActivity extends BaseActivity implements FlairBottomS
         mLockFab = mSharedPreferences.getBoolean(SharedPreferencesUtils.LOCK_JUMP_TO_NEXT_TOP_LEVEL_COMMENT_BUTTON, false);
         mSwipeUpToHideFab = mSharedPreferences.getBoolean(SharedPreferencesUtils.SWIPE_UP_TO_HIDE_JUMP_TO_NEXT_TOP_LEVEL_COMMENT_BUTTON, false);
         mExpandChildren = !mSharedPreferences.getBoolean(SharedPreferencesUtils.SHOW_TOP_LEVEL_COMMENTS_FIRST, false);
+        mCommentToolbarHidden = mSharedPreferences.getBoolean(SharedPreferencesUtils.COMMENT_TOOLBAR_HIDDEN, false);
+        mCommentToolbarHideOnClick= mSharedPreferences.getBoolean(SharedPreferencesUtils.COMMENT_TOOLBAR_HIDE_ON_CLICK, true);
         mShowCommentDivider = mSharedPreferences.getBoolean(SharedPreferencesUtils.SHOW_COMMENT_DIVIDER, false);
         mShowAbsoluteNumberOfVotes = mSharedPreferences.getBoolean(SharedPreferencesUtils.SHOW_ABSOLUTE_NUMBER_OF_VOTES, true);
 
@@ -500,8 +504,8 @@ public class ViewPostDetailActivity extends BaseActivity implements FlairBottomS
             mAdapter = new CommentAndPostRecyclerViewAdapter(ViewPostDetailActivity.this,
                     mCustomThemeWrapper, mRetrofit, mOauthRetrofit, mRedditDataRoomDatabase, mGlide,
                     mAccessToken, mAccountName, mPost, mLocale, mSingleCommentId, isSingleCommentThreadMode,
-                    mNeedBlurNsfw, mNeedBlurSpoiler, mVoteButtonsOnTheRight, mShowElapsedTime,
-                    mExpandChildren, mShowCommentDivider, mShowAbsoluteNumberOfVotes,
+                    mNeedBlurNsfw, mNeedBlurSpoiler, mVoteButtonsOnTheRight, mShowElapsedTime, mExpandChildren,
+                    mCommentToolbarHidden, mCommentToolbarHideOnClick, mShowCommentDivider,mShowAbsoluteNumberOfVotes,
                     new CommentAndPostRecyclerViewAdapter.CommentRecyclerViewAdapterCallback() {
                         @Override
                         public void updatePost(Post post) {
@@ -630,10 +634,9 @@ public class ViewPostDetailActivity extends BaseActivity implements FlairBottomS
 
                             mAdapter = new CommentAndPostRecyclerViewAdapter(ViewPostDetailActivity.this,
                                     mCustomThemeWrapper, mRetrofit, mOauthRetrofit, mRedditDataRoomDatabase, mGlide,
-                                    mAccessToken, mAccountName, mPost, mLocale, mSingleCommentId,
-                                    isSingleCommentThreadMode, mNeedBlurNsfw, mNeedBlurSpoiler,
-                                    mVoteButtonsOnTheRight, mShowElapsedTime, mExpandChildren, mShowCommentDivider,
-                                    mShowAbsoluteNumberOfVotes,
+                                    mAccessToken, mAccountName, mPost, mLocale, mSingleCommentId, isSingleCommentThreadMode,
+                                    mNeedBlurNsfw, mNeedBlurSpoiler, mVoteButtonsOnTheRight, mShowElapsedTime, mExpandChildren,
+                                    mCommentToolbarHidden, mCommentToolbarHideOnClick, mShowCommentDivider, mShowAbsoluteNumberOfVotes,
                                     new CommentAndPostRecyclerViewAdapter.CommentRecyclerViewAdapterCallback() {
                                         @Override
                                         public void updatePost(Post post) {

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/Adapter/CommentAndPostRecyclerViewAdapter.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/Adapter/CommentAndPostRecyclerViewAdapter.java
@@ -17,6 +17,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.ImageView;
+import android.widget.LinearLayout;
 import android.widget.ProgressBar;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
@@ -125,6 +126,8 @@ public class CommentAndPostRecyclerViewAdapter extends RecyclerView.Adapter<Recy
     private boolean mVoteButtonsOnTheRight;
     private boolean mShowElapsedTime;
     private boolean mExpandChildren;
+    private boolean mCommentToolbarHidden;
+    private boolean mCommentToolbarHideOnClick;
     private boolean mShowCommentDivider;
     private boolean mShowAbsoluteNumberOfVotes;
     private CommentRecyclerViewAdapterCallback mCommentRecyclerViewAdapterCallback;
@@ -185,7 +188,8 @@ public class CommentAndPostRecyclerViewAdapter extends RecyclerView.Adapter<Recy
                                              String accessToken, String accountName, Post post, Locale locale,
                                              String singleCommentId, boolean isSingleCommentThreadMode,
                                              boolean needBlurNSFW, boolean needBlurSpoiler, boolean voteButtonsOnTheRight,
-                                             boolean showElapsedTime, boolean expandChildren, boolean showCommentDivider,
+                                             boolean showElapsedTime, boolean expandChildren, boolean commentToolbarHidden,
+                                             boolean commentToolbarHideOnClick, boolean showCommentDivider,
                                              boolean showAbsoluteNumberOfVotes,
                                              CommentRecyclerViewAdapterCallback commentRecyclerViewAdapterCallback) {
         mActivity = activity;
@@ -277,6 +281,8 @@ public class CommentAndPostRecyclerViewAdapter extends RecyclerView.Adapter<Recy
         mVoteButtonsOnTheRight = voteButtonsOnTheRight;
         mShowElapsedTime = showElapsedTime;
         mExpandChildren = expandChildren;
+        mCommentToolbarHidden = commentToolbarHidden;
+        mCommentToolbarHideOnClick = commentToolbarHideOnClick;
         mShowCommentDivider = showCommentDivider;
         mShowAbsoluteNumberOfVotes = showAbsoluteNumberOfVotes;
         mCommentRecyclerViewAdapterCallback = commentRecyclerViewAdapterCallback;
@@ -846,9 +852,19 @@ public class CommentAndPostRecyclerViewAdapter extends RecyclerView.Adapter<Recy
                 ((CommentViewHolder) holder).commentTimeTextView.setText(comment.getCommentTime());
             }
 
+            if (mCommentToolbarHidden) {
+                ((CommentViewHolder) holder).bottomConstraintLayout.setVisibility(View.GONE);
+                ((CommentViewHolder) holder).topScoreTextView.setVisibility(View.VISIBLE);
+            } else {
+                ((CommentViewHolder) holder).bottomConstraintLayout.setVisibility(View.VISIBLE);
+                ((CommentViewHolder) holder).topScoreTextView.setVisibility(View.GONE);
+            }
+
             mCommentMarkwon.setMarkdown(((CommentViewHolder) holder).commentMarkdownView, comment.getCommentMarkdown());
             ((CommentViewHolder) holder).scoreTextView.setText(Utils.getNVotes(mShowAbsoluteNumberOfVotes,
                     comment.getScore() + comment.getVoteType()));
+            ((CommentViewHolder) holder).topScoreTextView.setText(Utils.getNVotes(mShowAbsoluteNumberOfVotes,
+                    comment.getScore() + comment.getVoteType()) + " pts");
 
             ((CommentViewHolder) holder).itemView.setPadding(comment.getDepth() * 8, 0, 0, 0);
             if (comment.getDepth() > 0) {
@@ -885,6 +901,21 @@ public class CommentAndPostRecyclerViewAdapter extends RecyclerView.Adapter<Recy
                 ViewGroup.LayoutParams params = ((CommentViewHolder) holder).verticalBlock.getLayoutParams();
                 params.width = 8;
                 ((CommentViewHolder) holder).verticalBlock.setLayoutParams(params);
+            }
+
+            if (mCommentToolbarHideOnClick) {
+                View.OnClickListener hideToolbarOnClickListener = view -> {
+                    if (((CommentViewHolder) holder).bottomConstraintLayout.getVisibility() == View.GONE){
+                        ((CommentViewHolder) holder).bottomConstraintLayout.setVisibility(View.VISIBLE);
+                        ((CommentViewHolder) holder).topScoreTextView.setVisibility(View.GONE);
+                    } else {
+                        ((CommentViewHolder) holder).bottomConstraintLayout.setVisibility(View.GONE);
+                        ((CommentViewHolder) holder).topScoreTextView.setVisibility(View.VISIBLE);
+                    }
+                };
+                ((CommentViewHolder) holder).linearLayout.setOnClickListener(hideToolbarOnClickListener);
+                ((CommentViewHolder) holder).commentMarkdownView.setOnClickListener(hideToolbarOnClickListener);
+                ((CommentViewHolder) holder).commentTimeTextView.setOnClickListener(hideToolbarOnClickListener);
             }
 
             ((CommentViewHolder) holder).moreButton.setOnClickListener(view -> {
@@ -1002,6 +1033,8 @@ public class CommentAndPostRecyclerViewAdapter extends RecyclerView.Adapter<Recy
 
                 ((CommentViewHolder) holder).scoreTextView.setText(Utils.getNVotes(mShowAbsoluteNumberOfVotes,
                         comment.getScore() + comment.getVoteType()));
+                ((CommentViewHolder) holder).topScoreTextView.setText(Utils.getNVotes(mShowAbsoluteNumberOfVotes,
+                        comment.getScore() + comment.getVoteType()) + " pts");
 
                 VoteThing.voteThing(mActivity, mOauthRetrofit, mAccessToken, new VoteThing.VoteThingListener() {
                     @Override
@@ -1019,6 +1052,8 @@ public class CommentAndPostRecyclerViewAdapter extends RecyclerView.Adapter<Recy
                         ((CommentViewHolder) holder).downvoteButton.setColorFilter(mCommentIconAndInfoColor, android.graphics.PorterDuff.Mode.SRC_IN);
                         ((CommentViewHolder) holder).scoreTextView.setText(Utils.getNVotes(mShowAbsoluteNumberOfVotes,
                                 comment.getScore() + comment.getVoteType()));
+                        ((CommentViewHolder) holder).topScoreTextView.setText(Utils.getNVotes(mShowAbsoluteNumberOfVotes,
+                                comment.getScore() + comment.getVoteType()) + " pts");
                     }
 
                     @Override
@@ -1059,6 +1094,8 @@ public class CommentAndPostRecyclerViewAdapter extends RecyclerView.Adapter<Recy
 
                 ((CommentViewHolder) holder).scoreTextView.setText(Utils.getNVotes(mShowAbsoluteNumberOfVotes,
                         comment.getScore() + comment.getVoteType()));
+                ((CommentViewHolder) holder).topScoreTextView.setText(Utils.getNVotes(mShowAbsoluteNumberOfVotes,
+                        comment.getScore() + comment.getVoteType()) + " pts");
 
                 VoteThing.voteThing(mActivity, mOauthRetrofit, mAccessToken, new VoteThing.VoteThingListener() {
                     @Override
@@ -1076,6 +1113,8 @@ public class CommentAndPostRecyclerViewAdapter extends RecyclerView.Adapter<Recy
                         ((CommentViewHolder) holder).upvoteButton.setColorFilter(mCommentIconAndInfoColor, android.graphics.PorterDuff.Mode.SRC_IN);
                         ((CommentViewHolder) holder).scoreTextView.setText(Utils.getNVotes(mShowAbsoluteNumberOfVotes,
                                 comment.getScore() + comment.getVoteType()));
+                        ((CommentViewHolder) holder).topScoreTextView.setText(Utils.getNVotes(mShowAbsoluteNumberOfVotes,
+                                comment.getScore() + comment.getVoteType()) + " pts");
                     }
 
                     @Override
@@ -2059,6 +2098,8 @@ public class CommentAndPostRecyclerViewAdapter extends RecyclerView.Adapter<Recy
     }
 
     class CommentViewHolder extends RecyclerView.ViewHolder {
+        @BindView(R.id.linear_layout_item_comment)
+        LinearLayout linearLayout;
         @BindView(R.id.author_text_view_item_post_comment)
         TextView authorTextView;
         @BindView(R.id.author_flair_text_view_item_post_comment)
@@ -2067,6 +2108,8 @@ public class CommentAndPostRecyclerViewAdapter extends RecyclerView.Adapter<Recy
         ImageView authorTypeImageView;
         @BindView(R.id.comment_time_text_view_item_post_comment)
         TextView commentTimeTextView;
+        @BindView(R.id.top_score_text_view_item_post_comment)
+        TextView topScoreTextView;
         @BindView(R.id.comment_markdown_view_item_post_comment)
         TextView commentMarkdownView;
         @BindView(R.id.bottom_constraint_layout_item_post_comment)

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/Utils/SharedPreferencesUtils.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/Utils/SharedPreferencesUtils.java
@@ -75,6 +75,8 @@ public class SharedPreferencesUtils {
     public static final String SHOW_TOP_LEVEL_COMMENTS_FIRST = "show_top_level_comments_first";
     public static final String CONFIRM_TO_EXIT = "confirm_to_exit";
     public static final String LOCK_BOTTOM_APP_BAR = "lock_bottom_app_bar";
+    public static final String COMMENT_TOOLBAR_HIDDEN = "comment_toolbar_hidden";
+    public static final String COMMENT_TOOLBAR_HIDE_ON_CLICK = "comment_toolbar_hide_on_click";
     public static final String SHOW_COMMENT_DIVIDER = "show_comment_divider";
     public static final String SHOW_ABSOLUTE_NUMBER_OF_VOTES = "show_absolute_number_of_votes";
     public static final String CUSTOMIZE_LIGHT_THEME = "customize_light_theme";

--- a/app/src/main/res/layout/item_comment.xml
+++ b/app/src/main/res/layout/item_comment.xml
@@ -21,7 +21,8 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="12dp"
             android:layout_marginBottom="12dp"
-            android:orientation="vertical">
+            android:orientation="vertical"
+            android:animateLayoutChanges="true">
 
             <androidx.constraintlayout.widget.ConstraintLayout
                 android:layout_width="match_parent"
@@ -70,6 +71,17 @@
                     app:layout_constraintTop_toBottomOf="@id/author_text_view_item_post_comment" />
 
                 <TextView
+                    android:id="@+id/top_score_text_view_item_post_comment"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="8dp"
+                    android:gravity="end"
+                    android:textSize="?attr/font_default"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toStartOf="@id/comment_time_text_view_item_post_comment"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <TextView
                     android:id="@+id/comment_time_text_view_item_post_comment"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
@@ -84,7 +96,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     app:barrierDirection="start"
-                    app:constraint_referenced_ids="comment_time_text_view_item_post_comment" />
+                    app:constraint_referenced_ids="top_score_text_view_item_post_comment" />
 
             </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -314,6 +314,8 @@
     <string name="settings_confirm_to_exit">Confirm to Exit</string>
     <string name="settings_show_top_level_comments_first_title">Show Top-level Comments First</string>
     <string name="settings_show_comment_divider_title">Show Comment Divider</string>
+    <string name="settings_comment_toolbar_hide_on_click">Click to Show/Hide Comment Toolbar</string>
+    <string name="settings_comment_toolbar_hidden">Comment Toolbar Hidden by Default</string>
     <string name="settings_show_absolute_number_of_votes_title">Show Absolute Number of Votes</string>
     <string name="settings_show_elapsed_time">Show Elapsed Time in Posts and Comments</string>
     <string name="settings_default_post_layout">Default Post Layout</string>

--- a/app/src/main/res/xml/interface_preference.xml
+++ b/app/src/main/res/xml/interface_preference.xml
@@ -52,6 +52,16 @@
         app:title="@string/settings_show_comment_divider_title" />
 
     <SwitchPreference
+        app:defaultValue="false"
+        app:key="comment_toolbar_hidden"
+        app:title="@string/settings_comment_toolbar_hidden" />
+
+    <SwitchPreference
+        app:defaultValue="true"
+        app:key="comment_toolbar_hide_on_click"
+        app:title="@string/settings_comment_toolbar_hide_on_click" />
+
+    <SwitchPreference
         app:defaultValue="true"
         app:key="show_absolute_number_of_votes"
         app:title="@string/settings_show_absolute_number_of_votes_title" />


### PR DESCRIPTION
Implement #72 

I have added 2 settings options (toolbar hidden by default and show/hide on click).

I also added the upvotes count to the top. This is how it looks like:

![comment-no-toolbar](https://user-images.githubusercontent.com/34722728/77839643-d5806180-717e-11ea-8ce2-f546c651bab7.jpg)
