### PR TITLE
Feature: See removed posts and comments

### DIFF
--- a/app/src/main/java/ml/docilealligator/infinityforreddit/API/PushshiftAPI.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/API/PushshiftAPI.java
@@ -7,4 +7,7 @@ import retrofit2.http.Query;
 public interface PushshiftAPI {
     @GET("reddit/comment/search/")
     Call<String> getRemovedComment(@Query("ids") String commentId);
+
+    @GET("reddit/submission/search/")
+    Call<String> getRemovedPost(@Query("ids") String postId);
 }

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/API/PushshiftAPI.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/API/PushshiftAPI.java
@@ -1,0 +1,10 @@
+package ml.docilealligator.infinityforreddit.API;
+
+import retrofit2.Call;
+import retrofit2.http.GET;
+import retrofit2.http.Query;
+
+public interface PushshiftAPI {
+    @GET("reddit/comment/search/")
+    Call<String> getRemovedComment(@Query("ids") String commentId);
+}

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/Activity/ViewPostDetailActivity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/Activity/ViewPostDetailActivity.java
@@ -74,6 +74,7 @@ import ml.docilealligator.infinityforreddit.Event.PostUpdateEventToPostList;
 import ml.docilealligator.infinityforreddit.Event.SwitchAccountEvent;
 import ml.docilealligator.infinityforreddit.FetchComment;
 import ml.docilealligator.infinityforreddit.FetchRemovedComment;
+import ml.docilealligator.infinityforreddit.FetchRemovedPost;
 import ml.docilealligator.infinityforreddit.Flair;
 import ml.docilealligator.infinityforreddit.Infinity;
 import ml.docilealligator.infinityforreddit.ParseComment;
