### PR TITLE
Autoplay video background

### DIFF
--- a/app/src/main/res/drawable/background_autoplay.xml
+++ b/app/src/main/res/drawable/background_autoplay.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle" >
+
+	<solid
+		android:color="#80000000" />
+
+	<corners
+		android:topLeftRadius="16dp"
+		android:topRightRadius="16dp" />
+
+</shape>

--- a/app/src/main/res/layout/exo_autoplay_playback_control_view.xml
+++ b/app/src/main/res/layout/exo_autoplay_playback_control_view.xml
@@ -5,7 +5,8 @@
     android:layout_height="wrap_content"
     android:paddingStart="16dp"
     android:paddingEnd="8dp"
-    android:layout_gravity="bottom">
+    android:layout_gravity="bottom"
+    android:background="@drawable/background_autoplay">
 
     <TextView android:id="@id/exo_position"
         android:layout_width="wrap_content"

--- a/app/src/main/res/layout/item_post_detail_video_autoplay.xml
+++ b/app/src/main/res/layout/item_post_detail_video_autoplay.xml
@@ -205,7 +205,8 @@
             android:id="@+id/player_view_item_post_detail_video_autoplay"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            app:controller_layout_id="@layout/exo_autoplay_playback_control_view"/>
+            app:controller_layout_id="@layout/exo_autoplay_playback_control_view"
+            android:animateLayoutChanges="true" />
 
         <pl.droidsonroids.gif.GifImageView
             android:id="@+id/preview_image_view_item_post_detail_video_autoplay"

--- a/app/src/main/res/layout/item_post_video_type_autoplay.xml
+++ b/app/src/main/res/layout/item_post_video_type_autoplay.xml
@@ -208,7 +208,8 @@
                 android:id="@+id/player_view_item_post_video_type_autoplay"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                app:controller_layout_id="@layout/exo_autoplay_playback_control_view" />
+                app:controller_layout_id="@layout/exo_autoplay_playback_control_view"
+                android:animateLayoutChanges="true" />
 
             <pl.droidsonroids.gif.GifImageView
                 android:id="@+id/preview_image_view_item_post_video_type_autoplay"


### PR DESCRIPTION
Added a translucent background to the video autoplay controls. Before, when the video background was white, you couldn't see the video controls; this fixes #219.

The background is a black background that is halfway transparent. The top corners are rounded at 16dp like the rest of the UI. Controls fade in and out.