### PR TITLE
feat: "real" Material You implementation

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
     defaultConfig {
         applicationId "ml.docilealligator.infinityforreddit"
         minSdkVersion 21

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/utils/MaterialYouUtils.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/utils/MaterialYouUtils.java
@@ -15,6 +15,7 @@ import org.greenrobot.eventbus.EventBus;
 
 import java.util.concurrent.Executor;
 
+import ml.docilealligator.infinityforreddit.R;
 import ml.docilealligator.infinityforreddit.RedditDataRoomDatabase;
 import ml.docilealligator.infinityforreddit.customtheme.CustomTheme;
 import ml.docilealligator.infinityforreddit.customtheme.CustomThemeWrapper;
@@ -23,6 +24,7 @@ import ml.docilealligator.infinityforreddit.events.RecreateActivityEvent;
 public class MaterialYouUtils {
     public interface CheckThemeNameListener {
         void themeNotExists();
+
         void themeExists();
     }
 
@@ -48,83 +50,92 @@ public class MaterialYouUtils {
                                    SharedPreferences amoledThemeSharedPreferences,
                                    @Nullable MaterialYouListener materialYouListener) {
         executor.execute(() -> {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
-                WallpaperManager wallpaperManager = WallpaperManager.getInstance(context);
-                WallpaperColors wallpaperColors = wallpaperManager.getWallpaperColors(WallpaperManager.FLAG_SYSTEM);
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                CustomTheme lightTheme = CustomThemeWrapper.getIndigo(context);
+                CustomTheme darkTheme = CustomThemeWrapper.getIndigoDark(context);
+                CustomTheme amoledTheme = CustomThemeWrapper.getIndigoAmoled(context);
 
-                if (wallpaperColors != null) {
-                    int colorPrimaryInt = lightenColor(wallpaperColors.getPrimaryColor().toArgb(), 0.4);
-                    int colorPrimaryDarkInt = darkenColor(colorPrimaryInt, 0.3);
-                    int backgroundColor = lightenColor(colorPrimaryInt, 0.2);
-                    int cardViewBackgroundColor = lightenColor(colorPrimaryInt, 0.6);
-                    Color colorAccent = wallpaperColors.getSecondaryColor();
-                    int colorAccentInt = lightenColor(colorAccent == null ? customThemeWrapper.getColorAccent() : colorAccent.toArgb(), 0.4);
 
-                    int colorPrimaryAppropriateTextColor = getAppropriateTextColor(colorPrimaryInt);
-                    int backgroundColorAppropriateTextColor = getAppropriateTextColor(backgroundColor);
+                lightTheme.colorPrimary = context.getColor(android.R.color.system_accent1_300);
+                lightTheme.colorPrimaryDark = context.getColor(android.R.color.system_accent1_500);
+                lightTheme.colorAccent = context.getColor(android.R.color.system_accent3_300);
+                lightTheme.colorPrimaryLightTheme = context.getColor(android.R.color.system_accent1_200);
+                lightTheme.backgroundColor = context.getColor(android.R.color.system_neutral1_10);
+                lightTheme.cardViewBackgroundColor = context.getColor(android.R.color.system_neutral2_50);
+                lightTheme.commentBackgroundColor = context.getColor(android.R.color.system_neutral2_50);
+                lightTheme.awardedCommentBackgroundColor = context.getColor(android.R.color.system_neutral2_100);
+                lightTheme.bottomAppBarBackgroundColor = context.getColor(android.R.color.system_accent2_100);
+                lightTheme.navBarColor = context.getColor(android.R.color.system_neutral2_100);
+                lightTheme.primaryTextColor = context.getColor(android.R.color.system_neutral1_900);
+                lightTheme.secondaryTextColor = context.getColor(android.R.color.system_neutral1_900);
+                lightTheme.bottomAppBarIconColor = context.getColor(android.R.color.system_accent1_400);;
+                lightTheme.primaryIconColor = context.getColor(android.R.color.system_accent1_400);
+                lightTheme.fabIconColor = context.getColor(android.R.color.system_neutral1_10);
+                lightTheme.toolbarPrimaryTextAndIconColor = context.getColor(android.R.color.system_accent1_50);
+                lightTheme.toolbarSecondaryTextColor = context.getColor(android.R.color.system_accent3_50);
+                lightTheme.tabLayoutWithCollapsedCollapsingToolbarTabIndicator = context.getColor(android.R.color.system_accent1_50);
+                lightTheme.tabLayoutWithCollapsedCollapsingToolbarTextColor = context.getColor(android.R.color.system_accent1_50);
+                lightTheme.tabLayoutWithCollapsedCollapsingToolbarTabBackground = context.getColor(android.R.color.system_accent1_50);
+                lightTheme.tabLayoutWithExpandedCollapsingToolbarTabBackground = context.getColor(android.R.color.system_accent1_50);
+                lightTheme.tabLayoutWithExpandedCollapsingToolbarTabIndicator = context.getColor(android.R.color.system_accent1_50);
+                lightTheme.tabLayoutWithExpandedCollapsingToolbarTextColor = context.getColor(android.R.color.system_accent1_50);
+                lightTheme.circularProgressBarBackground = context.getColor(android.R.color.system_accent1_10);
+                lightTheme.dividerColor = context.getColor(android.R.color.system_neutral1_100);
+                lightTheme.isLightStatusBar = false;
+                lightTheme.isChangeStatusBarIconColorAfterToolbarCollapsedInImmersiveInterface = false;
+                lightTheme.name = "Material You";
 
-                    CustomTheme lightTheme = CustomThemeWrapper.getIndigo(context);
-                    CustomTheme darkTheme = CustomThemeWrapper.getIndigoDark(context);
-                    CustomTheme amoledTheme = CustomThemeWrapper.getIndigoAmoled(context);
+                darkTheme.colorPrimary = context.getColor(android.R.color.system_accent1_100);
+                darkTheme.colorPrimaryDark = context.getColor(android.R.color.system_accent1_300);
+                darkTheme.colorAccent = context.getColor(android.R.color.system_accent3_100);
+                darkTheme.colorPrimaryLightTheme = context.getColor(android.R.color.system_accent1_100);
+                darkTheme.backgroundColor = context.getColor(android.R.color.system_neutral1_900);
+                darkTheme.cardViewBackgroundColor = context.getColor(android.R.color.system_neutral2_800);
+                darkTheme.commentBackgroundColor = context.getColor(android.R.color.system_neutral2_800);
+                darkTheme.awardedCommentBackgroundColor = context.getColor(android.R.color.system_neutral2_800);
+                darkTheme.bottomAppBarBackgroundColor = context.getColor(android.R.color.system_accent2_800);
+                darkTheme.navBarColor = context.getColor(android.R.color.system_neutral2_800);
+                darkTheme.primaryTextColor = context.getColor(android.R.color.system_neutral1_10);
+                darkTheme.secondaryTextColor = context.getColor(android.R.color.system_neutral1_10);
+                darkTheme.bottomAppBarIconColor = context.getColor(android.R.color.system_accent1_100);;
+                darkTheme.primaryIconColor = context.getColor(android.R.color.system_accent1_100);
+                darkTheme.fabIconColor = context.getColor(android.R.color.system_neutral1_900);
+                darkTheme.toolbarPrimaryTextAndIconColor = context.getColor(android.R.color.system_accent1_900);
+                darkTheme.toolbarSecondaryTextColor = context.getColor(android.R.color.system_accent3_900);
+                darkTheme.tabLayoutWithCollapsedCollapsingToolbarTabIndicator = context.getColor(android.R.color.system_accent1_800);
+                darkTheme.tabLayoutWithCollapsedCollapsingToolbarTextColor = context.getColor(android.R.color.system_accent1_800);
+                darkTheme.tabLayoutWithCollapsedCollapsingToolbarTabBackground = context.getColor(android.R.color.system_accent1_800);
+                darkTheme.tabLayoutWithExpandedCollapsingToolbarTabBackground = context.getColor(android.R.color.system_accent1_800);
+                darkTheme.tabLayoutWithExpandedCollapsingToolbarTabIndicator = context.getColor(android.R.color.system_accent1_800);
+                darkTheme.tabLayoutWithExpandedCollapsingToolbarTextColor = context.getColor(android.R.color.system_accent1_800);
+                darkTheme.circularProgressBarBackground = context.getColor(android.R.color.system_accent1_900);
+                darkTheme.dividerColor = context.getColor(android.R.color.system_neutral1_600);
+                darkTheme.isLightStatusBar = true;
+                darkTheme.isChangeStatusBarIconColorAfterToolbarCollapsedInImmersiveInterface = true;
+                darkTheme.name = "Material You Dark";
 
-                    lightTheme.colorPrimary = colorPrimaryInt;
-                    lightTheme.colorPrimaryDark = colorPrimaryDarkInt;
-                    lightTheme.colorAccent = colorAccentInt;
-                    lightTheme.colorPrimaryLightTheme = colorPrimaryInt;
-                    lightTheme.backgroundColor = backgroundColor;
-                    lightTheme.cardViewBackgroundColor = cardViewBackgroundColor;
-                    lightTheme.commentBackgroundColor = cardViewBackgroundColor;
-                    lightTheme.awardedCommentBackgroundColor = cardViewBackgroundColor;
-                    lightTheme.bottomAppBarBackgroundColor = colorPrimaryInt;
-                    lightTheme.navBarColor = colorPrimaryInt;
-                    lightTheme.primaryTextColor = backgroundColorAppropriateTextColor;
-                    lightTheme.secondaryTextColor = backgroundColorAppropriateTextColor == Color.BLACK ? Color.parseColor("#8A000000") : Color.parseColor("#B3FFFFFF");
-                    lightTheme.bottomAppBarIconColor = colorPrimaryAppropriateTextColor;
-                    lightTheme.primaryIconColor = backgroundColorAppropriateTextColor;
-                    lightTheme.fabIconColor = colorPrimaryAppropriateTextColor;
-                    lightTheme.toolbarPrimaryTextAndIconColor = colorPrimaryAppropriateTextColor;
-                    lightTheme.toolbarSecondaryTextColor = colorPrimaryAppropriateTextColor;
-                    lightTheme.tabLayoutWithCollapsedCollapsingToolbarTabIndicator = colorPrimaryAppropriateTextColor;
-                    lightTheme.tabLayoutWithCollapsedCollapsingToolbarTextColor = colorPrimaryAppropriateTextColor;
-                    lightTheme.tabLayoutWithCollapsedCollapsingToolbarTabBackground = colorPrimaryInt;
-                    lightTheme.tabLayoutWithExpandedCollapsingToolbarTabBackground = colorPrimaryInt;
-                    lightTheme.tabLayoutWithExpandedCollapsingToolbarTabIndicator = colorPrimaryAppropriateTextColor;
-                    lightTheme.tabLayoutWithExpandedCollapsingToolbarTextColor = colorPrimaryAppropriateTextColor;
-                    lightTheme.circularProgressBarBackground = colorPrimaryInt;
-                    lightTheme.dividerColor = backgroundColorAppropriateTextColor == Color.BLACK ? Color.parseColor("#E0E0E0") : Color.parseColor("69666C");
-                    lightTheme.isLightStatusBar = colorPrimaryAppropriateTextColor == Color.BLACK;
-                    lightTheme.isChangeStatusBarIconColorAfterToolbarCollapsedInImmersiveInterface =
-                            (lightTheme.isLightStatusBar && getAppropriateTextColor(cardViewBackgroundColor) == Color.WHITE)
-                                    || (!lightTheme.isLightStatusBar && getAppropriateTextColor(cardViewBackgroundColor) == Color.BLACK);
-                    lightTheme.name = "Material You";
+                amoledTheme.colorAccent = context.getColor(android.R.color.system_accent1_100);
+                amoledTheme.colorPrimaryLightTheme = context.getColor(android.R.color.system_accent3_100);
+                amoledTheme.name = "Material You Amoled";
 
-                    darkTheme.colorAccent = colorPrimaryInt;
-                    darkTheme.colorPrimaryLightTheme = colorPrimaryInt;
-                    darkTheme.name = "Material You Dark";
+                redditDataRoomDatabase.customThemeDao().unsetLightTheme();
+                redditDataRoomDatabase.customThemeDao().unsetDarkTheme();
+                redditDataRoomDatabase.customThemeDao().unsetAmoledTheme();
 
-                    amoledTheme.colorAccent = colorPrimaryInt;
-                    amoledTheme.colorPrimaryLightTheme = colorPrimaryInt;
-                    amoledTheme.name = "Material You Amoled";
+                redditDataRoomDatabase.customThemeDao().insert(lightTheme);
+                redditDataRoomDatabase.customThemeDao().insert(darkTheme);
+                redditDataRoomDatabase.customThemeDao().insert(amoledTheme);
 
-                    redditDataRoomDatabase.customThemeDao().unsetLightTheme();
-                    redditDataRoomDatabase.customThemeDao().unsetDarkTheme();
-                    redditDataRoomDatabase.customThemeDao().unsetAmoledTheme();
-                    
-                    redditDataRoomDatabase.customThemeDao().insert(lightTheme);
-                    redditDataRoomDatabase.customThemeDao().insert(darkTheme);
-                    redditDataRoomDatabase.customThemeDao().insert(amoledTheme);
+                CustomThemeSharedPreferencesUtils.insertThemeToSharedPreferences(lightTheme, lightThemeSharedPreferences);
+                CustomThemeSharedPreferencesUtils.insertThemeToSharedPreferences(darkTheme, darkThemeSharedPreferences);
+                CustomThemeSharedPreferencesUtils.insertThemeToSharedPreferences(amoledTheme, amoledThemeSharedPreferences);
 
-                    CustomThemeSharedPreferencesUtils.insertThemeToSharedPreferences(lightTheme, lightThemeSharedPreferences);
-                    CustomThemeSharedPreferencesUtils.insertThemeToSharedPreferences(darkTheme, darkThemeSharedPreferences);
-                    CustomThemeSharedPreferencesUtils.insertThemeToSharedPreferences(amoledTheme, amoledThemeSharedPreferences);
-
-                    handler.post(() -> {
-                        if (materialYouListener != null) {
-                            materialYouListener.applied();
-                        }
-                        EventBus.getDefault().post(new RecreateActivityEvent());
-                    });
-                }
+                handler.post(() -> {
+                    if (materialYouListener != null) {
+                        materialYouListener.applied();
+                    }
+                    EventBus.getDefault().post(new RecreateActivityEvent());
+                });
             }
         });
     }

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/utils/MaterialYouUtils.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/utils/MaterialYouUtils.java
@@ -15,7 +15,6 @@ import org.greenrobot.eventbus.EventBus;
 
 import java.util.concurrent.Executor;
 
-import ml.docilealligator.infinityforreddit.R;
 import ml.docilealligator.infinityforreddit.RedditDataRoomDatabase;
 import ml.docilealligator.infinityforreddit.customtheme.CustomTheme;
 import ml.docilealligator.infinityforreddit.customtheme.CustomThemeWrapper;
@@ -24,7 +23,6 @@ import ml.docilealligator.infinityforreddit.events.RecreateActivityEvent;
 public class MaterialYouUtils {
     public interface CheckThemeNameListener {
         void themeNotExists();
-
         void themeExists();
     }
 

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/utils/MaterialYouUtils.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/utils/MaterialYouUtils.java
@@ -82,7 +82,7 @@ public class MaterialYouUtils {
                 lightTheme.circularProgressBarBackground = context.getColor(android.R.color.system_accent1_10);
                 lightTheme.dividerColor = context.getColor(android.R.color.system_neutral1_100);
                 lightTheme.isLightStatusBar = false;
-                lightTheme.isChangeStatusBarIconColorAfterToolbarCollapsedInImmersiveInterface = false;
+                lightTheme.isChangeStatusBarIconColorAfterToolbarCollapsedInImmersiveInterface = true;
                 lightTheme.name = "Material You";
 
                 darkTheme.colorPrimary = context.getColor(android.R.color.system_accent1_100);
@@ -136,6 +136,83 @@ public class MaterialYouUtils {
                     }
                     EventBus.getDefault().post(new RecreateActivityEvent());
                 });
+            } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
+                WallpaperManager wallpaperManager = WallpaperManager.getInstance(context);
+                WallpaperColors wallpaperColors = wallpaperManager.getWallpaperColors(WallpaperManager.FLAG_SYSTEM);
+
+                if (wallpaperColors != null) {
+                    int colorPrimaryInt = lightenColor(wallpaperColors.getPrimaryColor().toArgb(), 0.4);
+                    int colorPrimaryDarkInt = darkenColor(colorPrimaryInt, 0.3);
+                    int backgroundColor = lightenColor(colorPrimaryInt, 0.2);
+                    int cardViewBackgroundColor = lightenColor(colorPrimaryInt, 0.6);
+                    Color colorAccent = wallpaperColors.getSecondaryColor();
+                    int colorAccentInt = lightenColor(colorAccent == null ? customThemeWrapper.getColorAccent() : colorAccent.toArgb(), 0.4);
+
+                    int colorPrimaryAppropriateTextColor = getAppropriateTextColor(colorPrimaryInt);
+                    int backgroundColorAppropriateTextColor = getAppropriateTextColor(backgroundColor);
+
+                    CustomTheme lightTheme = CustomThemeWrapper.getIndigo(context);
+                    CustomTheme darkTheme = CustomThemeWrapper.getIndigoDark(context);
+                    CustomTheme amoledTheme = CustomThemeWrapper.getIndigoAmoled(context);
+
+                    lightTheme.colorPrimary = colorPrimaryInt;
+                    lightTheme.colorPrimaryDark = colorPrimaryDarkInt;
+                    lightTheme.colorAccent = colorAccentInt;
+                    lightTheme.colorPrimaryLightTheme = colorPrimaryInt;
+                    lightTheme.backgroundColor = backgroundColor;
+                    lightTheme.cardViewBackgroundColor = cardViewBackgroundColor;
+                    lightTheme.commentBackgroundColor = cardViewBackgroundColor;
+                    lightTheme.awardedCommentBackgroundColor = cardViewBackgroundColor;
+                    lightTheme.bottomAppBarBackgroundColor = colorPrimaryInt;
+                    lightTheme.navBarColor = colorPrimaryInt;
+                    lightTheme.primaryTextColor = backgroundColorAppropriateTextColor;
+                    lightTheme.secondaryTextColor = backgroundColorAppropriateTextColor == Color.BLACK ? Color.parseColor("#8A000000") : Color.parseColor("#B3FFFFFF");
+                    lightTheme.bottomAppBarIconColor = colorPrimaryAppropriateTextColor;
+                    lightTheme.primaryIconColor = backgroundColorAppropriateTextColor;
+                    lightTheme.fabIconColor = colorPrimaryAppropriateTextColor;
+                    lightTheme.toolbarPrimaryTextAndIconColor = colorPrimaryAppropriateTextColor;
+                    lightTheme.toolbarSecondaryTextColor = colorPrimaryAppropriateTextColor;
+                    lightTheme.tabLayoutWithCollapsedCollapsingToolbarTabIndicator = colorPrimaryAppropriateTextColor;
+                    lightTheme.tabLayoutWithCollapsedCollapsingToolbarTextColor = colorPrimaryAppropriateTextColor;
+                    lightTheme.tabLayoutWithCollapsedCollapsingToolbarTabBackground = colorPrimaryInt;
+                    lightTheme.tabLayoutWithExpandedCollapsingToolbarTabBackground = colorPrimaryInt;
+                    lightTheme.tabLayoutWithExpandedCollapsingToolbarTabIndicator = colorPrimaryAppropriateTextColor;
+                    lightTheme.tabLayoutWithExpandedCollapsingToolbarTextColor = colorPrimaryAppropriateTextColor;
+                    lightTheme.circularProgressBarBackground = colorPrimaryInt;
+                    lightTheme.dividerColor = backgroundColorAppropriateTextColor == Color.BLACK ? Color.parseColor("#E0E0E0") : Color.parseColor("69666C");
+                    lightTheme.isLightStatusBar = colorPrimaryAppropriateTextColor == Color.BLACK;
+                    lightTheme.isChangeStatusBarIconColorAfterToolbarCollapsedInImmersiveInterface =
+                            (lightTheme.isLightStatusBar && getAppropriateTextColor(cardViewBackgroundColor) == Color.WHITE)
+                                    || (!lightTheme.isLightStatusBar && getAppropriateTextColor(cardViewBackgroundColor) == Color.BLACK);
+                    lightTheme.name = "Material You";
+
+                    darkTheme.colorAccent = colorPrimaryInt;
+                    darkTheme.colorPrimaryLightTheme = colorPrimaryInt;
+                    darkTheme.name = "Material You Dark";
+
+                    amoledTheme.colorAccent = colorPrimaryInt;
+                    amoledTheme.colorPrimaryLightTheme = colorPrimaryInt;
+                    amoledTheme.name = "Material You Amoled";
+
+                    redditDataRoomDatabase.customThemeDao().unsetLightTheme();
+                    redditDataRoomDatabase.customThemeDao().unsetDarkTheme();
+                    redditDataRoomDatabase.customThemeDao().unsetAmoledTheme();
+
+                    redditDataRoomDatabase.customThemeDao().insert(lightTheme);
+                    redditDataRoomDatabase.customThemeDao().insert(darkTheme);
+                    redditDataRoomDatabase.customThemeDao().insert(amoledTheme);
+
+                    CustomThemeSharedPreferencesUtils.insertThemeToSharedPreferences(lightTheme, lightThemeSharedPreferences);
+                    CustomThemeSharedPreferencesUtils.insertThemeToSharedPreferences(darkTheme, darkThemeSharedPreferences);
+                    CustomThemeSharedPreferencesUtils.insertThemeToSharedPreferences(amoledTheme, amoledThemeSharedPreferences);
+
+                    handler.post(() -> {
+                        if (materialYouListener != null) {
+                            materialYouListener.applied();
+                        }
+                        EventBus.getDefault().post(new RecreateActivityEvent());
+                    });
+                }
             }
         });
     }


### PR DESCRIPTION
This implementation largely just swaps out the wallpaper manager-generated colors for the system-provided color palette, and thus provides more coherence with the rest of the themed applications.

* An orange color scheme
<p align="left">
<img src="https://user-images.githubusercontent.com/19289296/138135378-97283075-46cf-4773-a5be-4a15d3b6307a.png" width=200/>
<img src="https://user-images.githubusercontent.com/19289296/138135394-9655c4d7-6174-4870-ad0f-3a5ec4d5ff2e.png" width=200/>
</p>

* A green color scheme
<p align="left">
<img src="https://user-images.githubusercontent.com/19289296/138135402-19e85236-bc4c-435d-a50a-a766d11792f0.png" width=200/>
<img src="https://user-images.githubusercontent.com/19289296/138135409-bf3fe813-a262-4ede-953b-7fc4c9ac6946.png" width=200/>
</p>
