### PR TITLE
Fix scroll using volume on multireddit

### DIFF
--- a/app/src/main/java/ml/docilealligator/infinityforreddit/activities/ViewMultiRedditDetailActivity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/activities/ViewMultiRedditDetailActivity.java
@@ -9,6 +9,7 @@ import android.os.Handler;
 import android.text.Editable;
 import android.text.TextWatcher;
 import android.view.Gravity;
+import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -140,6 +141,13 @@ public class ViewMultiRedditDetailActivity extends BaseActivity implements SortT
     private boolean lockBottomAppBar;
     private Call<String> subredditAutocompleteCall;
     private NavigationWrapper navigationWrapper;
+
+    @Override
+    public boolean onKeyDown(int keyCode, KeyEvent event) {
+        if (mFragment instanceof PostFragment)
+            return ((PostFragment) mFragment).handleKeyDown(keyCode);
+        return super.onKeyDown(keyCode, event);
+    }
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {


### PR DESCRIPTION
Scrolling on Multireddit using volume buttons is fixed.

When in a Multireddit, the keypress event is received by the activity `ViewMultiRedditDetailActivity`. As long as we are working with a `PostFragment`, I am forwarding the event to the `PostFragment` which properly handles the scrolling.

Closes #831.