### PR TITLE
Fix Wiki Page Handling

### DIFF
--- a/app/src/main/java/ml/docilealligator/infinityforreddit/activities/LinkResolverActivity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/activities/LinkResolverActivity.java
@@ -49,7 +49,7 @@ public class LinkResolverActivity extends AppCompatActivity {
     private static final String IMGUR_ALBUM_PATTERN = "/(album|a)/\\w+/?";
     private static final String IMGUR_IMAGE_PATTERN = "/\\w+/?";
     private static final String RPAN_BROADCAST_PATTERN = "/rpan/r/[\\w-]+/\\w+/?\\w+/?";
-    private static final String WIKI_PATTERN = "/[rR]/[\\w-]+/(wiki|w)/?\\w+";
+    private static final String WIKI_PATTERN = "/[rR]/[\\w-]+/(wiki|w)?(?:/\\w+)+";
 
     @Inject
     @Named("default")
@@ -173,8 +173,10 @@ public class LinkResolverActivity extends AppCompatActivity {
                                     deepLinkError(uri);
                                 }
                             } else if (path.matches(WIKI_PATTERN)) {
+                                final String wikiPage = path.substring(path.lastIndexOf("/wiki/") + 6);
                                 Intent intent = new Intent(this, WikiActivity.class);
                                 intent.putExtra(WikiActivity.EXTRA_SUBREDDIT_NAME, segments.get(1));
+                                intent.putExtra(WikiActivity.EXTRA_WIKI_PATH, wikiPage);
                                 startActivity(intent);
                             } else if (path.matches(SUBREDDIT_PATTERN)) {
                                 Intent intent = new Intent(this, ViewSubredditDetailActivity.class);

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/activities/ViewSubredditDetailActivity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/activities/ViewSubredditDetailActivity.java
@@ -1180,6 +1180,12 @@ public class ViewSubredditDetailActivity extends BaseActivity implements SortTyp
                 Toast.makeText(this, R.string.no_app, Toast.LENGTH_SHORT).show();
             }
             return true;
+        } else if (itemId == R.id.action_go_to_wiki_activity ) {
+            Intent wikiIntent = new Intent(this, WikiActivity.class);
+            wikiIntent.putExtra(WikiActivity.EXTRA_SUBREDDIT_NAME, subredditName);
+            wikiIntent.putExtra(WikiActivity.EXTRA_WIKI_PATH, "index");
+            startActivity(wikiIntent);
+            return true;
         }
         return false;
     }

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/activities/WikiActivity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/activities/WikiActivity.java
@@ -71,7 +71,7 @@ import retrofit2.Retrofit;
 public class WikiActivity extends BaseActivity {
 
     public static final String EXTRA_SUBREDDIT_NAME = "ESN";
-    public static final String WIKI_PATH = "WP";
+    public static final String EXTRA_WIKI_PATH = "EWP";
     private static final String WIKI_MARKDOWN_STATE = "WMS";
 
     @BindView(R.id.coordinator_layout_comment_wiki_activity)
@@ -282,7 +282,7 @@ public class WikiActivity extends BaseActivity {
         Glide.with(this).clear(mFetchWikiInfoImageView);
         mFetchWikiInfoLinearLayout.setVisibility(View.GONE);
 
-        retrofit.create(RedditAPI.class).getWiki(getIntent().getStringExtra(EXTRA_SUBREDDIT_NAME)).enqueue(new Callback<String>() {
+        retrofit.create(RedditAPI.class).getWikiPage(getIntent().getStringExtra(EXTRA_SUBREDDIT_NAME), getIntent().getStringExtra(EXTRA_WIKI_PATH)).enqueue(new Callback<String>() {
             @Override
             public void onResponse(@NonNull Call<String> call, @NonNull Response<String> response) {
                 if (response.isSuccessful()) {

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/activities/WikiActivity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/activities/WikiActivity.java
@@ -71,6 +71,7 @@ import retrofit2.Retrofit;
 public class WikiActivity extends BaseActivity {
 
     public static final String EXTRA_SUBREDDIT_NAME = "ESN";
+    public static final String WIKI_PATH = "WP";
     private static final String WIKI_MARKDOWN_STATE = "WMS";
 
     @BindView(R.id.coordinator_layout_comment_wiki_activity)

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/apis/RedditAPI.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/apis/RedditAPI.java
@@ -294,8 +294,12 @@ public interface RedditAPI {
     @GET("/api/trending_searches_v1.json?withAds=0&raw_json=1&gilding_detail=1")
     Call<String> getTrendingSearches(@HeaderMap Map<String, String> headers);
 
-    @GET("/r/{subredditName}/wiki/index.json?raw_json=1")
-    Call<String> getWiki(@Path("subredditName") String subredditName);
+    default Call<String> getWiki(@Path("subredditName") String subredditName) {
+        return getWikiPage(subredditName, "index");
+    };
+
+    @GET("/r/{subredditName}/wiki/{wikiPage}.json?raw_json=1")
+    Call<String> getWikiPage(@Path("subredditName") String subredditName, @Path("wikiPage") String wikiPage);
 
     @GET("{sortType}?raw_json=1")
     ListenableFuture<Response<String>> getBestPostsListenableFuture(@Path("sortType") String sortType, @Query("after") String lastItem, @HeaderMap Map<String, String> headers);

--- a/app/src/main/res/menu/view_subreddit_detail_activity.xml
+++ b/app/src/main/res/menu/view_subreddit_detail_activity.xml
@@ -58,4 +58,10 @@
         android:orderInCategory="9"
         android:title="@string/action_share"
         app:showAsAction="never" />
+
+    <item
+        android:id="@+id/action_go_to_wiki_activity"
+        android:orderInCategory="10"
+        android:title="@string/action_go_to_wiki"
+        app:showAsAction="never" />
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1190,5 +1190,6 @@
     <string name="app_lock_timeout_6_hours">6 hours</string>
     <string name="app_lock_timeout_12_hours">12 hours</string>
     <string name="app_lock_timeout_24_hours">24 hours</string>
+    <string name="action_go_to_wiki">Go to Wiki</string>
 
 </resources>


### PR DESCRIPTION
This PR addresses two main issues:

1.  Viewing wiki's within the app. Previously only the index of the wiki was viewable. This has been updated to allow any page of a wiki (even nested pages).
2. Access to a subreddits wiki. An option was added to the subreddit details menu. This option will take you to the index of the sub's wiki, or show a page saying the sub has no wiki. Example shown below:
<img src="https://user-images.githubusercontent.com/12701490/134281992-cb4080a9-dc62-4fd6-9203-323806426834.png" width="300" height="816">
