### PR TITLE
Added background to autoplay controls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,5 @@ fabric.properties
 !/gradle/wrapper/gradle-wrapper.jar
 
 # End of https://www.gitignore.io/api/androidstudio
+
+app/keystore.conf

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,17 @@
 apply plugin: 'com.android.application'
 
 android {
+        signingConfigs {
+        'Default' {
+            Properties keystoreProperties = new Properties()
+            keystoreProperties.load(new FileInputStream(file('keystore.conf')))
+
+            storeFile keystoreProperties['storeFile'] ? file(keystoreProperties['storeFile']) : null
+            storePassword keystoreProperties['storePassword']
+            keyAlias keystoreProperties['keyAlias']
+            keyPassword keystoreProperties['keyPassword']
+        }
+    }
     compileSdkVersion 30
     defaultConfig {
         applicationId "ml.docilealligator.infinityforreddit"
@@ -14,6 +25,7 @@ android {
                 arguments = [ eventBusIndex : 'ml.docilealligator.infinityforreddit.EventBusIndex' ]
             }
         }
+        resValue "string", "application_name" , "Infinity"
     }
     buildTypes {
         release {
@@ -27,10 +39,46 @@ android {
             shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
+        debug {
+            jniDebuggable true
+            renderscriptDebuggable true
+            versionNameSuffix 'DEBUG'
+            renderscriptOptimLevel 0
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
+        minifiedDebug {
+            debuggable true
+            jniDebuggable true
+            renderscriptDebuggable true
+            minifyEnabled true
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
     }
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
+    }
+    flavorDimensions 'Build Types'
+    productFlavors {
+        Development {
+            dimension 'Build Types'
+            signingConfig signingConfigs.'Default'
+            applicationIdSuffix '.development'
+            versionNameSuffix 'd'
+            resValue "string", "application_name" , "Infinity Development"
+        }
+        Beta {
+            dimension 'Build Types'
+            versionNameSuffix 'b'
+            applicationIdSuffix '.beta'
+            resValue "string", "application_name" , "Infinity Beta"
+            signingConfig signingConfigs.'Default'
+        }
+        Production {
+            dimension 'Build Types'
+            signingConfig signingConfigs.'Default'
+        }
     }
 }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -366,7 +366,7 @@
 
         <provider
             android:name="androidx.core.content.FileProvider"
-            android:authorities="ml.docilealligator.infinityforreddit.provider"
+            android:authorities="ml.docilealligator.${applicationId}.provider"
             android:exported="false"
             android:grantUriPermissions="true">
             <meta-data

--- a/app/src/main/res/drawable/gradient_background_autoplay.xml
+++ b/app/src/main/res/drawable/gradient_background_autoplay.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle" >
+
+	<solid
+		android:color="#80000000" />
+
+	<corners
+		android:topLeftRadius="16dp"
+		android:topRightRadius="16dp" />
+
+</shape>

--- a/app/src/main/res/layout/exo_autoplay_playback_control_view.xml
+++ b/app/src/main/res/layout/exo_autoplay_playback_control_view.xml
@@ -5,7 +5,8 @@
     android:layout_height="wrap_content"
     android:paddingStart="16dp"
     android:paddingEnd="8dp"
-    android:layout_gravity="bottom">
+    android:layout_gravity="bottom"
+    android:background="@drawable/gradient_background_autoplay">
 
     <TextView android:id="@id/exo_position"
         android:layout_width="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,4 @@
 <resources>
-    <string name="application_name" translatable="false">Infinity</string>
     <string name="login_activity_label">Login</string>
     <string name="search_activity_label">Search</string>
     <string name="comment_activity_label">Send Comment</string>


### PR DESCRIPTION
Added a translucent background to the video autoplay controls. Before, when the video background was white, you couldn't see the video controls; this fixes #219.

The background is a black background that is halfway transparent. The top corners are rounded at 16dp like the rest of the UI.