### PR TITLE
Added Setting for Separate NSFW Download Folder

### DIFF
--- a/app/src/main/java/ml/docilealligator/infinityforreddit/activities/ViewImageOrGifActivity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/activities/ViewImageOrGifActivity.java
@@ -83,6 +83,7 @@ public class ViewImageOrGifActivity extends AppCompatActivity implements SetAsWa
     public static final String EXTRA_FILE_NAME_KEY = "EFNK";
     public static final String EXTRA_SUBREDDIT_OR_USERNAME_KEY = "ESOUK";
     public static final String EXTRA_POST_TITLE_KEY = "EPTK";
+    public static final String EXTRA_IS_NSFW = "EIN";
     private static final int PERMISSION_REQUEST_WRITE_EXTERNAL_STORAGE = 0;
     @BindView(R.id.progress_bar_view_image_or_gif_activity)
     ProgressBar mProgressBar;
@@ -112,6 +113,7 @@ public class ViewImageOrGifActivity extends AppCompatActivity implements SetAsWa
     private String mImageFileName;
     private String mSubredditName;
     private boolean isGif = true;
+    private boolean isNsfw;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -165,6 +167,7 @@ public class ViewImageOrGifActivity extends AppCompatActivity implements SetAsWa
         mImageFileName = intent.getStringExtra(EXTRA_FILE_NAME_KEY);
         String postTitle = intent.getStringExtra(EXTRA_POST_TITLE_KEY);
         mSubredditName = intent.getStringExtra(EXTRA_SUBREDDIT_OR_USERNAME_KEY);
+        isNsfw = intent.getBooleanExtra(EXTRA_IS_NSFW, false);
 
         boolean useBottomAppBar = mSharedPreferences.getBoolean(SharedPreferencesUtils.USE_BOTTOM_TOOLBAR_IN_MEDIA_VIEWER, false);
         if (postTitle != null) {
@@ -368,6 +371,7 @@ public class ViewImageOrGifActivity extends AppCompatActivity implements SetAsWa
         intent.putExtra(DownloadMediaService.EXTRA_MEDIA_TYPE, isGif ? DownloadMediaService.EXTRA_MEDIA_TYPE_GIF : DownloadMediaService.EXTRA_MEDIA_TYPE_IMAGE);
         intent.putExtra(DownloadMediaService.EXTRA_FILE_NAME, mImageFileName);
         intent.putExtra(DownloadMediaService.EXTRA_SUBREDDIT_NAME, mSubredditName);
+        intent.putExtra(DownloadMediaService.EXTRA_IS_NSFW, isNsfw);
         ContextCompat.startForegroundService(this, intent);
         Toast.makeText(this, R.string.download_started, Toast.LENGTH_SHORT).show();
     }

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/activities/ViewRedditGalleryActivity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/activities/ViewRedditGalleryActivity.java
@@ -57,6 +57,7 @@ public class ViewRedditGalleryActivity extends AppCompatActivity implements SetA
 
     public static final String EXTRA_REDDIT_GALLERY = "ERG";
     public static final String EXTRA_SUBREDDIT_NAME = "ESN";
+    public static final String EXTRA_IS_NSFW = "EIN";
 
     @BindView(R.id.hauler_view_view_reddit_gallery_activity)
     HaulerView haulerView;
@@ -70,6 +71,7 @@ public class ViewRedditGalleryActivity extends AppCompatActivity implements SetA
     private SectionsPagerAdapter sectionsPagerAdapter;
     private ArrayList<Post.Gallery> gallery;
     private String subredditName;
+    private boolean isNsfw;
     private boolean useBottomAppBar;
 
     @Override
@@ -155,6 +157,7 @@ public class ViewRedditGalleryActivity extends AppCompatActivity implements SetA
             return;
         }
         subredditName = getIntent().getStringExtra(EXTRA_SUBREDDIT_NAME);
