### PR TITLE
Show OP badge on restored comment

### DIFF
--- a/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/CommentsRecyclerViewAdapter.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/CommentsRecyclerViewAdapter.java
@@ -985,8 +985,15 @@ public class CommentsRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerVi
     }
 
     public void editComment(String commentAuthor, String commentContentMarkdown, int position) {
-        if (commentAuthor != null)
+        editComment(commentAuthor, mVisibleComments.get(position).isSubmitter(), commentContentMarkdown, position);
+    }
+
+    public void editComment(String commentAuthor, boolean isSubmitter, String commentContentMarkdown, int position) {
+        if (commentAuthor != null) {
             mVisibleComments.get(position).setAuthor(commentAuthor);
+        }
+
+        mVisibleComments.get(position).setSubmittedByAuthor(isSubmitter);
 
         mVisibleComments.get(position).setCommentMarkdown(commentContentMarkdown);
         if (mIsSingleCommentThreadMode) {

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/comment/Comment.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/comment/Comment.java
@@ -233,6 +233,10 @@ public class Comment implements Parcelable {
         return isSubmitter;
     }
 
+    public void setSubmittedByAuthor(boolean isSubmittedByAuthor) {
+        this.isSubmitter = isSubmittedByAuthor;
+    }
+
     public boolean isModerator() {
         return distinguished != null && distinguished.equals("moderator");
     }

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/comment/FetchRemovedComment.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/comment/FetchRemovedComment.java
@@ -56,7 +56,7 @@ public class FetchRemovedComment {
                         comment.getLinkId(),
                         3000,
                         "asc",
-                        "id,author,body",
+                        "id,author,body,is_submitter",
                         after,
                         after + 43200, // 12 Hours later
                         "*").execute();
@@ -107,6 +107,7 @@ public class FetchRemovedComment {
         String id = result.getString(JSONUtils.ID_KEY);
         String author = result.getString(JSONUtils.AUTHOR_KEY);
         String body = Utils.modifyMarkdown(result.optString(JSONUtils.BODY_KEY).trim());
+        boolean isSubmitter = result.getBoolean(JSONUtils.IS_SUBMITTER_KEY);
 
         if (id.equals(comment.getId()) &&
                 (!author.equals(comment.getAuthor()) ||
@@ -115,6 +116,7 @@ public class FetchRemovedComment {
             comment.setAuthor(author);
             comment.setCommentMarkdown(body);
             comment.setCommentRawText(body);
+            comment.setSubmittedByAuthor(isSubmitter);
             return comment;
         } else {
             return null;

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/comment/FetchRemovedCommentReveddit.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/comment/FetchRemovedCommentReveddit.java
@@ -55,11 +55,13 @@ public class FetchRemovedCommentReveddit {
         String id = result.getString(JSONUtils.ID_KEY);
         String author = result.getString(JSONUtils.AUTHOR_KEY);
         String body = Utils.modifyMarkdown(result.optString(JSONUtils.BODY_KEY).trim());
+        boolean isSubmitter = result.getBoolean(JSONUtils.IS_SUBMITTER_KEY);
 
         if (id.equals(comment.getId()) && (!author.equals(comment.getAuthor()) || !body.equals(comment.getCommentRawText()))) {
             comment.setAuthor(author);
             comment.setCommentMarkdown(body);
             comment.setCommentRawText(body);
+            comment.setSubmittedByAuthor(isSubmitter);
             return comment;
         } else {
             return null;


### PR DESCRIPTION
This fix closes #904, as OP's badge is now shown on restored comment

By the way, `editComment` method is turning a weak part and probably will require a little refactoring in the near future