@@ -453,63 +454,7 @@ public class ViewPostDetailActivity extends BaseActivity implements FlairBottomS
         if (mPost == null) {
             fetchPostAndCommentsById(getIntent().getStringExtra(EXTRA_POST_ID));
         } else {
-            if (mMenu != null) {
-                MenuItem saveItem = mMenu.findItem(R.id.action_save_view_post_detail_activity);
-                MenuItem hideItem = mMenu.findItem(R.id.action_hide_view_post_detail_activity);
-
-                mMenu.findItem(R.id.action_comment_view_post_detail_activity).setVisible(true);
-                mMenu.findItem(R.id.action_sort_view_post_detail_activity).setVisible(true);
-
-                if (mAccessToken != null) {
-                    if (mPost.isSaved()) {
-                        saveItem.setVisible(true);
-                        saveItem.setIcon(mSavedIcon);
-                    } else {
-                        saveItem.setVisible(true);
-                        saveItem.setIcon(mUnsavedIcon);
-                    }
-
-                    if (mPost.isHidden()) {
-                        hideItem.setVisible(true);
-                        hideItem.setTitle(R.string.action_unhide_post);
-                    } else {
-                        hideItem.setVisible(true);
-                        hideItem.setTitle(R.string.action_hide_post);
-                    }
-
-                    mMenu.findItem(R.id.action_report_view_post_detail_activity).setVisible(true);
-                } else {
-                    saveItem.setVisible(false);
-                    hideItem.setVisible(false);
-                }
-
-                if (mPost.getAuthor().equals(mAccountName)) {
-                    if (mPost.getPostType() == Post.TEXT_TYPE) {
-                        mMenu.findItem(R.id.action_edit_view_post_detail_activity).setVisible(true);
-                    }
-                    mMenu.findItem(R.id.action_delete_view_post_detail_activity).setVisible(true);
-
-                    MenuItem nsfwItem = mMenu.findItem(R.id.action_nsfw_view_post_detail_activity);
-                    nsfwItem.setVisible(true);
-                    if (mPost.isNSFW()) {
-                        nsfwItem.setTitle(R.string.action_unmark_nsfw);
-                    } else {
-                        nsfwItem.setTitle(R.string.action_mark_nsfw);
-                    }
-
-                    MenuItem spoilerItem = mMenu.findItem(R.id.action_spoiler_view_post_detail_activity);
-                    spoilerItem.setVisible(true);
-                    if (mPost.isSpoiler()) {
-                        spoilerItem.setTitle(R.string.action_unmark_spoiler);
-                    } else {
-                        spoilerItem.setTitle(R.string.action_mark_spoiler);
-                    }
-
-                    mMenu.findItem(R.id.action_edit_flair_view_post_detail_activity).setVisible(true);
-                }
-
-                mMenu.findItem(R.id.action_view_crosspost_parent_view_post_detail_activity).setVisible(mPost.getCrosspostParentId() != null);
-            }
+            setupMenu();
 
             mAdapter = new CommentAndPostRecyclerViewAdapter(ViewPostDetailActivity.this,
                     mCustomThemeWrapper, mRetrofit, mOauthRetrofit, mRedditDataRoomDatabase, mGlide,
@@ -563,6 +508,66 @@ public class ViewPostDetailActivity extends BaseActivity implements FlairBottomS
         fab.setOnClickListener(view -> scrollToNextParentComment());
     }
 
+    private void setupMenu() {
+        if (mMenu != null) {
+            MenuItem saveItem = mMenu.findItem(R.id.action_save_view_post_detail_activity);
+            MenuItem hideItem = mMenu.findItem(R.id.action_hide_view_post_detail_activity);
+
+            mMenu.findItem(R.id.action_comment_view_post_detail_activity).setVisible(true);
+            mMenu.findItem(R.id.action_sort_view_post_detail_activity).setVisible(true);
+
+            if (mAccessToken != null) {
+                if (mPost.isSaved()) {
+                    saveItem.setVisible(true);
+                    saveItem.setIcon(mSavedIcon);
+                } else {
+                    saveItem.setVisible(true);
+                    saveItem.setIcon(mUnsavedIcon);
+                }
+
+                if (mPost.isHidden()) {
+                    hideItem.setVisible(true);
+                    hideItem.setTitle(R.string.action_unhide_post);
+                } else {
+                    hideItem.setVisible(true);
+                    hideItem.setTitle(R.string.action_hide_post);
+                }
+
+                mMenu.findItem(R.id.action_report_view_post_detail_activity).setVisible(true);
+            } else {
+                saveItem.setVisible(false);
+                hideItem.setVisible(false);
+            }
+
+            if (mPost.getAuthor().equals(mAccountName)) {
+                if (mPost.getPostType() == Post.TEXT_TYPE) {
+                    mMenu.findItem(R.id.action_edit_view_post_detail_activity).setVisible(true);
+                }
+                mMenu.findItem(R.id.action_delete_view_post_detail_activity).setVisible(true);
+
+                MenuItem nsfwItem = mMenu.findItem(R.id.action_nsfw_view_post_detail_activity);
+                nsfwItem.setVisible(true);
+                if (mPost.isNSFW()) {
+                    nsfwItem.setTitle(R.string.action_unmark_nsfw);
+                } else {
+                    nsfwItem.setTitle(R.string.action_mark_nsfw);
+                }
+
+                MenuItem spoilerItem = mMenu.findItem(R.id.action_spoiler_view_post_detail_activity);
+                spoilerItem.setVisible(true);
+                if (mPost.isSpoiler()) {
+                    spoilerItem.setTitle(R.string.action_unmark_spoiler);
+                } else {
+                    spoilerItem.setTitle(R.string.action_mark_spoiler);
+                }
+
+                mMenu.findItem(R.id.action_edit_flair_view_post_detail_activity).setVisible(true);
+            }
+
+            mMenu.findItem(R.id.action_view_crosspost_parent_view_post_detail_activity).setVisible(mPost.getCrosspostParentId() != null);
+        }
+    }
+
     private Drawable getMenuItemIcon(int drawableId) {
         Drawable icon = getDrawable(drawableId);
         if (icon != null) {
@@ -606,45 +611,7 @@ public class ViewPostDetailActivity extends BaseActivity implements FlairBottomS
                         public void onParsePostSuccess(Post post) {
                             mPost = post;
 
-                            if (mMenu != null) {
-                                MenuItem saveItem = mMenu.findItem(R.id.action_save_view_post_detail_activity);
-                                MenuItem hideItem = mMenu.findItem(R.id.action_hide_view_post_detail_activity);
-
-                                mMenu.findItem(R.id.action_comment_view_post_detail_activity).setVisible(true);
-                                mMenu.findItem(R.id.action_sort_view_post_detail_activity).setVisible(true);
-
-                                if (mAccessToken != null) {
-                                    if (post.isSaved()) {
-                                        saveItem.setVisible(true);
-                                        saveItem.setIcon(mSavedIcon);
-                                    } else {
-                                        saveItem.setVisible(true);
-                                        saveItem.setIcon(mUnsavedIcon);
-                                    }
-
-                                    if (post.isHidden()) {
-                                        hideItem.setVisible(true);
-                                        hideItem.setTitle(R.string.action_unhide_post);
-                                    } else {
-                                        hideItem.setVisible(true);
-                                        hideItem.setTitle(R.string.action_hide_post);
-                                    }
-
-                                    mMenu.findItem(R.id.action_report_view_post_detail_activity).setVisible(true);
-                                } else {
-                                    saveItem.setVisible(false);
-                                    hideItem.setVisible(false);
-                                }
-
-                                if (mPost.getAuthor().equals(mAccountName)) {
-                                    if (mPost.getPostType() == Post.TEXT_TYPE) {
-                                        mMenu.findItem(R.id.action_edit_view_post_detail_activity).setVisible(true);
-                                    }
-                                    mMenu.findItem(R.id.action_delete_view_post_detail_activity).setVisible(true);
-                                }
-
-                                mMenu.findItem(R.id.action_view_crosspost_parent_view_post_detail_activity).setVisible(mPost.getCrosspostParentId() != null);
-                            }
+                            setupMenu();
 
                             mAdapter = new CommentAndPostRecyclerViewAdapter(ViewPostDetailActivity.this,
                                     mCustomThemeWrapper, mRetrofit, mOauthRetrofit, mRedditDataRoomDatabase, mGlide,
@@ -914,38 +881,7 @@ public class ViewPostDetailActivity extends BaseActivity implements FlairBottomS
                                 mAdapter.updatePost(mPost);
                                 EventBus.getDefault().post(new PostUpdateEventToPostList(mPost, postListPosition));
                                 isRefreshing = false;
-                                if (mMenu != null) {
-                                    MenuItem saveItem = mMenu.findItem(R.id.action_save_view_post_detail_activity);
-                                    MenuItem hideItem = mMenu.findItem(R.id.action_hide_view_post_detail_activity);
-
-                                    mMenu.findItem(R.id.action_comment_view_post_detail_activity).setVisible(true);
-                                    mMenu.findItem(R.id.action_sort_view_post_detail_activity).setVisible(true);
-
-                                    if (mAccessToken != null) {
-                                        if (post.isSaved()) {
-                                            saveItem.setVisible(true);
-                                            saveItem.setIcon(mSavedIcon);
-                                        } else {
-                                            saveItem.setVisible(true);
-                                            saveItem.setIcon(mUnsavedIcon);
-                                        }
-
-                                        if (post.isHidden()) {
-                                            hideItem.setVisible(true);
-                                            hideItem.setTitle(R.string.action_unhide_post);
-                                        } else {
-                                            hideItem.setVisible(true);
-                                            hideItem.setTitle(R.string.action_hide_post);
-                                        }
-
-                                        mMenu.findItem(R.id.action_report_view_post_detail_activity).setVisible(true);
-                                    } else {
-                                        saveItem.setVisible(false);
-                                        hideItem.setVisible(false);
-                                    }
-
-                                    mMenu.findItem(R.id.action_view_crosspost_parent_view_post_detail_activity).setVisible(mPost.getCrosspostParentId() != null);
-                                }
+                                setupMenu();
                                 mSwipeRefreshLayout.setRefreshing(false);
                             }
 
@@ -1279,61 +1215,7 @@ public class ViewPostDetailActivity extends BaseActivity implements FlairBottomS
         applyMenuItemTheme(menu);
         mMenu = menu;
         if (mPost != null) {
-            MenuItem saveItem = mMenu.findItem(R.id.action_save_view_post_detail_activity);
-            MenuItem hideItem = mMenu.findItem(R.id.action_hide_view_post_detail_activity);
-
-            mMenu.findItem(R.id.action_comment_view_post_detail_activity).setVisible(true);
-            mMenu.findItem(R.id.action_sort_view_post_detail_activity).setVisible(true);
-
-            if (mAccessToken != null) {
-                if (mPost.isSaved()) {
-                    saveItem.setVisible(true);
-                    saveItem.setIcon(mSavedIcon);
-                } else {
-                    saveItem.setVisible(true);
-                    saveItem.setIcon(mUnsavedIcon);
-                }
-
-                if (mPost.isHidden()) {
-                    hideItem.setVisible(true);
-                    hideItem.setTitle(R.string.action_unhide_post);
-                } else {
-                    hideItem.setVisible(true);
-                    hideItem.setTitle(R.string.action_hide_post);
-                }
-
-                mMenu.findItem(R.id.action_report_view_post_detail_activity).setVisible(true);
-            } else {
-                saveItem.setVisible(false);
-                hideItem.setVisible(false);
-            }
-
-            if (mPost.getAuthor().equals(mAccountName)) {
-                if (mPost.getPostType() == Post.TEXT_TYPE) {
-                    menu.findItem(R.id.action_edit_view_post_detail_activity).setVisible(true);
-                }
-                menu.findItem(R.id.action_delete_view_post_detail_activity).setVisible(true);
-
-                MenuItem nsfwItem = menu.findItem(R.id.action_nsfw_view_post_detail_activity);
-                nsfwItem.setVisible(true);
-                if (mPost.isNSFW()) {
-                    nsfwItem.setTitle(R.string.action_unmark_nsfw);
-                } else {
-                    nsfwItem.setTitle(R.string.action_mark_nsfw);
-                }
-
-                MenuItem spoilerItem = menu.findItem(R.id.action_spoiler_view_post_detail_activity);
-                spoilerItem.setVisible(true);
-                if (mPost.isSpoiler()) {
-                    spoilerItem.setTitle(R.string.action_unmark_spoiler);
-                } else {
-                    spoilerItem.setTitle(R.string.action_mark_spoiler);
-                }
-
-                menu.findItem(R.id.action_edit_flair_view_post_detail_activity).setVisible(true);
-            }
-
-            menu.findItem(R.id.action_view_crosspost_parent_view_post_detail_activity).setVisible(mPost.getCrosspostParentId() != null);
+            setupMenu();
         }
         return true;
     }
@@ -1472,12 +1354,12 @@ public class ViewPostDetailActivity extends BaseActivity implements FlairBottomS
                 }
                 return true;
             case R.id.action_edit_view_post_detail_activity:
-                Intent editPostItent = new Intent(this, EditPostActivity.class);
-                editPostItent.putExtra(EditPostActivity.EXTRA_ACCESS_TOKEN, mAccessToken);
-                editPostItent.putExtra(EditPostActivity.EXTRA_FULLNAME, mPost.getFullName());
-                editPostItent.putExtra(EditPostActivity.EXTRA_TITLE, mPost.getTitle());
-                editPostItent.putExtra(EditPostActivity.EXTRA_CONTENT, mPost.getSelfText());
-                startActivityForResult(editPostItent, EDIT_POST_REQUEST_CODE);
+                Intent editPostIntent = new Intent(this, EditPostActivity.class);
+                editPostIntent.putExtra(EditPostActivity.EXTRA_ACCESS_TOKEN, mAccessToken);
+                editPostIntent.putExtra(EditPostActivity.EXTRA_FULLNAME, mPost.getFullName());
+                editPostIntent.putExtra(EditPostActivity.EXTRA_TITLE, mPost.getTitle());
+                editPostIntent.putExtra(EditPostActivity.EXTRA_CONTENT, mPost.getSelfText());
+                startActivityForResult(editPostIntent, EDIT_POST_REQUEST_CODE);
                 return true;
             case R.id.action_delete_view_post_detail_activity:
                 new MaterialAlertDialogBuilder(this, R.style.MaterialAlertDialogTheme)

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/Activity/ViewPostDetailActivity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/Activity/ViewPostDetailActivity.java
@@ -566,7 +566,10 @@ public class ViewPostDetailActivity extends BaseActivity implements FlairBottomS
 
             mMenu.findItem(R.id.action_view_crosspost_parent_view_post_detail_activity).setVisible(mPost.getCrosspostParentId() != null);
 
-            if ("[deleted]".equals(mPost.getAuthor()) || "[deleted]".equals(mPost.getSelfText())) {
+            if ("[deleted]".equals(mPost.getAuthor()) ||
+                    "[deleted]".equals(mPost.getSelfText()) ||
+                    "[removed]".equals(mPost.getSelfText())
+            ) {
                 mMenu.findItem(R.id.action_see_removed_view_post_detail_activity).setVisible(true);
             }
         }

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/Activity/ViewPostDetailActivity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/Activity/ViewPostDetailActivity.java
@@ -566,7 +566,7 @@ public class ViewPostDetailActivity extends BaseActivity implements FlairBottomS
 
             mMenu.findItem(R.id.action_view_crosspost_parent_view_post_detail_activity).setVisible(mPost.getCrosspostParentId() != null);
 
-            if (mPost.getSelfText().equals("[deleted]")) {
+            if ("[deleted]".equals(mPost.getAuthor()) || "[deleted]".equals(mPost.getSelfText())) {
                 mMenu.findItem(R.id.action_see_removed_view_post_detail_activity).setVisible(true);
             }
         }

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/Activity/ViewPostDetailActivity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/Activity/ViewPostDetailActivity.java
@@ -565,6 +565,10 @@ public class ViewPostDetailActivity extends BaseActivity implements FlairBottomS
             }
 
             mMenu.findItem(R.id.action_view_crosspost_parent_view_post_detail_activity).setVisible(mPost.getCrosspostParentId() != null);
+
+            if (mPost.getSelfText().equals("[deleted]")) {
+                mMenu.findItem(R.id.action_see_removed_view_post_detail_activity).setVisible(true);
+            }
         }
     }
 
