### PR TITLE
Add Post Titles to Filenames

### DIFF
--- a/app/src/main/java/ml/docilealligator/infinityforreddit/activities/ViewImageOrGifActivity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/activities/ViewImageOrGifActivity.java
@@ -111,6 +111,7 @@ public class ViewImageOrGifActivity extends AppCompatActivity implements SetAsWa
     private RequestManager glide;
     private String mImageUrl;
     private String mImageFileName;
+    private String mPostTitle;
     private String mSubredditName;
     private boolean isGif = true;
     private boolean isNsfw;
@@ -165,13 +166,13 @@ public class ViewImageOrGifActivity extends AppCompatActivity implements SetAsWa
             mImageUrl = intent.getStringExtra(EXTRA_IMAGE_URL_KEY);
         }
         mImageFileName = intent.getStringExtra(EXTRA_FILE_NAME_KEY);
-        String postTitle = intent.getStringExtra(EXTRA_POST_TITLE_KEY);
+        mPostTitle = intent.getStringExtra(EXTRA_POST_TITLE_KEY);
         mSubredditName = intent.getStringExtra(EXTRA_SUBREDDIT_OR_USERNAME_KEY);
         isNsfw = intent.getBooleanExtra(EXTRA_IS_NSFW, false);
 
         boolean useBottomAppBar = mSharedPreferences.getBoolean(SharedPreferencesUtils.USE_BOTTOM_TOOLBAR_IN_MEDIA_VIEWER, false);
