### PR TITLE
Add support for parsing inline static emotes

### DIFF
--- a/app/src/main/java/ml/docilealligator/infinityforreddit/comment/ParseComment.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/comment/ParseComment.java
@@ -1,5 +1,9 @@
 package ml.docilealligator.infinityforreddit.comment;
 
+import static ml.docilealligator.infinityforreddit.comment.Comment.VOTE_TYPE_DOWNVOTE;
+import static ml.docilealligator.infinityforreddit.comment.Comment.VOTE_TYPE_NO_VOTE;
+import static ml.docilealligator.infinityforreddit.comment.Comment.VOTE_TYPE_UPVOTE;
+
 import android.os.Handler;
 import android.text.Html;
 
@@ -14,10 +18,6 @@ import java.util.concurrent.Executor;
 
 import ml.docilealligator.infinityforreddit.utils.JSONUtils;
 import ml.docilealligator.infinityforreddit.utils.Utils;
-
-import static ml.docilealligator.infinityforreddit.comment.Comment.VOTE_TYPE_DOWNVOTE;
-import static ml.docilealligator.infinityforreddit.comment.Comment.VOTE_TYPE_NO_VOTE;
-import static ml.docilealligator.infinityforreddit.comment.Comment.VOTE_TYPE_UPVOTE;
 
 public class ParseComment {
     public static void parseComment(Executor executor, Handler handler, String response,
@@ -189,6 +189,10 @@ public class ParseComment {
         String commentMarkdown = "";
         if (!singleCommentData.isNull(JSONUtils.BODY_KEY)) {
             commentMarkdown = Utils.parseInlineGifInComments(Utils.modifyMarkdown(singleCommentData.getString(JSONUtils.BODY_KEY).trim()));
+            if (!singleCommentData.isNull(JSONUtils.MEDIA_METADATA_KEY)) {
+                JSONObject mediaMetadataObject = singleCommentData.getJSONObject(JSONUtils.MEDIA_METADATA_KEY);
+                commentMarkdown = Utils.parseInlineEmotes(commentMarkdown, mediaMetadataObject);
+            }
         }
         String commentRawText = Utils.trimTrailingWhitespace(
                 Html.fromHtml(singleCommentData.getString(JSONUtils.BODY_HTML_KEY))).toString();
@@ -229,7 +233,7 @@ public class ParseComment {
         return new Comment(id, fullName, author, authorFlair, authorFlairHTMLBuilder.toString(),
                 linkAuthor, submitTime, commentMarkdown, commentRawText,
                 linkId, subredditName, parentId, score, voteType, isSubmitter, distinguished,
-                permalink, awardingsBuilder.toString(),depth, collapsed, hasReply, scoreHidden, saved);
+                permalink, awardingsBuilder.toString(), depth, collapsed, hasReply, scoreHidden, saved);
     }
 
     @Nullable

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/utils/JSONUtils.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/utils/JSONUtils.java
@@ -175,4 +175,5 @@ public class JSONUtils {
     public static final String CAPTION_URL_KEY = "outbound_url";
     public static final String FILES_KEY = "files";
     public static final String MP4_MOBILE_KEY = "mp4-mobile";
+    public static final String STATUS_KEY = "status";
 }


### PR DESCRIPTION
Now we can open stickers, emojis etc. as links.

![IMG_20211214_154952.jpg](https://user-images.githubusercontent.com/91804886/146002464-333f2fda-09d6-4dab-a5de-2e646fc656e9.jpg) ![IMG_20211214_154908.jpg](https://user-images.githubusercontent.com/91804886/146002612-6081d9a9-b7b0-4cc6-86b4-8c841010155b.jpg)

Also, wouldn't it be better if we processed inline emotes at a later point in order not to mess with the comment when we edit it? Or maybe we can have two separate variables for post markdown, one original, one processed? Original will be used when we are editing the comment. Or is this something that is already being done?