### PR TITLE
Add nightly build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,12 +22,26 @@ jobs:
     - name: Grant Execute Permission for gradlew
       run: chmod +x gradlew
 
-    - name: Build with Gradle
-      run: ./gradlew build -x lint
+    - name: Cache Gradle
+      uses: actions/cache@v2
+      with:
+        path: ~/.gradle/caches
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+        restore-keys: ${{ runner.os }}-gradle
+
+    - name: Restore Keystore
+      run: |
+        echo "${{ secrets.NIGHTLY_PROP }}" > nightly.properties.asc
+         echo "${{ secrets.NIGHTLY_KEYSTORE }}" > nightly.keystore.asc
+         gpg --batch --passphrase "${{ secrets.PASSKEY }}" -d -o nightly.properties nightly.properties.asc
+         gpg --batch --passphrase "${{ secrets.PASSKEY }}" -d -o nightly.keystore nightly.keystore.asc
+
+    - name: Build Nightly APK with Gradle
+      run: ./gradlew -S :app:assembleNightlyRelease -x lint
 
     - name: Upload apk
       uses: actions/upload-artifact@v2
       with:
         name: Infinity-${{github.sha}}
-        path: app/build/outputs/apk/
+        path: app/build/outputs/apk/nightlyRelease/app-nightlyRelease.apk
         if-no-files-found: error

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,6 +15,20 @@ android {
             }
         }
     }
+    signingConfigs {
+        nightly {
+            def signingPropsFile = rootProject.file('nightly.properties')
+            def properties = null
+            if (signingPropsFile.exists()) {
+                properties = new Properties()
+                signingPropsFile.withInputStream { properties.load it }
+                storeFile properties?.get('secretKeyFile')?.with(rootProject.&file)
+                storePassword properties?.get('secretStorePassword')
+                keyAlias properties?.get('secretKeyAlias')
+                keyPassword properties?.get('secretKeyPassword')
+            }
+        }
+    }
     buildTypes {
         release {
             minifyEnabled false
@@ -26,6 +40,18 @@ android {
             minifyEnabled true
             shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+        nightlyRelease {
+            initWith buildTypes.minifiedRelease
+            signingConfig = signingConfigs.nightly
+        }
+    }
+    applicationVariants.all { variants ->
+        if (variants.buildType.name == 'nightlyRelease') {
+            variants.outputs.all { output ->
+                output.versionCodeOverride = defaultConfig.versionCode + 10000
+                output.versionNameOverride = defaultConfig.versionName + '-Nightly'
+            }
         }
     }
     compileOptions {


### PR DESCRIPTION
`secrets.NIGHTLY_PROP`  = encrypted nightly.properties with gpg

```bash
$ gpg -ca -o nightly.properties.txt nightly.properties
```

content nightly.properties: (-- change value property; except secretKeyFile)
```properties
#
secretKeyFile=nightly.keystore
secretStorePassword=android
secretKeyPassword=android
secretKeyAlias=androiddebugkey
```

`secrets.NIGHTLY_KEYSTORE` = encrypted nightly.keystore with gpg

```bash
$ gpg -ca -o nightly.keystore.txt nightly.keystore
```

`secrets.PASSKEY` = passphrase 

---
Refference: [How to store a Android Keystore safely on GitHub Actions](https://stefma.medium.com/how-to-store-a-android-keystore-safely-on-github-actions-f0cef9413784)