### PR TITLE
Fix loading previews after quick scroll

### DIFF
--- a/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/PostRecyclerViewAdapter.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/PostRecyclerViewAdapter.java
@@ -812,6 +812,7 @@ public class PostRecyclerViewAdapter extends PagingDataAdapter<Post, RecyclerVie
                             Post.Preview preview = getSuitablePreview(post.getPreviews());
                             ((PostWithPreviewTypeViewHolder) holder).preview = preview;
                             if (preview != null) {
+                                ((PostWithPreviewTypeViewHolder) holder).imageView.setVisibility(View.VISIBLE);
                                 ((PostWithPreviewTypeViewHolder) holder).imageWrapperRelativeLayout.setVisibility(View.VISIBLE);
                                 if (mFixedHeightPreviewInCard || (preview.getPreviewWidth() <= 0 || preview.getPreviewHeight() <= 0)) {
                                     int height = (int) (400 * mScale);
@@ -1847,6 +1848,7 @@ public class PostRecyclerViewAdapter extends PagingDataAdapter<Post, RecyclerVie
                 ((PostVideoAutoplayViewHolder) holder).previewImageView.setVisibility(View.GONE);
             } else if (holder instanceof PostWithPreviewTypeViewHolder) {
                 mGlide.clear(((PostWithPreviewTypeViewHolder) holder).imageView);
+                ((PostWithPreviewTypeViewHolder) holder).imageView.setVisibility(View.GONE);
                 ((PostWithPreviewTypeViewHolder) holder).imageWrapperRelativeLayout.setVisibility(View.GONE);
                 ((PostWithPreviewTypeViewHolder) holder).errorTextView.setVisibility(View.GONE);
                 ((PostWithPreviewTypeViewHolder) holder).noPreviewLinkImageView.setVisibility(View.GONE);

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/customviews/AspectRatioGifImageView.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/customviews/AspectRatioGifImageView.java
@@ -25,7 +25,12 @@ public class AspectRatioGifImageView extends GifImageView {
     }
 
     public final void setRatio(float var1) {
-        this.ratio = var1;
+        if (this.ratio != var1) {
+            this.ratio = var1;
+
+            requestLayout();
+            invalidate();
+        }
     }
 
     private void init(Context context, AttributeSet attrs) {


### PR DESCRIPTION
That was an interesting bug to understand. I don't understand a couple details, but here's the general idea:

- Images are loaded only in `onLayoutChanged` of `imageview` since [3cae2b](https://github.com/Docile-Alligator/Infinity-For-Reddit/commit/3cae2b0dbadfcc109f8e7f52170722c664638d1f) as fix of #107 
- At first nothing is laid out, so callback gets triggered when view is first shown.
- Next, something keeps requesting new layout so it continues to get triggered. My guess is that when glide removes loaded image in `onViewRecycled`, `ImageView` sees it and request layout. However it is no longer part of visible tree, so it does not get laid out until it is bound to a new `ViewHolder`, when we are already listening to layout changes again.
- Now when we are scrolling quickly it breaks - view is laid out, image gets requested, but then it is cancelled before being added to `ImageView`. So `ImageView` doesn't need to request layout again - nothing has changed. And this breaks the cycle.

The main fix is requesting new layout when ratio changes. This leaves an edge case, when ratio doesn't change so additionaly I change visibility of `imageVIew`. This actually happens in all other if/else branches and probably is the reason nobody noticed.

Now I wonder if the workaround with `onLayoutChanged` is still necessary and in general if `AspectRatioGifImageView` is necessary or is `GifImageView` with  `adjustBounds:true` is enough. 

Fixes #860 