@@ -1220,6 +1224,25 @@ public class ViewPostDetailActivity extends BaseActivity implements FlairBottomS
         return true;
     }
 
+    public void showRemovedPost() {
+        Toast.makeText(ViewPostDetailActivity.this, R.string.fetching_removed_post, Toast.LENGTH_SHORT).show();
+        FetchRemovedPost.fetchRemovedPost(
+                pushshiftRetrofit,
+                mPost,
+                new FetchRemovedPost.FetchRemovedPostListener() {
+                    @Override
+                    public void fetchSuccess(Post post) {
+                        mPost = post;
+                        mAdapter.updatePost(post);
+                    }
+
+                    @Override
+                    public void fetchFailed() {
+                        Toast.makeText(ViewPostDetailActivity.this, R.string.show_removed_post_failed, Toast.LENGTH_SHORT).show();
+                    }
+                });
+    }
+
     @Override
     public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         switch (item.getItemId()) {
@@ -1408,6 +1431,10 @@ public class ViewPostDetailActivity extends BaseActivity implements FlairBottomS
                 intent.putExtra(ReportActivity.EXTRA_SUBREDDIT_NAME, mPost.getSubredditName());
                 intent.putExtra(ReportActivity.EXTRA_THING_FULLNAME, mPost.getFullName());
                 startActivity(intent);
+                return true;
+            case R.id.action_see_removed_view_post_detail_activity:
+                showRemovedPost();
+                return true;
             case android.R.id.home:
                 onBackPressed();
                 return true;

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/Adapter/CommentAndPostRecyclerViewAdapter.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/Adapter/CommentAndPostRecyclerViewAdapter.java
@@ -1384,8 +1384,10 @@ public class CommentAndPostRecyclerViewAdapter extends RecyclerView.Adapter<Recy
         }
     }
 
