### PR TITLE
Exclude transitive dependency from Google services.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -82,7 +82,9 @@ dependencies {
 
     def toroVersion = '3.7.0.2010003'
     implementation "im.ene.toro3:toro:$toroVersion"
-    implementation "im.ene.toro3:toro-ext-exoplayer:$toroVersion"
+    implementation("im.ene.toro3:toro-ext-exoplayer:$toroVersion") {
+        exclude module: 'extension-ima'
+    }
 
     testImplementation 'junit:junit:4.13'
     androidTestImplementation 'androidx.test:runner:1.2.0'


### PR DESCRIPTION
Found in this dependency graph:

```
\--- im.ene.toro3:toro-ext-exoplayer:3.7.0.2010003
     \--- com.google.android.exoplayer:extension-ima:2.10.3
          \--- com.google.android.gms:play-services-ads-identifier:16.0.0
               \--- com.google.android.gms:play-services-basement:16.0.1
```