### PR TITLE
Fix issue with gifs not playing with invalid gfycat id

### DIFF
--- a/app/src/main/java/ml/docilealligator/infinityforreddit/post/ParsePost.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/post/ParsePost.java
@@ -403,7 +403,7 @@ public class ParsePost {
                     if (gfycatId.contains("-")) {
                         gfycatId = gfycatId.substring(0, gfycatId.indexOf('-'));
                     }
-                    post.setGfycatId(gfycatId);
+                    post.setGfycatId(gfycatId.toLowerCase());
                 } else if (authority != null && authority.contains("redgifs.com")) {
                     String gfycatId = url.substring(url.lastIndexOf("/") + 1);
                     if (gfycatId.contains("-")) {
@@ -411,7 +411,7 @@ public class ParsePost {
                     }
                     post.setIsRedgifs(true);
                     post.setVideoUrl(url);
-                    post.setGfycatId(gfycatId);
+                    post.setGfycatId(gfycatId.toLowerCase());
                 }
             } catch (IllegalArgumentException ignore) { }
         } else if (post.getPostType() == Post.LINK_TYPE || post.getPostType() == Post.NO_PREVIEW_LINK_TYPE) {
@@ -449,16 +449,21 @@ public class ParsePost {
             } else if (post.getPostType() == Post.LINK_TYPE) {
                 Uri uri = Uri.parse(url);
                 String authority = uri.getAuthority();
+
+                // Gyfcat ids must be lowercase to resolve to a video through the api, we are not
+                // guaranteed to get an id that is all lowercase.
+                String gfycatId = url.substring(url.lastIndexOf("/") + 1).toLowerCase();
+
                 if (authority != null && (authority.contains("gfycat.com"))) {
                     post.setPostType(Post.VIDEO_TYPE);
                     post.setIsGfycat(true);
                     post.setVideoUrl(url);
-                    post.setGfycatId(url.substring(url.lastIndexOf("/") + 1));
+                    post.setGfycatId(gfycatId);
                 } else if (authority != null && authority.contains("redgifs.com")) {
                     post.setPostType(Post.VIDEO_TYPE);
                     post.setIsRedgifs(true);
                     post.setVideoUrl(url);
-                    post.setGfycatId(url.substring(url.lastIndexOf("/") + 1));
+                    post.setGfycatId(gfycatId);
                 }
             }
         }


### PR DESCRIPTION
Occasionally [Post](https://github.com/Docile-Alligator/Infinity-For-Reddit/blob/master/app/src/main/java/ml/docilealligator/infinityforreddit/post/Post.java) can have a gfycat/redgifs id that contains capital letters, which will results in the video lookup to fail with a 404. Example post that gets an invalid id [here (nsfw)](https://old.reddit.com/r/goddesses/comments/a8zjp4/katie_bell/).