### PR TITLE
Make downloaded vreddit video visible for galleries.

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -744,5 +744,6 @@
     <string name="downloading_reddit_video_audio_track">Downloading Audio Track For %1$s</string>
     <string name="downloading_reddit_video_muxing">Muxing Video</string>
     <string name="downloading_reddit_video_finished">%1$s Downloaded</string>
+    <string name="downloading_reddit_video_failed">Failed To Download Video</string>
 
 </resources>


### PR DESCRIPTION
This pull request make downloaded video visible for galleries and simplify the code a bit.
This also gives a notification in case of error and allow you to view the video when clicking the successful notification before Android Q (because I am not sure how the video URI should be gotten in Q).
This still can be improved by downloading the video and the audio in parallel and muxing and copying the result afterwards.