### PR TITLE
Fix image view with low resolution.

### DIFF
--- a/app/src/main/java/ml/docilealligator/infinityforreddit/Activity/ViewImageActivity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/Activity/ViewImageActivity.java
@@ -91,6 +91,7 @@ public class ViewImageActivity extends AppCompatActivity {
     private String mImageFileName;
     private float totalLengthY = 0.0f;
     private float touchY = -1.0f;
+    private float initialZoom = 1.0f;
     private float zoom = 1.0f;
     private boolean isSwiping = false;
     private RequestManager glide;
@@ -327,7 +328,7 @@ public class ViewImageActivity extends AppCompatActivity {
 
             @Override
             public void onStateReset(State oldState, State newState) {
-
+                initialZoom = newState.getZoom();
             }
         });
 
@@ -367,7 +368,7 @@ public class ViewImageActivity extends AppCompatActivity {
                 mProgressBar.setVisibility(View.GONE);
                 return false;
             }
-        }).apply(new RequestOptions().fitCenter()).into(mImageView);
+        }).into(mImageView);
     }
 
     @Override
@@ -455,7 +456,7 @@ public class ViewImageActivity extends AppCompatActivity {
 
     @Override
     public boolean dispatchTouchEvent(MotionEvent ev) {
-        if (zoom == 1.0) {
+        if (Math.abs(zoom - initialZoom) <= 0.000001) {
             swipe.dispatchTouchEvent(ev);
         }
         return super.dispatchTouchEvent(ev);


### PR DESCRIPTION
This pull request solves the problem of the image being rendered with a low resolution when zooming.

![infinity_image_preview](https://user-images.githubusercontent.com/34722728/81360452-266b6a00-90dc-11ea-81f5-e140e5aaee95.png)

Glide was resizing the image to fit the screen. Since the GestureImageView already does that by default, that's not necessary.

But when doing so, the initial zoom is not 1 anymore, so we need to compare to that instead.