### PR TITLE
Enable minify, reduce release apk size.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,9 @@ android {
     }
     buildTypes {
         release {
-            minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            minifyEnabled true
+            shrinkResources true
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     compileOptions {


### PR DESCRIPTION
This pull request enables minify (R8 and Proguard), reducing release apk file size, methods and classes, single dex file (as it has 64k methods limit), and optimize the code, improving performance.

Full diff:
![infinity_minify](https://user-images.githubusercontent.com/34722728/81413596-fbb5fb80-9145-11ea-9b0d-cd369d71c338.png)

I don't know why it wasn't enabled before, but from my tests I don't see any regression.