### PR TITLE
Add editor done action to dialog_go_to_thing_edit_text

### DIFF
--- a/app/src/main/java/ml/docilealligator/infinityforreddit/activities/InboxActivity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/activities/InboxActivity.java
@@ -12,6 +12,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.view.Window;
 import android.view.WindowManager;
+import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.Toast;
 
@@ -177,6 +178,18 @@ public class InboxActivity extends BaseActivity implements ActivityToolbarInterf
             if (imm != null) {
                 imm.toggleSoftInput(InputMethodManager.SHOW_FORCED, 0);
             }
+            thingEditText.setOnEditorActionListener((textView, i, keyEvent) -> {
+                if (i == EditorInfo.IME_ACTION_DONE) {
+                    if (imm != null) {
+                        imm.hideSoftInputFromWindow(thingEditText.getWindowToken(), 0);
+                    }
+                    Intent pmIntent = new Intent(this, SendPrivateMessageActivity.class);
+                    pmIntent.putExtra(SendPrivateMessageActivity.EXTRA_RECIPIENT_USERNAME, thingEditText.getText().toString());
+                    startActivity(pmIntent);
+                    return true;
+                }
+                return false;
+            });
             new MaterialAlertDialogBuilder(this, R.style.MaterialAlertDialogTheme)
                     .setTitle(R.string.choose_a_user)
                     .setView(rootView)

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/activities/MainActivity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/activities/MainActivity.java
@@ -16,6 +16,7 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.Window;
 import android.view.WindowManager;
+import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
@@ -1377,6 +1378,18 @@ public class MainActivity extends BaseActivity implements SortTypeSelectionCallb
         if (imm != null) {
             imm.toggleSoftInput(InputMethodManager.SHOW_FORCED, 0);
         }
+        thingEditText.setOnEditorActionListener((textView, i, keyEvent) -> {
+            if (i == EditorInfo.IME_ACTION_DONE) {
+                if (imm != null) {
+                    imm.hideSoftInputFromWindow(thingEditText.getWindowToken(), 0);
+                }
+                Intent subredditIntent = new Intent(this, ViewSubredditDetailActivity.class);
+                subredditIntent.putExtra(ViewSubredditDetailActivity.EXTRA_SUBREDDIT_NAME_KEY, thingEditText.getText().toString());
+                startActivity(subredditIntent);
+                return true;
+            }
+            return false;
+        });
         new MaterialAlertDialogBuilder(this, R.style.MaterialAlertDialogTheme)
                 .setTitle(R.string.go_to_subreddit)
                 .setView(rootView)
@@ -1406,6 +1419,18 @@ public class MainActivity extends BaseActivity implements SortTypeSelectionCallb
         if (imm != null) {
             imm.toggleSoftInput(InputMethodManager.SHOW_FORCED, 0);
         }
+        thingEditText.setOnEditorActionListener((textView, i, keyEvent) -> {
+            if (i == EditorInfo.IME_ACTION_DONE) {
+                if (imm != null) {
+                    imm.hideSoftInputFromWindow(thingEditText.getWindowToken(), 0);
+                }
+                Intent userIntent = new Intent(this, ViewUserDetailActivity.class);
+                userIntent.putExtra(ViewUserDetailActivity.EXTRA_USER_NAME_KEY, thingEditText.getText().toString());
+                startActivity(userIntent);
+                return true;
+            }
+            return false;
+        });
         new MaterialAlertDialogBuilder(this, R.style.MaterialAlertDialogTheme)
                 .setTitle(R.string.go_to_user)
                 .setView(rootView)

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/activities/SearchResultActivity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/activities/SearchResultActivity.java
@@ -11,6 +11,7 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.Window;
 import android.view.WindowManager;
+import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputMethodManager;
 
 import androidx.annotation.NonNull;
@@ -548,6 +549,18 @@ public class SearchResultActivity extends BaseActivity implements SortTypeSelect
         if (imm != null) {
             imm.toggleSoftInput(InputMethodManager.SHOW_FORCED, 0);
         }
+        thingEditText.setOnEditorActionListener((textView, i, keyEvent) -> {
+            if (i == EditorInfo.IME_ACTION_DONE) {
+                if (imm != null) {
+                    imm.hideSoftInputFromWindow(thingEditText.getWindowToken(), 0);
+                }
+                Intent subredditIntent = new Intent(this, ViewSubredditDetailActivity.class);
+                subredditIntent.putExtra(ViewSubredditDetailActivity.EXTRA_SUBREDDIT_NAME_KEY, thingEditText.getText().toString());
+                startActivity(subredditIntent);
+                return true;
+            }
+            return false;
+        });
         new MaterialAlertDialogBuilder(this, R.style.MaterialAlertDialogTheme)
                 .setTitle(R.string.go_to_subreddit)
                 .setView(rootView)
@@ -577,6 +590,18 @@ public class SearchResultActivity extends BaseActivity implements SortTypeSelect
         if (imm != null) {
             imm.toggleSoftInput(InputMethodManager.SHOW_FORCED, 0);
         }
+        thingEditText.setOnEditorActionListener((textView, i, keyEvent) -> {
+            if (i == EditorInfo.IME_ACTION_DONE) {
+                if (imm != null) {
+                    imm.hideSoftInputFromWindow(thingEditText.getWindowToken(), 0);
+                }
+                Intent userIntent = new Intent(this, ViewUserDetailActivity.class);
+                userIntent.putExtra(ViewUserDetailActivity.EXTRA_USER_NAME_KEY, thingEditText.getText().toString());
+                startActivity(userIntent);
+                return true;
+            }
+            return false;
+        });
         new MaterialAlertDialogBuilder(this, R.style.MaterialAlertDialogTheme)
                 .setTitle(R.string.go_to_user)
                 .setView(rootView)

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/activities/ViewSubredditDetailActivity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/activities/ViewSubredditDetailActivity.java
@@ -14,6 +14,7 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.Window;
 import android.view.WindowManager;
