### PR TITLE
Manage theme insertion callbacks behaviour

### DIFF
--- a/app/src/main/java/ml/docilealligator/infinityforreddit/asynctasks/InsertCustomTheme.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/asynctasks/InsertCustomTheme.java
@@ -19,33 +19,33 @@ public class InsertCustomTheme {
                                          CustomTheme customTheme, boolean checkDuplicate,
                                          InsertCustomThemeListener insertCustomThemeListener) {
         executor.execute(() -> {
-            if (checkDuplicate) {
-                if (redditDataRoomDatabase.customThemeDao().getCustomTheme(customTheme.name) != null) {
-                    handler.post(insertCustomThemeListener::duplicate);
-                }
-            }
             CustomTheme previousTheme = redditDataRoomDatabase.customThemeDao().getCustomTheme(customTheme.name);
-            if (customTheme.isLightTheme) {
-                redditDataRoomDatabase.customThemeDao().unsetLightTheme();
-                CustomThemeSharedPreferencesUtils.insertThemeToSharedPreferences(customTheme, lightThemeSharedPreferences);
-            } else if (previousTheme != null && previousTheme.isLightTheme) {
-                lightThemeSharedPreferences.edit().clear().apply();
-            }
-            if (customTheme.isDarkTheme) {
-                redditDataRoomDatabase.customThemeDao().unsetDarkTheme();
-                CustomThemeSharedPreferencesUtils.insertThemeToSharedPreferences(customTheme, darkThemeSharedPreferences);
-            } else if (previousTheme != null && previousTheme.isDarkTheme) {
-                darkThemeSharedPreferences.edit().clear().apply();
-            }
-            if (customTheme.isAmoledTheme) {
-                redditDataRoomDatabase.customThemeDao().unsetAmoledTheme();
-                CustomThemeSharedPreferencesUtils.insertThemeToSharedPreferences(customTheme, amoledThemeSharedPreferences);
-            } else if (previousTheme != null && previousTheme.isAmoledTheme) {
-                amoledThemeSharedPreferences.edit().clear().apply();
-            }
-            redditDataRoomDatabase.customThemeDao().insert(customTheme);
 
-            handler.post(insertCustomThemeListener::success);
+            if (checkDuplicate && previousTheme != null) {
+                handler.post(insertCustomThemeListener::duplicate);
+            } else {
+                if (customTheme.isLightTheme) {
+                    redditDataRoomDatabase.customThemeDao().unsetLightTheme();
+                    CustomThemeSharedPreferencesUtils.insertThemeToSharedPreferences(customTheme, lightThemeSharedPreferences);
+                } else if (previousTheme != null && previousTheme.isLightTheme) {
+                    lightThemeSharedPreferences.edit().clear().apply();
+                }
+                if (customTheme.isDarkTheme) {
+                    redditDataRoomDatabase.customThemeDao().unsetDarkTheme();
+                    CustomThemeSharedPreferencesUtils.insertThemeToSharedPreferences(customTheme, darkThemeSharedPreferences);
+                } else if (previousTheme != null && previousTheme.isDarkTheme) {
+                    darkThemeSharedPreferences.edit().clear().apply();
+                }
+                if (customTheme.isAmoledTheme) {
+                    redditDataRoomDatabase.customThemeDao().unsetAmoledTheme();
+                    CustomThemeSharedPreferencesUtils.insertThemeToSharedPreferences(customTheme, amoledThemeSharedPreferences);
+                } else if (previousTheme != null && previousTheme.isAmoledTheme) {
+                    amoledThemeSharedPreferences.edit().clear().apply();
+                }
+                redditDataRoomDatabase.customThemeDao().insert(customTheme);
+
+                handler.post(insertCustomThemeListener::success);
+            }
         });
     }
 


### PR DESCRIPTION
This fix closes #891 by managing theme insertion callbacks behaviour. Only one of them ("success" or "duplicate") can be called at a time now. The issue was caused by "success" method being called even when duplication was found