### PR TITLE
Set default position of cursor at the end of query

### DIFF
--- a/app/src/main/java/ml/docilealligator/infinityforreddit/activities/SearchActivity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/activities/SearchActivity.java
@@ -395,6 +395,7 @@ public class SearchActivity extends BaseActivity {
 
         if (query != null) {
             searchEditText.setText(query);
+            searchEditText.setSelection(query.length());
             query = null;
         }
 


### PR DESCRIPTION
This change resolves #810. Cursor will appear at the end or query line by default now.