+        isNsfw = getIntent().getBooleanExtra(EXTRA_IS_NSFW, false);
 
         if (sharedPreferences.getBoolean(SharedPreferencesUtils.SWIPE_VERTICALLY_TO_GO_BACK_FROM_MEDIA, true)) {
             haulerView.setOnDragDismissedListener(dragDirection -> {
@@ -290,6 +293,7 @@ public class ViewRedditGalleryActivity extends AppCompatActivity implements SetA
                 bundle.putString(ViewRedditGalleryVideoFragment.EXTRA_SUBREDDIT_NAME, subredditName);
                 bundle.putInt(ViewRedditGalleryVideoFragment.EXTRA_INDEX, position);
                 bundle.putInt(ViewRedditGalleryVideoFragment.EXTRA_MEDIA_COUNT, gallery.size());
+                bundle.putBoolean(ViewRedditGalleryVideoFragment.EXTRA_IS_NSFW, isNsfw);
                 fragment.setArguments(bundle);
                 return fragment;
             } else {
@@ -299,6 +303,7 @@ public class ViewRedditGalleryActivity extends AppCompatActivity implements SetA
                 bundle.putString(ViewRedditGalleryImageOrGifFragment.EXTRA_SUBREDDIT_NAME, subredditName);
                 bundle.putInt(ViewRedditGalleryImageOrGifFragment.EXTRA_INDEX, position);
                 bundle.putInt(ViewRedditGalleryImageOrGifFragment.EXTRA_MEDIA_COUNT, gallery.size());
+                bundle.putBoolean(ViewRedditGalleryImageOrGifFragment.EXTRA_IS_NSFW, false);
                 fragment.setArguments(bundle);
                 return fragment;
             }

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/activities/ViewVideoActivity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/activities/ViewVideoActivity.java
@@ -895,11 +895,13 @@ public class ViewVideoActivity extends AppCompatActivity {
             intent.putExtra(DownloadMediaService.EXTRA_MEDIA_TYPE, DownloadMediaService.EXTRA_MEDIA_TYPE_VIDEO);
             intent.putExtra(DownloadMediaService.EXTRA_FILE_NAME, videoFileName);
             intent.putExtra(DownloadMediaService.EXTRA_SUBREDDIT_NAME, subredditName);
+            intent.putExtra(DownloadMediaService.EXTRA_IS_NSFW, isNSFW);
         } else {
             intent = new Intent(this, DownloadRedditVideoService.class);
             intent.putExtra(DownloadRedditVideoService.EXTRA_VIDEO_URL, videoDownloadUrl);
             intent.putExtra(DownloadRedditVideoService.EXTRA_POST_ID, id);
             intent.putExtra(DownloadRedditVideoService.EXTRA_SUBREDDIT, subredditName);
+            intent.putExtra(DownloadRedditVideoService.EXTRA_IS_NSFW, isNSFW);
         }
         ContextCompat.startForegroundService(this, intent);
         Toast.makeText(this, R.string.download_started, Toast.LENGTH_SHORT).show();

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/PostRecyclerViewAdapter.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/PostRecyclerViewAdapter.java
@@ -1988,6 +1988,7 @@ public class PostRecyclerViewAdapter extends PagingDataAdapter<Post, RecyclerVie
                 Intent intent = new Intent(mActivity, ViewRedditGalleryActivity.class);
                 intent.putParcelableArrayListExtra(ViewRedditGalleryActivity.EXTRA_REDDIT_GALLERY, post.getGallery());
                 intent.putExtra(ViewRedditGalleryActivity.EXTRA_SUBREDDIT_NAME, post.getSubredditName());
+                intent.putExtra(ViewRedditGalleryActivity.EXTRA_IS_NSFW, post.isNSFW());
                 mActivity.startActivity(intent);
             }
         }

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/PostRecyclerViewAdapter.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/PostRecyclerViewAdapter.java
@@ -1967,6 +1967,7 @@ public class PostRecyclerViewAdapter extends PagingDataAdapter<Post, RecyclerVie
                         + "-" + post.getId() + ".jpg");
                 intent.putExtra(ViewImageOrGifActivity.EXTRA_POST_TITLE_KEY, post.getTitle());
                 intent.putExtra(ViewImageOrGifActivity.EXTRA_SUBREDDIT_OR_USERNAME_KEY, post.getSubredditName());