+import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
@@ -1338,6 +1339,18 @@ public class ViewSubredditDetailActivity extends BaseActivity implements SortTyp
         if (imm != null) {
             imm.toggleSoftInput(InputMethodManager.SHOW_FORCED, 0);
         }
+        thingEditText.setOnEditorActionListener((textView, i, keyEvent) -> {
+            if (i == EditorInfo.IME_ACTION_DONE) {
+                if (imm != null) {
+                    imm.hideSoftInputFromWindow(thingEditText.getWindowToken(), 0);
+                }
+                Intent subredditIntent = new Intent(this, ViewSubredditDetailActivity.class);
+                subredditIntent.putExtra(ViewSubredditDetailActivity.EXTRA_SUBREDDIT_NAME_KEY, thingEditText.getText().toString());
+                startActivity(subredditIntent);
+                return true;
+            }
+            return false;
+        });
         new MaterialAlertDialogBuilder(this, R.style.MaterialAlertDialogTheme)
                 .setTitle(R.string.go_to_subreddit)
                 .setView(rootView)
@@ -1367,6 +1380,16 @@ public class ViewSubredditDetailActivity extends BaseActivity implements SortTyp
         if (imm != null) {
             imm.toggleSoftInput(InputMethodManager.SHOW_FORCED, 0);
         }
+        thingEditText.setOnEditorActionListener((textView, i, keyEvent) -> {
+            if (i == EditorInfo.IME_ACTION_DONE) {
+                if (imm != null) {
+                    imm.hideSoftInputFromWindow(thingEditText.getWindowToken(), 0);
+                }
+                Intent userIntent = new Intent(this, ViewUserDetailActivity.class);
+                userIntent.putExtra(ViewUserDetailActivity.EXTRA_USER_NAME_KEY, thingEditText.getText().toString());
+                startActivity(userIntent);
+            }
+        });
         new MaterialAlertDialogBuilder(this, R.style.MaterialAlertDialogTheme)
                 .setTitle(R.string.go_to_user)
                 .setView(rootView)

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/activities/ViewUserDetailActivity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/activities/ViewUserDetailActivity.java
@@ -17,6 +17,7 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.Window;
 import android.view.WindowManager;
+import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
@@ -1149,6 +1150,18 @@ public class ViewUserDetailActivity extends BaseActivity implements SortTypeSele
         if (imm != null) {
             imm.toggleSoftInput(InputMethodManager.SHOW_FORCED, 0);
         }
+        thingEditText.setOnEditorActionListener((textView, i, keyEvent) -> {
+            if (i == EditorInfo.IME_ACTION_DONE) {
+                if (imm != null) {
+                    imm.hideSoftInputFromWindow(thingEditText.getWindowToken(), 0);
+                }
+                Intent subredditIntent = new Intent(this, ViewSubredditDetailActivity.class);
+                subredditIntent.putExtra(ViewSubredditDetailActivity.EXTRA_SUBREDDIT_NAME_KEY, thingEditText.getText().toString());
+                startActivity(subredditIntent);
+                return true;
+            }
+            return false;
+        });
         new MaterialAlertDialogBuilder(this, R.style.MaterialAlertDialogTheme)
                 .setTitle(R.string.go_to_subreddit)
                 .setView(rootView)
@@ -1178,6 +1191,18 @@ public class ViewUserDetailActivity extends BaseActivity implements SortTypeSele
         if (imm != null) {
             imm.toggleSoftInput(InputMethodManager.SHOW_FORCED, 0);
         }
+        thingEditText.setOnEditorActionListener((textView, i, keyEvent) -> {
+            if (i == EditorInfo.IME_ACTION_DONE) {
+                if (imm != null) {
+                    imm.hideSoftInputFromWindow(thingEditText.getWindowToken(), 0);
+                }
+                Intent userIntent = new Intent(this, ViewUserDetailActivity.class);
+                userIntent.putExtra(ViewUserDetailActivity.EXTRA_USER_NAME_KEY, thingEditText.getText().toString());
+                startActivity(userIntent);
+                return true;
+            }
+            return false;
+        });
         new MaterialAlertDialogBuilder(this, R.style.MaterialAlertDialogTheme)
                 .setTitle(R.string.go_to_user)
                 .setView(rootView)

--- a/app/src/main/res/layout/dialog_go_to_thing_edit_text.xml
+++ b/app/src/main/res/layout/dialog_go_to_thing_edit_text.xml
@@ -18,6 +18,8 @@
         android:fontFamily="?attr/font_family"
         android:hint="@string/go_to_thing_hint"
         android:textColor="?attr/primaryTextColor"
-        android:textSize="?attr/font_default" />
+        android:textSize="?attr/font_default"
+        android:singleLine="true"
+        android:imeOptions="actionDone"/>
 
 </com.google.android.material.textfield.TextInputLayout>


### PR DESCRIPTION
This pull request adds an editor done action to the dialog_go_to_thing_edit_text. It makes it easier to search a user or subreddit: the enter button on the keyboard is now a submit button instead of an enter button (which is not needed in these dialogs)