### PR TITLE
Don't cancel all ImageLoader instances

### DIFF
--- a/app/src/main/java/ml/docilealligator/infinityforreddit/fragments/ViewRedditGalleryImageOrGifFragment.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/fragments/ViewRedditGalleryImageOrGifFragment.java
@@ -427,7 +427,7 @@ public class ViewRedditGalleryImageOrGifFragment extends Fragment {
     @Override
     public void onDestroyView() {
         super.onDestroyView();
-        BigImageViewer.imageLoader().cancelAll();
+        imageView.cancel();
         SubsamplingScaleImageView subsamplingScaleImageView = imageView.getSSIV();
         if (subsamplingScaleImageView != null) {
             subsamplingScaleImageView.recycle();


### PR DESCRIPTION
If you cancel them all then next one loading will also be cancelled. Instead, just cancel the previous imageLoader.

Addresses #548, probably a continuation of #360.