+                intent.putExtra(ViewImageOrGifActivity.EXTRA_IS_NSFW, post.isNSFW());
                 mActivity.startActivity(intent);
             } else if (post.getPostType() == Post.GIF_TYPE) {
                 Intent intent = new Intent(mActivity, ViewImageOrGifActivity.class);
@@ -1975,6 +1976,7 @@ public class PostRecyclerViewAdapter extends PagingDataAdapter<Post, RecyclerVie
                 intent.putExtra(ViewImageOrGifActivity.EXTRA_GIF_URL_KEY, post.getVideoUrl());
                 intent.putExtra(ViewImageOrGifActivity.EXTRA_POST_TITLE_KEY, post.getTitle());
                 intent.putExtra(ViewImageOrGifActivity.EXTRA_SUBREDDIT_OR_USERNAME_KEY, post.getSubredditName());
+                intent.putExtra(ViewImageOrGifActivity.EXTRA_IS_NSFW, post.isNSFW());
                 mActivity.startActivity(intent);
             } else if (post.getPostType() == Post.LINK_TYPE || post.getPostType() == Post.NO_PREVIEW_LINK_TYPE) {
                 Intent intent = new Intent(mActivity, LinkResolverActivity.class);

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/fragments/ViewRedditGalleryImageOrGifFragment.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/fragments/ViewRedditGalleryImageOrGifFragment.java
@@ -75,6 +75,7 @@ public class ViewRedditGalleryImageOrGifFragment extends Fragment {
     public static final String EXTRA_SUBREDDIT_NAME = "ESN";
     public static final String EXTRA_INDEX = "EI";
     public static final String EXTRA_MEDIA_COUNT = "EMC";
+    public static final String EXTRA_IS_NSFW = "EIN";
     private static final int PERMISSION_REQUEST_WRITE_EXTERNAL_STORAGE = 0;
 
     @BindView(R.id.progress_bar_view_reddit_gallery_image_or_gif_fragment)
@@ -108,6 +109,7 @@ public class ViewRedditGalleryImageOrGifFragment extends Fragment {
     private RequestManager glide;
     private Post.Gallery media;
     private String subredditName;
+    private boolean isNsfw;
     private boolean isDownloading = false;
     private boolean isActionBarHidden = false;
     private boolean isUseBottomCaption = false;
@@ -132,6 +134,7 @@ public class ViewRedditGalleryImageOrGifFragment extends Fragment {
 
         media = getArguments().getParcelable(EXTRA_REDDIT_GALLERY_MEDIA);
         subredditName = getArguments().getString(EXTRA_SUBREDDIT_NAME);
+        isNsfw = getArguments().getBoolean(EXTRA_IS_NSFW, false);
         glide = Glide.with(activity);
 
         imageView.setImageViewFactory(new GlideImageViewFactory());
@@ -398,6 +401,7 @@ public class ViewRedditGalleryImageOrGifFragment extends Fragment {
         intent.putExtra(DownloadMediaService.EXTRA_MEDIA_TYPE, media.mediaType == Post.Gallery.TYPE_GIF ? DownloadMediaService.EXTRA_MEDIA_TYPE_GIF: DownloadMediaService.EXTRA_MEDIA_TYPE_IMAGE);
         intent.putExtra(DownloadMediaService.EXTRA_FILE_NAME, media.fileName);
         intent.putExtra(DownloadMediaService.EXTRA_SUBREDDIT_NAME, subredditName);
+        intent.putExtra(DownloadMediaService.EXTRA_IS_NSFW, isNsfw);
         ContextCompat.startForegroundService(activity, intent);
         Toast.makeText(activity, R.string.download_started, Toast.LENGTH_SHORT).show();
     }

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/fragments/ViewRedditGalleryVideoFragment.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/fragments/ViewRedditGalleryVideoFragment.java
@@ -62,6 +62,7 @@ public class ViewRedditGalleryVideoFragment extends Fragment {
     public static final String EXTRA_SUBREDDIT_NAME = "ESN";
     public static final String EXTRA_INDEX = "EI";
     public static final String EXTRA_MEDIA_COUNT = "EMC";
+    public static final String EXTRA_IS_NSFW = "EIN";
     private static final int PERMISSION_REQUEST_WRITE_EXTERNAL_STORAGE = 0;
     private static final String IS_MUTE_STATE = "IMS";
     private static final String POSITION_STATE = "PS";
@@ -79,6 +80,7 @@ public class ViewRedditGalleryVideoFragment extends Fragment {
     private ViewRedditGalleryActivity activity;
     private Post.Gallery galleryVideo;
     private String subredditName;
+    private boolean isNsfw;
     private SimpleExoPlayer player;
     private DataSource.Factory dataSourceFactory;
     private boolean wasPlaying = false;
@@ -109,6 +111,7 @@ public class ViewRedditGalleryVideoFragment extends Fragment {
 
         galleryVideo = getArguments().getParcelable(EXTRA_REDDIT_GALLERY_VIDEO);
         subredditName = getArguments().getString(EXTRA_SUBREDDIT_NAME);
+        isNsfw = getArguments().getBoolean(EXTRA_IS_NSFW, false);
 
         if (!mSharedPreferences.getBoolean(SharedPreferencesUtils.VIDEO_PLAYER_IGNORE_NAV_BAR, false)) {
             if (getResources().getConfiguration().orientation == Configuration.ORIENTATION_PORTRAIT || getResources().getBoolean(R.bool.isTablet)) {
@@ -242,6 +245,7 @@ public class ViewRedditGalleryVideoFragment extends Fragment {
         intent.putExtra(DownloadMediaService.EXTRA_MEDIA_TYPE, DownloadMediaService.EXTRA_MEDIA_TYPE_VIDEO);
         intent.putExtra(DownloadMediaService.EXTRA_FILE_NAME, galleryVideo.fileName);
         intent.putExtra(DownloadMediaService.EXTRA_SUBREDDIT_NAME, subredditName);
+        intent.putExtra(DownloadMediaService.EXTRA_IS_NSFW, isNsfw);
         ContextCompat.startForegroundService(activity, intent);
         Toast.makeText(activity, R.string.download_started, Toast.LENGTH_SHORT).show();
     }

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/services/DownloadMediaService.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/services/DownloadMediaService.java
@@ -57,6 +57,7 @@ public class DownloadMediaService extends Service {
     public static final String EXTRA_FILE_NAME = "EFN";
     public static final String EXTRA_SUBREDDIT_NAME = "ESN";
     public static final String EXTRA_MEDIA_TYPE = "EIG";
+    public static final String EXTRA_IS_NSFW = "EIN";
     public static final int EXTRA_MEDIA_TYPE_IMAGE = 0;
     public static final int EXTRA_MEDIA_TYPE_GIF = 1;
     public static final int EXTRA_MEDIA_TYPE_VIDEO = 2;
@@ -101,6 +102,7 @@ public class DownloadMediaService extends Service {
             String fileName = intent.getString(EXTRA_FILE_NAME);
             String subredditName = intent.getString(EXTRA_SUBREDDIT_NAME);
             int mediaType = intent.getInt(EXTRA_MEDIA_TYPE, EXTRA_MEDIA_TYPE_IMAGE);
+            boolean isNsfw = intent.getBoolean(EXTRA_IS_NSFW, false);
             String mimeType = mediaType == EXTRA_MEDIA_TYPE_VIDEO ? "video/*" : "image/*";
 
             final DownloadProgressResponseBody.ProgressListener progressListener = new DownloadProgressResponseBody.ProgressListener() {
@@ -139,7 +141,7 @@ public class DownloadMediaService extends Service {
             try {
                 response = retrofit.create(DownloadFile.class).downloadFile(fileUrl).execute();
                 if (response.isSuccessful() && response.body() != null) {
-                    String destinationFileDirectory = getDownloadLocation(mediaType);
+                    String destinationFileDirectory = getDownloadLocation(mediaType, isNsfw);
                     if (destinationFileDirectory.equals("")) {
                         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
                             File directory = getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES);
@@ -462,7 +464,10 @@ public class DownloadMediaService extends Service {
         }
     }
 
-    private String getDownloadLocation(int mediaType) {
+    private String getDownloadLocation(int mediaType, boolean isNsfw) {
+        if (isNsfw && mSharedPreferences.getBoolean(SharedPreferencesUtils.SEPARATE_NSFW_FOLDER, false)) {
+            return mSharedPreferences.getString(SharedPreferencesUtils.NSFW_DOWNLOAD_LOCATION, "");
+        }
         switch (mediaType) {
             case EXTRA_MEDIA_TYPE_GIF:
                 return mSharedPreferences.getString(SharedPreferencesUtils.GIF_DOWNLOAD_LOCATION, "");

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/services/DownloadRedditVideoService.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/services/DownloadRedditVideoService.java
@@ -63,6 +63,7 @@ public class DownloadRedditVideoService extends Service {
     public static final String EXTRA_VIDEO_URL = "EVU";
     public static final String EXTRA_SUBREDDIT = "ES";
     public static final String EXTRA_POST_ID = "EPI";
+    public static final String EXTRA_IS_NSFW = "EIN";
 
     private static final int NO_ERROR = -1;
     private static final int ERROR_CANNOT_GET_CACHE_DIRECTORY = 0;
@@ -99,6 +100,7 @@ public class DownloadRedditVideoService extends Service {
             String audioUrl = videoUrl.substring(0, videoUrl.lastIndexOf('/')) + "/DASH_audio.mp4";
             String subredditName = intent.getString(EXTRA_SUBREDDIT);
             String fileNameWithoutExtension = subredditName + "-" + intent.getString(EXTRA_POST_ID);
+            boolean isNsfw = intent.getBoolean(EXTRA_IS_NSFW, false);
             int randomNotificationIdOffset = msg.arg1;
 
             final DownloadProgressResponseBody.ProgressListener progressListener = new DownloadProgressResponseBody.ProgressListener() {
@@ -141,7 +143,12 @@ public class DownloadRedditVideoService extends Service {
                     Response<ResponseBody> videoResponse = downloadFile.downloadFile(videoUrl).execute();
                     if (videoResponse.isSuccessful() && videoResponse.body() != null) {
                         String externalCacheDirectoryPath = externalCacheDirectory.getAbsolutePath() + "/";
-                        String destinationFileDirectory = sharedPreferences.getString(SharedPreferencesUtils.VIDEO_DOWNLOAD_LOCATION, "");
+                        String destinationFileDirectory;
+                        if (isNsfw) {
+                            destinationFileDirectory = sharedPreferences.getString(SharedPreferencesUtils.NSFW_DOWNLOAD_LOCATION, "");
+                        } else {
+                            destinationFileDirectory = sharedPreferences.getString(SharedPreferencesUtils.VIDEO_DOWNLOAD_LOCATION, "");
+                        }
                         String destinationFileUriString;
                         boolean isDefaultDestination;
                         if (destinationFileDirectory.equals("")) {

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/services/DownloadRedditVideoService.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/services/DownloadRedditVideoService.java
@@ -144,7 +144,7 @@ public class DownloadRedditVideoService extends Service {
                     if (videoResponse.isSuccessful() && videoResponse.body() != null) {
                         String externalCacheDirectoryPath = externalCacheDirectory.getAbsolutePath() + "/";
                         String destinationFileDirectory;
-                        if (isNsfw) {
+                        if (isNsfw && sharedPreferences.getBoolean(SharedPreferencesUtils.SEPARATE_NSFW_FOLDER, false)) {
                             destinationFileDirectory = sharedPreferences.getString(SharedPreferencesUtils.NSFW_DOWNLOAD_LOCATION, "");
                         } else {
                             destinationFileDirectory = sharedPreferences.getString(SharedPreferencesUtils.VIDEO_DOWNLOAD_LOCATION, "");

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/settings/DownloadLocationPreferenceFragment.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/settings/DownloadLocationPreferenceFragment.java
@@ -24,10 +24,12 @@ public class DownloadLocationPreferenceFragment extends PreferenceFragmentCompat
     private static final int IMAGE_DOWNLOAD_LOCATION_REQUEST_CODE = 10;
     private static final int GIF_DOWNLOAD_LOCATION_REQUEST_CODE = 11;
     private static final int VIDEO_DOWNLOAD_LOCATION_REQUEST_CODE = 12;
+    private static final int NSFW_DOWNLOAD_LOCATION_REQUEST_CODE = 13;
 
     Preference imageDownloadLocationPreference;
     Preference gifDownloadLocationPreference;
     Preference videoDownloadLocationPreference;
+    Preference nsfwDownloadLocationPreference;
     private Activity activity;
     @Inject
     @Named("default")
@@ -40,7 +42,21 @@ public class DownloadLocationPreferenceFragment extends PreferenceFragmentCompat
         imageDownloadLocationPreference = findPreference(SharedPreferencesUtils.IMAGE_DOWNLOAD_LOCATION);
         gifDownloadLocationPreference = findPreference(SharedPreferencesUtils.GIF_DOWNLOAD_LOCATION);
         videoDownloadLocationPreference = findPreference(SharedPreferencesUtils.VIDEO_DOWNLOAD_LOCATION);
+        nsfwDownloadLocationPreference = findPreference(SharedPreferencesUtils.NSFW_DOWNLOAD_LOCATION);
 
+        if (nsfwDownloadLocationPreference != null) {
+            String downloadLocation = sharedPreferences.getString(SharedPreferencesUtils.NSFW_DOWNLOAD_LOCATION, "");
+            if (!downloadLocation.equals("")) {
+                nsfwDownloadLocationPreference.setSummary(downloadLocation);
+            }
+
+            nsfwDownloadLocationPreference.setOnPreferenceClickListener(preference -> {
+                Intent intent = new Intent(ACTION_OPEN_DOCUMENT_TREE);
+                intent.addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
+                startActivityForResult(intent, NSFW_DOWNLOAD_LOCATION_REQUEST_CODE);
+                return true;
+            });
+        }
         if (imageDownloadLocationPreference != null) {
             String downloadLocation = sharedPreferences.getString(SharedPreferencesUtils.IMAGE_DOWNLOAD_LOCATION, "");
             if (!downloadLocation.equals("")) {

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/utils/SharedPreferencesUtils.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/utils/SharedPreferencesUtils.java
@@ -130,6 +130,8 @@ public class SharedPreferencesUtils {
     public static final String IMAGE_DOWNLOAD_LOCATION = "image_download_location";
     public static final String GIF_DOWNLOAD_LOCATION = "gif_download_location";
     public static final String VIDEO_DOWNLOAD_LOCATION = "video_download_location";
+    public static final String NSFW_DOWNLOAD_LOCATION = "nsfw_download_location";
+    public static final String SEPARATE_NSFW_FOLDER = "separate_nsfw_folder";
     public static final String SEPARATE_FOLDER_FOR_EACH_SUBREDDIT = "separate_folder_for_each_subreddit";
     public static final String VIBRATE_WHEN_ACTION_TRIGGERED = "vibrate_when_action_triggered";
     public static final String DISABLE_SWIPING_BETWEEN_TABS = "disable_swiping_between_tabs";

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
-<resources>
+ <resources>
     <string name="application_name" translatable="false">Infinity</string>
     <string name="login_activity_label">Login</string>
     <string name="search_activity_label" translatable="false"> </string>
@@ -516,6 +516,8 @@
     <string name="settings_image_download_location_title">Image Download Location</string>
     <string name="settings_gif_download_location_title">Gif Download Location</string>
     <string name="settings_video_download_location_title">Video Download Location</string>
+     <string name="settings_nsfw_download_location_title">NSFW Download Location</string>
+     <string name="settings_nsfw_separate_folder">Separate Folder for NSFW Posts</string>
     <string name="settings_separate_folder_for_each_subreddit">Separate Folder for Each Subreddit</string>
     <string name="settings_swipe_action_title">Swipe Action</string>
     <string name="settings_swipe_action_haptic_feedback_title">Haptic Feedback</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -516,8 +516,8 @@
     <string name="settings_image_download_location_title">Image Download Location</string>
     <string name="settings_gif_download_location_title">Gif Download Location</string>
     <string name="settings_video_download_location_title">Video Download Location</string>
-     <string name="settings_nsfw_download_location_title">NSFW Download Location</string>
-     <string name="settings_nsfw_separate_folder">Separate Folder for NSFW Posts</string>
+    <string name="settings_nsfw_download_location_title">NSFW Download Location</string>
+    <string name="settings_nsfw_separate_folder">Separate Folder for NSFW Posts</string>
     <string name="settings_separate_folder_for_each_subreddit">Separate Folder for Each Subreddit</string>
     <string name="settings_swipe_action_title">Swipe Action</string>
     <string name="settings_swipe_action_haptic_feedback_title">Haptic Feedback</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
- <resources>
+<resources>
     <string name="application_name" translatable="false">Infinity</string>
     <string name="login_activity_label">Login</string>
     <string name="search_activity_label" translatable="false"> </string>

--- a/app/src/main/res/xml/download_location_preferences.xml
+++ b/app/src/main/res/xml/download_location_preferences.xml
@@ -11,6 +11,16 @@
         app:key="video_download_location"
         app:title="@string/settings_video_download_location_title" />
 
+    <Preference
+        app:key="nsfw_download_location"
+        app:title="@string/settings_nsfw_download_location_title"
+        app:isPreferenceVisible="false"/>
+
+    <SwitchPreference
+        app:defaultValue="false"
+        app:key="separate_nsfw_location"
+        app:title="@string/settings_nsfw_separate_folder" />
+
     <SwitchPreference
         app:defaultValue="false"
         app:key="separate_folder_for_each_subreddit"

--- a/app/src/main/res/xml/download_location_preferences.xml
+++ b/app/src/main/res/xml/download_location_preferences.xml
@@ -18,7 +18,7 @@
 
     <SwitchPreference
         app:defaultValue="false"
-        app:key="separate_nsfw_location"
+        app:key="separate_nsfw_folder"
         app:title="@string/settings_nsfw_separate_folder" />
 
     <SwitchPreference

--- a/app/src/main/res/xml/download_location_preferences.xml
+++ b/app/src/main/res/xml/download_location_preferences.xml
@@ -13,8 +13,7 @@
 
     <Preference
         app:key="nsfw_download_location"
-        app:title="@string/settings_nsfw_download_location_title"
-        app:isPreferenceVisible="false"/>
+        app:title="@string/settings_nsfw_download_location_title" />
 
     <SwitchPreference
         app:defaultValue="false"


### PR DESCRIPTION
An additional setting has been added allowing users to download NSFW media (images, gifs, videos, and gallery content) to a separate location instead of the usual media folder. This change allows users to keep their NSFW content more organized from the rest of their downloaded files.