-        if (postTitle != null) {
-            Spanned title = Html.fromHtml(String.format("<font color=\"#FFFFFF\"><small>%s</small></font>", postTitle));
+        if (mPostTitle != null) {
+            Spanned title = Html.fromHtml(String.format("<font color=\"#FFFFFF\"><small>%s</small></font>", mPostTitle));
             if (useBottomAppBar) {
                 titleTextView.setText(title);
             } else {
@@ -369,7 +370,7 @@ public class ViewImageOrGifActivity extends AppCompatActivity implements SetAsWa
         Intent intent = new Intent(this, DownloadMediaService.class);
         intent.putExtra(DownloadMediaService.EXTRA_URL, mImageUrl);
         intent.putExtra(DownloadMediaService.EXTRA_MEDIA_TYPE, isGif ? DownloadMediaService.EXTRA_MEDIA_TYPE_GIF : DownloadMediaService.EXTRA_MEDIA_TYPE_IMAGE);
-        intent.putExtra(DownloadMediaService.EXTRA_FILE_NAME, mImageFileName);
+        intent.putExtra(DownloadMediaService.EXTRA_FILE_NAME, mPostTitle + "-" + mImageFileName);
         intent.putExtra(DownloadMediaService.EXTRA_SUBREDDIT_NAME, mSubredditName);
         intent.putExtra(DownloadMediaService.EXTRA_IS_NSFW, isNsfw);
         ContextCompat.startForegroundService(this, intent);

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/activities/ViewRedditGalleryActivity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/activities/ViewRedditGalleryActivity.java
@@ -158,7 +158,7 @@ public class ViewRedditGalleryActivity extends AppCompatActivity implements SetA
             finish();
             return;
         }
-        postTitle = getIntent().getStringExtra(EXTRA_POST_TITLE_KEY);
+        postTitle = getIntent().getStringExtra(EXTRA_POST_TITLE);
         subredditName = getIntent().getStringExtra(EXTRA_SUBREDDIT_NAME);
         isNsfw = getIntent().getBooleanExtra(EXTRA_IS_NSFW, false);
 

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/activities/ViewRedditGalleryActivity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/activities/ViewRedditGalleryActivity.java
@@ -58,6 +58,7 @@ public class ViewRedditGalleryActivity extends AppCompatActivity implements SetA
     public static final String EXTRA_REDDIT_GALLERY = "ERG";
     public static final String EXTRA_SUBREDDIT_NAME = "ESN";
     public static final String EXTRA_IS_NSFW = "EIN";
+    public static final String EXTRA_POST_TITLE = "EPT";
 
     @BindView(R.id.hauler_view_view_reddit_gallery_activity)
     HaulerView haulerView;
@@ -70,6 +71,7 @@ public class ViewRedditGalleryActivity extends AppCompatActivity implements SetA
     Executor executor;
     private SectionsPagerAdapter sectionsPagerAdapter;
     private ArrayList<Post.Gallery> gallery;
+    private String postTitle;
     private String subredditName;
     private boolean isNsfw;
     private boolean useBottomAppBar;
@@ -156,6 +158,7 @@ public class ViewRedditGalleryActivity extends AppCompatActivity implements SetA
             finish();
             return;
         }
+        postTitle = getIntent().getStringExtra(EXTRA_POST_TITLE_KEY);
         subredditName = getIntent().getStringExtra(EXTRA_SUBREDDIT_NAME);
         isNsfw = getIntent().getBooleanExtra(EXTRA_IS_NSFW, false);
 
@@ -290,6 +293,7 @@ public class ViewRedditGalleryActivity extends AppCompatActivity implements SetA
                 ViewRedditGalleryVideoFragment fragment = new ViewRedditGalleryVideoFragment();
                 Bundle bundle = new Bundle();
                 bundle.putParcelable(ViewRedditGalleryVideoFragment.EXTRA_REDDIT_GALLERY_VIDEO, media);
+                bundle.putString(ViewRedditGalleryVideoFragment.EXTRA_POST_TITLE, postTitle);
                 bundle.putString(ViewRedditGalleryVideoFragment.EXTRA_SUBREDDIT_NAME, subredditName);
                 bundle.putInt(ViewRedditGalleryVideoFragment.EXTRA_INDEX, position);
                 bundle.putInt(ViewRedditGalleryVideoFragment.EXTRA_MEDIA_COUNT, gallery.size());
@@ -300,6 +304,7 @@ public class ViewRedditGalleryActivity extends AppCompatActivity implements SetA
                 ViewRedditGalleryImageOrGifFragment fragment = new ViewRedditGalleryImageOrGifFragment();
                 Bundle bundle = new Bundle();
                 bundle.putParcelable(ViewRedditGalleryImageOrGifFragment.EXTRA_REDDIT_GALLERY_MEDIA, media);
+                bundle.putString(ViewRedditGalleryImageOrGifFragment.EXTRA_POST_TITLE, postTitle);
                 bundle.putString(ViewRedditGalleryImageOrGifFragment.EXTRA_SUBREDDIT_NAME, subredditName);
                 bundle.putInt(ViewRedditGalleryImageOrGifFragment.EXTRA_INDEX, position);
                 bundle.putInt(ViewRedditGalleryImageOrGifFragment.EXTRA_MEDIA_COUNT, gallery.size());

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/activities/ViewVideoActivity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/activities/ViewVideoActivity.java
@@ -175,6 +175,7 @@ public class ViewVideoActivity extends AppCompatActivity {
 
     private String videoDownloadUrl;
     private String videoFileName;
+    private String postTitle;
     private String subredditName;
     private String id;
     private boolean wasPlaying;
@@ -539,6 +540,7 @@ public class ViewVideoActivity extends AppCompatActivity {
             preparePlayer(savedInstanceState);
         } else {
             videoDownloadUrl = intent.getStringExtra(EXTRA_VIDEO_DOWNLOAD_URL);
+            postTitle = intent.getStringExtra(EXTRA_POST_TITLE);
             subredditName = intent.getStringExtra(EXTRA_SUBREDDIT);
             id = intent.getStringExtra(EXTRA_ID);
             videoFileName = subredditName + "-" + id + ".mp4";
@@ -914,13 +916,14 @@ public class ViewVideoActivity extends AppCompatActivity {
             intent = new Intent(this, DownloadMediaService.class);
             intent.putExtra(DownloadMediaService.EXTRA_URL, videoDownloadUrl);
             intent.putExtra(DownloadMediaService.EXTRA_MEDIA_TYPE, DownloadMediaService.EXTRA_MEDIA_TYPE_VIDEO);
-            intent.putExtra(DownloadMediaService.EXTRA_FILE_NAME, videoFileName);
+            intent.putExtra(DownloadMediaService.EXTRA_FILE_NAME, postTitle + "-" + videoFileName);
             intent.putExtra(DownloadMediaService.EXTRA_SUBREDDIT_NAME, subredditName);
             intent.putExtra(DownloadMediaService.EXTRA_IS_NSFW, isNSFW);
         } else {
             intent = new Intent(this, DownloadRedditVideoService.class);
             intent.putExtra(DownloadRedditVideoService.EXTRA_VIDEO_URL, videoDownloadUrl);
             intent.putExtra(DownloadRedditVideoService.EXTRA_POST_ID, id);
+            intent.putExtra(DownloadRedditVideoService.EXTRA_POST_TITLE, postTitle);
             intent.putExtra(DownloadRedditVideoService.EXTRA_SUBREDDIT, subredditName);
             intent.putExtra(DownloadRedditVideoService.EXTRA_IS_NSFW, isNSFW);
         }

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/PostRecyclerViewAdapter.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/PostRecyclerViewAdapter.java
@@ -1967,7 +1967,7 @@ public class PostRecyclerViewAdapter extends PagingDataAdapter<Post, RecyclerVie
             } else if (post.getPostType() == Post.IMAGE_TYPE) {
                 Intent intent = new Intent(mActivity, ViewImageOrGifActivity.class);
                 intent.putExtra(ViewImageOrGifActivity.EXTRA_IMAGE_URL_KEY, post.getUrl());
-                intent.putExtra(ViewImageOrGifActivity.EXTRA_FILE_NAME_KEY, post.getTitle() + "-" + post.getSubredditName()
+                intent.putExtra(ViewImageOrGifActivity.EXTRA_FILE_NAME_KEY, post.getSubredditName()
                         + "-" + post.getId() + ".jpg");
                 intent.putExtra(ViewImageOrGifActivity.EXTRA_POST_TITLE_KEY, post.getTitle());
                 intent.putExtra(ViewImageOrGifActivity.EXTRA_SUBREDDIT_OR_USERNAME_KEY, post.getSubredditName());
@@ -1975,7 +1975,7 @@ public class PostRecyclerViewAdapter extends PagingDataAdapter<Post, RecyclerVie
                 mActivity.startActivity(intent);
             } else if (post.getPostType() == Post.GIF_TYPE) {
                 Intent intent = new Intent(mActivity, ViewImageOrGifActivity.class);
-                intent.putExtra(ViewImageOrGifActivity.EXTRA_FILE_NAME_KEY, post.getTitle() + "-" + post.getSubredditName()
+                intent.putExtra(ViewImageOrGifActivity.EXTRA_FILE_NAME_KEY, post.getSubredditName()
                         + "-" + post.getId() + ".gif");
                 intent.putExtra(ViewImageOrGifActivity.EXTRA_GIF_URL_KEY, post.getVideoUrl());
                 intent.putExtra(ViewImageOrGifActivity.EXTRA_POST_TITLE_KEY, post.getTitle());

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/PostRecyclerViewAdapter.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/PostRecyclerViewAdapter.java
@@ -1967,7 +1967,7 @@ public class PostRecyclerViewAdapter extends PagingDataAdapter<Post, RecyclerVie
             } else if (post.getPostType() == Post.IMAGE_TYPE) {
                 Intent intent = new Intent(mActivity, ViewImageOrGifActivity.class);
                 intent.putExtra(ViewImageOrGifActivity.EXTRA_IMAGE_URL_KEY, post.getUrl());
-                intent.putExtra(ViewImageOrGifActivity.EXTRA_FILE_NAME_KEY, post.getSubredditName()
+                intent.putExtra(ViewImageOrGifActivity.EXTRA_FILE_NAME_KEY, post.getTitle() + "-" + post.getSubredditName()
                         + "-" + post.getId() + ".jpg");
                 intent.putExtra(ViewImageOrGifActivity.EXTRA_POST_TITLE_KEY, post.getTitle());
                 intent.putExtra(ViewImageOrGifActivity.EXTRA_SUBREDDIT_OR_USERNAME_KEY, post.getSubredditName());
@@ -1975,7 +1975,7 @@ public class PostRecyclerViewAdapter extends PagingDataAdapter<Post, RecyclerVie
                 mActivity.startActivity(intent);
             } else if (post.getPostType() == Post.GIF_TYPE) {
                 Intent intent = new Intent(mActivity, ViewImageOrGifActivity.class);
-                intent.putExtra(ViewImageOrGifActivity.EXTRA_FILE_NAME_KEY, post.getSubredditName()
+                intent.putExtra(ViewImageOrGifActivity.EXTRA_FILE_NAME_KEY, post.getTitle() + "-" + post.getSubredditName()
                         + "-" + post.getId() + ".gif");
                 intent.putExtra(ViewImageOrGifActivity.EXTRA_GIF_URL_KEY, post.getVideoUrl());
                 intent.putExtra(ViewImageOrGifActivity.EXTRA_POST_TITLE_KEY, post.getTitle());
@@ -1991,6 +1991,7 @@ public class PostRecyclerViewAdapter extends PagingDataAdapter<Post, RecyclerVie
             } else if (post.getPostType() == Post.GALLERY_TYPE) {
                 Intent intent = new Intent(mActivity, ViewRedditGalleryActivity.class);
                 intent.putParcelableArrayListExtra(ViewRedditGalleryActivity.EXTRA_REDDIT_GALLERY, post.getGallery());
+                intent.putExtra(ViewRedditGalleryActivity.EXTRA_POST_TITLE, post.getTitle());
                 intent.putExtra(ViewRedditGalleryActivity.EXTRA_SUBREDDIT_NAME, post.getSubredditName());
                 intent.putExtra(ViewRedditGalleryActivity.EXTRA_IS_NSFW, post.isNSFW());
                 mActivity.startActivity(intent);

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/fragments/ViewRedditGalleryImageOrGifFragment.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/fragments/ViewRedditGalleryImageOrGifFragment.java
@@ -72,6 +72,7 @@ import ml.docilealligator.infinityforreddit.services.DownloadMediaService;
 public class ViewRedditGalleryImageOrGifFragment extends Fragment {
 
     public static final String EXTRA_REDDIT_GALLERY_MEDIA = "ERGM";
+    public static final String EXTRA_POST_TITLE = "EPT";
     public static final String EXTRA_SUBREDDIT_NAME = "ESN";
     public static final String EXTRA_INDEX = "EI";
     public static final String EXTRA_MEDIA_COUNT = "EMC";
@@ -108,6 +109,8 @@ public class ViewRedditGalleryImageOrGifFragment extends Fragment {
     private ViewRedditGalleryActivity activity;
     private RequestManager glide;
     private Post.Gallery media;
+    private String postTitle;
+    private int galleryIndex;
     private String subredditName;
     private boolean isNsfw;
     private boolean isDownloading = false;
@@ -133,6 +136,8 @@ public class ViewRedditGalleryImageOrGifFragment extends Fragment {
         setHasOptionsMenu(true);
 
         media = getArguments().getParcelable(EXTRA_REDDIT_GALLERY_MEDIA);
+        postTitle = getArguments().getString(EXTRA_POST_TITLE);
+        galleryIndex = getArguments().getInt(EXTRA_INDEX) + 1;
         subredditName = getArguments().getString(EXTRA_SUBREDDIT_NAME);
         isNsfw = getArguments().getBoolean(EXTRA_IS_NSFW, false);
         glide = Glide.with(activity);
@@ -399,7 +404,7 @@ public class ViewRedditGalleryImageOrGifFragment extends Fragment {
         Intent intent = new Intent(activity, DownloadMediaService.class);
         intent.putExtra(DownloadMediaService.EXTRA_URL, media.hasFallback() ? media.fallbackUrl : media.url); // Retrieve original instead of the one additionally compressed by reddit
         intent.putExtra(DownloadMediaService.EXTRA_MEDIA_TYPE, media.mediaType == Post.Gallery.TYPE_GIF ? DownloadMediaService.EXTRA_MEDIA_TYPE_GIF: DownloadMediaService.EXTRA_MEDIA_TYPE_IMAGE);
-        intent.putExtra(DownloadMediaService.EXTRA_FILE_NAME, media.fileName);
+        intent.putExtra(DownloadMediaService.EXTRA_FILE_NAME, postTitle + "-" + galleryIndex + "-" + media.fileName);
         intent.putExtra(DownloadMediaService.EXTRA_SUBREDDIT_NAME, subredditName);
         intent.putExtra(DownloadMediaService.EXTRA_IS_NSFW, isNsfw);
         ContextCompat.startForegroundService(activity, intent);

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/fragments/ViewRedditGalleryVideoFragment.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/fragments/ViewRedditGalleryVideoFragment.java
@@ -59,6 +59,7 @@ import ml.docilealligator.infinityforreddit.utils.SharedPreferencesUtils;
 public class ViewRedditGalleryVideoFragment extends Fragment {
 
     public static final String EXTRA_REDDIT_GALLERY_VIDEO = "EIV";
+    public static final String EXTRA_POST_TITLE = "EPT";
     public static final String EXTRA_SUBREDDIT_NAME = "ESN";
     public static final String EXTRA_INDEX = "EI";
     public static final String EXTRA_MEDIA_COUNT = "EMC";
@@ -79,6 +80,8 @@ public class ViewRedditGalleryVideoFragment extends Fragment {
     ImageView downloadImageView;
     private ViewRedditGalleryActivity activity;
     private Post.Gallery galleryVideo;
+    private String postTitle;
+    private int galleryIndex;
     private String subredditName;
     private boolean isNsfw;
     private SimpleExoPlayer player;
@@ -110,6 +113,8 @@ public class ViewRedditGalleryVideoFragment extends Fragment {
         activity.setVolumeControlStream(AudioManager.STREAM_MUSIC);
 
         galleryVideo = getArguments().getParcelable(EXTRA_REDDIT_GALLERY_VIDEO);
+        postTitle = getArguments().getString(EXTRA_POST_TITLE);
+        galleryIndex = getArguments().getInt(EXTRA_INDEX) + 1;
         subredditName = getArguments().getString(EXTRA_SUBREDDIT_NAME);
         isNsfw = getArguments().getBoolean(EXTRA_IS_NSFW, false);
 
@@ -243,7 +248,7 @@ public class ViewRedditGalleryVideoFragment extends Fragment {
         Intent intent = new Intent(activity, DownloadMediaService.class);
         intent.putExtra(DownloadMediaService.EXTRA_URL, galleryVideo.url);
         intent.putExtra(DownloadMediaService.EXTRA_MEDIA_TYPE, DownloadMediaService.EXTRA_MEDIA_TYPE_VIDEO);
-        intent.putExtra(DownloadMediaService.EXTRA_FILE_NAME, galleryVideo.fileName);
+        intent.putExtra(DownloadMediaService.EXTRA_FILE_NAME, postTitle + "-" + galleryIndex + "-" + galleryVideo.fileName);
         intent.putExtra(DownloadMediaService.EXTRA_SUBREDDIT_NAME, subredditName);
         intent.putExtra(DownloadMediaService.EXTRA_IS_NSFW, isNsfw);
         ContextCompat.startForegroundService(activity, intent);

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/services/DownloadRedditVideoService.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/services/DownloadRedditVideoService.java
@@ -61,6 +61,7 @@ import static android.os.Environment.getExternalStoragePublicDirectory;
 public class DownloadRedditVideoService extends Service {
 
     public static final String EXTRA_VIDEO_URL = "EVU";
+    public static final String EXTRA_POST_TITLE = "EPT";
     public static final String EXTRA_SUBREDDIT = "ES";
     public static final String EXTRA_POST_ID = "EPI";
     public static final String EXTRA_IS_NSFW = "EIN";
@@ -98,8 +99,9 @@ public class DownloadRedditVideoService extends Service {
             Bundle intent = msg.getData();
             String videoUrl = intent.getString(EXTRA_VIDEO_URL);
             String audioUrl = videoUrl.substring(0, videoUrl.lastIndexOf('/')) + "/DASH_audio.mp4";
+            String postTitle = intent.getString(EXTRA_POST_TITLE);
             String subredditName = intent.getString(EXTRA_SUBREDDIT);
-            String fileNameWithoutExtension = subredditName + "-" + intent.getString(EXTRA_POST_ID);
+            String fileNameWithoutExtension = postTitle + "-" + subredditName + "-" + intent.getString(EXTRA_POST_ID);
             boolean isNsfw = intent.getBoolean(EXTRA_IS_NSFW, false);
             int randomNotificationIdOffset = msg.arg1;
 


### PR DESCRIPTION
Currently, filenames that are currently used by default do not stand out very much, especially when part of a large gallery. So, the rules have been updated to include the post title at the beginning of the filename to make individual files stand out more. In addition, gallery indexes have been added to filenames to ensure gallery images maintain their original order.