### PR TITLE
Enable EventBus Index, avoids reflection, and better performance.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,6 +9,11 @@ android {
         versionCode 35
         versionName "3.2.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        javaCompileOptions {
+            annotationProcessorOptions {
+                arguments = [ eventBusIndex : 'ml.docilealligator.inifinityforreddit.EventBusIndex' ]
+            }
+        }
     }
     buildTypes {
         release {
@@ -67,7 +72,10 @@ dependencies {
     implementation 'io.noties.markwon:recycler-table:4.3.1'
     implementation 'pl.droidsonroids.gif:android-gif-drawable:1.2.19'
     implementation 'com.github.Ferfalk:SimpleSearchView:0.1.4'
-    implementation 'org.greenrobot:eventbus:3.2.0'
+
+    def eventbusVersion = '3.2.0'
+    implementation "org.greenrobot:eventbus:$eventbusVersion"
+    annotationProcessor "org.greenrobot:eventbus-annotation-processor:$eventbusVersion"
     implementation 'com.libRG:customtextview:2.4'
     implementation 'com.github.Deishelon:RoundedBottomSheet:1.0.1'
     implementation 'com.github.livefront:bridge:v1.2.1'

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/Infinity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/Infinity.java
@@ -17,6 +17,7 @@ import org.greenrobot.eventbus.EventBus;
 import ml.docilealligator.infinityforreddit.BroadcastReceiver.NetworkWifiStatusReceiver;
 import ml.docilealligator.infinityforreddit.Event.ChangeWifiStatusEvent;
 import ml.docilealligator.infinityforreddit.Utils.Utils;
+import ml.docilealligator.inifinityforreddit.EventBusIndex;
 
 public class Infinity extends Application {
     private AppComponent mAppComponent;
@@ -41,6 +42,8 @@ public class Infinity extends Application {
                 StateSaver.restoreInstanceState(target, state);
             }
         });
+
+        EventBus.builder().addIndex(new EventBusIndex()).installDefaultEventBus();
 
         mNetworkWifiStatusReceiver =
                 new NetworkWifiStatusReceiver(() -> EventBus.getDefault().post(new ChangeWifiStatusEvent(Utils.isConnectedToWifi(getApplicationContext()))));


### PR DESCRIPTION
As recommended [here](https://github.com/greenrobot/EventBus/blob/1d995077d0b620a6aae9c60a8b96443113752305/README.md#L62).
I have been using the app with this a a while, and haven't found any problems. Haven't noticed better performance either, since the app doesn't use events that much, but it doesn't hurt to add.