-    public void editComment(String commentContent, int position) {
-        mVisibleComments.get(position).setCommentMarkdown(commentContent);
+    public void editComment(String commentAuthor, String commentContentMarkdown, int position) {
+        if (commentAuthor != null)
+            mVisibleComments.get(position).setAuthor(commentAuthor);
+        mVisibleComments.get(position).setCommentMarkdown(commentContentMarkdown);
         if (mIsSingleCommentThreadMode) {
             notifyItemChanged(position + 2);
         } else {

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/Adapter/CommentAndPostRecyclerViewAdapter.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/Adapter/CommentAndPostRecyclerViewAdapter.java
@@ -1387,6 +1387,7 @@ public class CommentAndPostRecyclerViewAdapter extends RecyclerView.Adapter<Recy
     public void editComment(String commentAuthor, String commentContentMarkdown, int position) {
         if (commentAuthor != null)
             mVisibleComments.get(position).setAuthor(commentAuthor);
+
         mVisibleComments.get(position).setCommentMarkdown(commentContentMarkdown);
         if (mIsSingleCommentThreadMode) {
             notifyItemChanged(position + 2);

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/AppModule.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/AppModule.java
@@ -131,6 +131,16 @@ class AppModule {
     }
 
     @Provides
+    @Named("pushshift")
+    @Singleton
+    Retrofit providePushshiftRetrofit() {
+        return new Retrofit.Builder()
+                .baseUrl(APIUtils.PUSHSHIFT_API_BASE_URI)
+                .addConverterFactory(ScalarsConverterFactory.create())
+                .build();
+    }
+
+    @Provides
     @Singleton
     OkHttpClient provideOkHttpClient(@Named("no_oauth") Retrofit retrofit, RedditDataRoomDatabase accountRoomDatabase) {
         OkHttpClient.Builder okHttpClientBuilder = new OkHttpClient.Builder();

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/BottomSheetFragment/CommentMoreBottomSheetFragment.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/BottomSheetFragment/CommentMoreBottomSheetFragment.java
@@ -134,7 +134,7 @@ public class CommentMoreBottomSheetFragment extends RoundedBottomSheetDialogFrag
             dismiss();
         });
 
-        if (commentData.getCommentRawText().equals("[removed]")) {
+        if ("[removed]".equals(commentData.getCommentRawText())) {
             seeRemovedTextView.setVisibility(View.VISIBLE);
 
             seeRemovedTextView.setOnClickListener(view -> {

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/BottomSheetFragment/CommentMoreBottomSheetFragment.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/BottomSheetFragment/CommentMoreBottomSheetFragment.java
@@ -47,7 +47,10 @@ public class CommentMoreBottomSheetFragment extends RoundedBottomSheetDialogFrag
     TextView copyTextView;
     @BindView(R.id.report_view_comment_more_bottom_sheet_fragment)
     TextView reportTextView;
+    @BindView(R.id.see_removed_view_comment_more_bottom_sheet_fragment)
+    TextView seeRemovedTextView;
     private AppCompatActivity activity;
+
     public CommentMoreBottomSheetFragment() {
         // Required empty public constructor
     }
@@ -130,6 +133,17 @@ public class CommentMoreBottomSheetFragment extends RoundedBottomSheetDialogFrag
 
             dismiss();
         });
+
+        if (commentData.getCommentRawText().equals("[removed]")) {
+            seeRemovedTextView.setVisibility(View.VISIBLE);
+
+            seeRemovedTextView.setOnClickListener(view -> {
+                dismiss();
+                if (activity instanceof ViewPostDetailActivity) {
+                    ((ViewPostDetailActivity) activity).showRemovedComment(commentData, bundle.getInt(EXTRA_POSITION));
+                }
+            });
+        }
 
         return rootView;
     }

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/BottomSheetFragment/CommentMoreBottomSheetFragment.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/BottomSheetFragment/CommentMoreBottomSheetFragment.java
@@ -134,7 +134,10 @@ public class CommentMoreBottomSheetFragment extends RoundedBottomSheetDialogFrag
             dismiss();
         });
 
-        if ("[removed]".equals(commentData.getCommentRawText())) {
+        if ("[deleted]".equals(commentData.getAuthor()) ||
+                "[deleted]".equals(commentData.getCommentRawText()) ||
+                "[removed]".equals(commentData.getCommentRawText())
+        ) {
             seeRemovedTextView.setVisibility(View.VISIBLE);
 
             seeRemovedTextView.setOnClickListener(view -> {

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/FetchRemovedComment.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/FetchRemovedComment.java
@@ -80,6 +80,7 @@ public class FetchRemovedComment {
                 comment = parseRemovedComment(commentJSON, comment);
             } catch (JSONException e) {
                 e.printStackTrace();
+                comment = null;
             }
             return null;
         }

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/FetchRemovedComment.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/FetchRemovedComment.java
@@ -1,0 +1,95 @@
+package ml.docilealligator.infinityforreddit;
+
+import android.os.AsyncTask;
+
+import androidx.annotation.NonNull;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import ml.docilealligator.infinityforreddit.API.PushshiftAPI;
+import ml.docilealligator.infinityforreddit.Utils.JSONUtils;
+import ml.docilealligator.infinityforreddit.Utils.Utils;
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+import retrofit2.Retrofit;
+
+public class FetchRemovedComment {
+
+    public static void fetchRemovedComment(Retrofit retrofit, CommentData comment, FetchRemovedCommentListener listener) {
+        retrofit.create(PushshiftAPI.class).getRemovedComment(comment.getId())
+                .enqueue(new Callback<String>() {
+                    @Override
+                    public void onResponse(@NonNull Call<String> call, @NonNull Response<String> response) {
+                        if (response.isSuccessful()) {
+                            new ParseCommentAsyncTask(response.body(), comment, listener).execute();
+                        } else {
+                            listener.fetchFailed();
+                        }
+                    }
+
+                    @Override
+                    public void onFailure(@NonNull Call<String> call, @NonNull Throwable t) {
+                        listener.fetchFailed();
+                    }
+                });
+    }
+
+    private static CommentData parseRemovedComment(JSONObject comment, CommentData commentData) throws JSONException {
+        String id = comment.getString(JSONUtils.ID_KEY);
+        if (id.equals(commentData.getId())) {
+            String author = comment.getString(JSONUtils.AUTHOR_KEY);
+            String commentMarkdown = "";
+            if (!comment.isNull(JSONUtils.BODY_KEY)) {
+                commentMarkdown = Utils.modifyMarkdown(comment.getString(JSONUtils.BODY_KEY).trim());
+            }
+
+            commentData.setAuthor(author);
+            commentData.setCommentMarkdown(commentMarkdown);
+            commentData.setCommentRawText(commentMarkdown);
+            return commentData;
+        } else {
+            return null;
+        }
+    }
+
+    public interface FetchRemovedCommentListener {
+        void fetchSuccess(CommentData comment);
+
+        void fetchFailed();
+    }
+
+    private static class ParseCommentAsyncTask extends AsyncTask<Void, Void, Void> {
+
+        private String responseBody;
+        private FetchRemovedCommentListener listener;
+        CommentData comment;
+
+        public ParseCommentAsyncTask(String responseBody, CommentData comment, FetchRemovedCommentListener listener) {
+            this.responseBody = responseBody;
+            this.comment = comment;
+            this.listener = listener;
+        }
+
+        @Override
+        protected Void doInBackground(Void... voids) {
+            try {
+                JSONObject commentJSON = new JSONObject(responseBody).getJSONArray(JSONUtils.DATA_KEY).getJSONObject(0);
+                comment = parseRemovedComment(commentJSON, comment);
+            } catch (JSONException e) {
+                e.printStackTrace();
+            }
+            return null;
+        }
+
+        @Override
+        protected void onPostExecute(Void aVoid) {
+            super.onPostExecute(aVoid);
+            if (comment != null)
+                listener.fetchSuccess(comment);
+            else
+                listener.fetchFailed();
+        }
+    }
+}

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/Post/Post.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/Post/Post.java
@@ -252,6 +252,11 @@ public class Post implements Parcelable {
         return author;
     }
 
+    public void setAuthor(String author) {
+        this.author = author;
+        this.authorNamePrefixed = "u/" + author;
+    }
+
     public String getAuthorNamePrefixed() {
         return authorNamePrefixed;
     }

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/Post/Post.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/Post/Post.java
@@ -325,6 +325,10 @@ public class Post implements Parcelable {
         return thumbnailPreviewUrl;
     }
 
+    public void setThumbnailPreviewUrl(String thumbnailPreviewUrl) {
+        this.thumbnailPreviewUrl = thumbnailPreviewUrl;
+    }
+
     public String getUrl() {
         return url;
     }

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/Utils/APIUtils.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/Utils/APIUtils.java
@@ -21,6 +21,7 @@ public class APIUtils {
     public static final String GFYCAT_API_BASE_URI = "https://api.gfycat.com/v1/gfycats/";
     public static final String REDGIFS_API_BASE_URI = "https://api.redgifs.com/v1/gfycats/";
     public static final String IMGUR_API_BASE_URI = "https://api.imgur.com/3/";
+    public static final String PUSHSHIFT_API_BASE_URI = "https://api.pushshift.io/";
 
     public static final String CLIENT_ID_KEY = "client_id";
     public static final String CLIENT_ID = "";

--- a/app/src/main/res/layout/fragment_comment_more_bottom_sheet.xml
+++ b/app/src/main/res/layout/fragment_comment_more_bottom_sheet.xml
@@ -104,6 +104,25 @@
             android:textSize="?attr/font_default"
             android:fontFamily="?attr/font_family" />
 
+        <TextView
+            android:id="@+id/see_removed_view_comment_more_bottom_sheet_fragment"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="?attr/selectableItemBackground"
+            android:clickable="true"
+            android:drawableStart="@drawable/ic_preview_24dp"
+            android:drawablePadding="48dp"
+            android:focusable="true"
+            android:gravity="center_vertical"
+            android:paddingStart="32dp"
+            android:paddingTop="16dp"
+            android:paddingEnd="32dp"
+            android:paddingBottom="16dp"
+            android:text="@string/see_removed_comment"
+            android:textColor="?attr/primaryTextColor"
+            android:textSize="?attr/font_default"
+            android:visibility="gone" />
+
     </LinearLayout>
 
 </androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/menu/view_post_detail_activity.xml
+++ b/app/src/main/res/menu/view_post_detail_activity.xml
@@ -80,5 +80,12 @@
         android:orderInCategory="12"
         android:title="@string/action_report"
         app:showAsAction="never"
+        android:visible="false"/>
+
+    <item
+        android:id="@+id/action_see_removed_view_post_detail_activity"
+        android:orderInCategory="13"
+        android:title="@string/action_see_removed"
+        app:showAsAction="never"
         android:visible="false" />
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -276,6 +276,10 @@
     <string name="are_you_sure">Are you sure?</string>
     <string name="edit">Edit</string>
     <string name="delete">Delete</string>
+    <string name="see_removed_comment">See Removed Comment</string>
+    <string name="see_removed_post">See Removed Post</string>
+    <string name="fetching_removed_comment">Fetching removed comment</string>
+    <string name="show_removed_comment_failed">Could not find the removed comment</string>
     <string name="cancel">Cancel</string>
     <string name="ok">OK</string>
     <string name="edit_success">Edit successful</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -61,6 +61,7 @@
     <string name="action_share">Share</string>
     <string name="action_preview">Preview</string>
     <string name="action_report">Report</string>
+    <string name="action_see_removed">See Removed</string>
     <string name="action_set_wallpaper">Set as Wallpaper</string>
 
     <string name="parse_json_response_error">Error occurred when parsing the JSON response</string>
@@ -277,9 +278,10 @@
     <string name="edit">Edit</string>
     <string name="delete">Delete</string>
     <string name="see_removed_comment">See Removed Comment</string>
-    <string name="see_removed_post">See Removed Post</string>
     <string name="fetching_removed_comment">Fetching removed comment</string>
     <string name="show_removed_comment_failed">Could not find the removed comment</string>
+    <string name="fetching_removed_post">Fetching removed post</string>
+    <string name="show_removed_post_failed">Could not find the removed post</string>
     <string name="cancel">Cancel</string>
     <string name="ok">OK</string>
     <string name="edit_success">Edit successful</string>


### PR DESCRIPTION
This is a work in progress, please don't merge for now.
This pull request implements the option to see removed posts and comments.
It uses the [Pushshift API](https://pushshift.io).
It is the same API those services use, so I don't think there would be a problem to maintain in the future.

Can be improved: There is no visual cue that the thing was removed after you see, it could change the color, or have a message on top.
There also is no loading animation or cue, only a Toast saying it's fetching. The post could use the refresh layout, but comment are a bit more tricky. I am not that good at UI, so I didn't try anything. 