### PR TITLE
Fix markdown in rules screen

### DIFF
--- a/app/src/main/java/ml/docilealligator/infinityforreddit/activities/RulesActivity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/activities/RulesActivity.java
@@ -20,6 +20,7 @@ import androidx.recyclerview.widget.RecyclerView;
 import com.google.android.material.appbar.AppBarLayout;
 import com.google.android.material.appbar.CollapsingToolbarLayout;
 import com.r0adkll.slidr.Slidr;
+import com.r0adkll.slidr.model.SlidrInterface;
 
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
@@ -87,8 +88,9 @@ public class RulesActivity extends BaseActivity {
 
         applyCustomTheme();
 
+        SlidrInterface slidrInterface = null;
         if (mSharedPreferences.getBoolean(SharedPreferencesUtils.SWIPE_RIGHT_TO_GO_BACK, true)) {
-            Slidr.attach(this);
+            slidrInterface = Slidr.attach(this);
         }
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
@@ -119,7 +121,7 @@ public class RulesActivity extends BaseActivity {
 
         mSubredditName = getIntent().getExtras().getString(EXTRA_SUBREDDIT_NAME);
 
-        mAdapter = new RulesRecyclerViewAdapter(this, mCustomThemeWrapper);
+        mAdapter = new RulesRecyclerViewAdapter(this, mCustomThemeWrapper, slidrInterface);
         recyclerView.setAdapter(mAdapter);
 
         FetchRules.fetchRules(mExecutor, new Handler(), mRetrofit, mSubredditName, new FetchRules.FetchRulesListener() {

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/RulesRecyclerViewAdapter.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/RulesRecyclerViewAdapter.java
@@ -11,7 +11,12 @@ import android.view.ViewGroup;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.recyclerview.widget.RecyclerView;
+
+import com.r0adkll.slidr.model.SlidrInterface;
+
+import org.commonmark.ext.gfm.tables.TableBlock;
 
 import java.util.ArrayList;
 
@@ -30,6 +35,9 @@ import io.noties.markwon.inlineparser.HtmlInlineProcessor;
 import io.noties.markwon.inlineparser.MarkwonInlineParserPlugin;
 import io.noties.markwon.linkify.LinkifyPlugin;
 import io.noties.markwon.movement.MovementMethodPlugin;
+import io.noties.markwon.recycler.MarkwonAdapter;
+import io.noties.markwon.recycler.table.TableEntry;
+import io.noties.markwon.recycler.table.TableEntryPlugin;
 import me.saket.bettermovementmethod.BetterLinkMovementMethod;
 import ml.docilealligator.infinityforreddit.R;
 import ml.docilealligator.infinityforreddit.Rule;
@@ -37,18 +45,27 @@ import ml.docilealligator.infinityforreddit.activities.BaseActivity;
 import ml.docilealligator.infinityforreddit.activities.LinkResolverActivity;
 import ml.docilealligator.infinityforreddit.bottomsheetfragments.UrlMenuBottomSheetFragment;
 import ml.docilealligator.infinityforreddit.customtheme.CustomThemeWrapper;
+import ml.docilealligator.infinityforreddit.customviews.LinearLayoutManagerBugFixed;
+import ml.docilealligator.infinityforreddit.customviews.MarkwonLinearLayoutManager;
+import ml.docilealligator.infinityforreddit.markdown.RedditHeadingPlugin;
+import ml.docilealligator.infinityforreddit.markdown.SpoilerParserPlugin;
 import ml.docilealligator.infinityforreddit.markdown.SuperscriptInlineProcessor;
 import ml.docilealligator.infinityforreddit.utils.Utils;
 
 public class RulesRecyclerViewAdapter extends RecyclerView.Adapter<RulesRecyclerViewAdapter.RuleViewHolder> {
     private BaseActivity activity;
     private Markwon markwon;
+    @Nullable
+    private final SlidrInterface slidrInterface;
     private ArrayList<Rule> rules;
     private int mPrimaryTextColor;
-    private int mSecondaryTextColor;
 
-    public RulesRecyclerViewAdapter(BaseActivity activity, CustomThemeWrapper customThemeWrapper) {
+    public RulesRecyclerViewAdapter(@NonNull BaseActivity activity,
+                                    @NonNull CustomThemeWrapper customThemeWrapper,
+                                    @Nullable SlidrInterface slidrInterface) {
         this.activity = activity;
+        this.slidrInterface = slidrInterface;
+        mPrimaryTextColor = customThemeWrapper.getPrimaryTextColor();
         markwon = Markwon.builder(activity)
                 .usePlugin(MarkwonInlineParserPlugin.create(plugin -> {
                     plugin.excludeInlineProcessor(AutolinkInlineProcessor.class);
@@ -102,9 +119,8 @@ public class RulesRecyclerViewAdapter extends RecyclerView.Adapter<RulesRecycler
                 })))
                 .usePlugin(LinkifyPlugin.create(Linkify.WEB_URLS))
                 .usePlugin(StrikethroughPlugin.create())
+                .usePlugin(TableEntryPlugin.create(activity))
                 .build();
-        mPrimaryTextColor = customThemeWrapper.getPrimaryTextColor();
-        mSecondaryTextColor = customThemeWrapper.getSecondaryTextColor();
     }
 
     @NonNull
@@ -115,11 +131,14 @@ public class RulesRecyclerViewAdapter extends RecyclerView.Adapter<RulesRecycler
 
     @Override
     public void onBindViewHolder(@NonNull RuleViewHolder holder, int position) {
-        holder.shortNameTextView.setText(rules.get(holder.getBindingAdapterPosition()).getShortName());
-        if (rules.get(holder.getBindingAdapterPosition()).getDescriptionHtml() == null) {
+        Rule rule = rules.get(holder.getBindingAdapterPosition());
+        holder.shortNameTextView.setText(rule.getShortName());
+        if (rule.getDescriptionHtml() == null) {
             holder.descriptionMarkwonView.setVisibility(View.GONE);
         } else {
-            markwon.setMarkdown(holder.descriptionMarkwonView, rules.get(holder.getBindingAdapterPosition()).getDescriptionHtml());
+            holder.markwonAdapter.setMarkdown(markwon, rule.getDescriptionHtml());
+            //noinspection NotifyDatasetChanged
+            holder.markwonAdapter.notifyDataSetChanged();
         }
     }
 
@@ -143,18 +162,41 @@ public class RulesRecyclerViewAdapter extends RecyclerView.Adapter<RulesRecycler
         @BindView(R.id.short_name_text_view_item_rule)
         TextView shortNameTextView;
         @BindView(R.id.description_markwon_view_item_rule)
-        TextView descriptionMarkwonView;
+        RecyclerView descriptionMarkwonView;
+        @NonNull
+        final MarkwonAdapter markwonAdapter;
 
         RuleViewHolder(@NonNull View itemView) {
             super(itemView);
             ButterKnife.bind(this, itemView);
             shortNameTextView.setTextColor(mPrimaryTextColor);
-            descriptionMarkwonView.setTextColor(mSecondaryTextColor);
 
             if (activity.typeface != null) {
                 shortNameTextView.setTypeface(activity.typeface);
-                descriptionMarkwonView.setTypeface(activity.typeface);
             }
+            markwonAdapter = MarkwonAdapter.builder(R.layout.adapter_default_entry, R.id.text)
+                    .include(TableBlock.class, TableEntry.create(builder -> builder
+                            .tableLayout(R.layout.adapter_table_block, R.id.table_layout)
+                            .textLayoutIsRoot(R.layout.view_table_entry_cell)))
+                    .build();
+            LinearLayoutManagerBugFixed linearLayoutManager = new MarkwonLinearLayoutManager(activity,
+                    new MarkwonLinearLayoutManager.HorizontalScrollViewScrolledListener() {
+                @Override
+                public void onScrolledLeft() {
+                    if (slidrInterface != null) {
+                        slidrInterface.lock();
+                    }
+                }
+
+                @Override
+                public void onScrolledRight() {
+                    if (slidrInterface != null) {
+                        slidrInterface.unlock();
+                    }
+                }
+            });
+            descriptionMarkwonView.setLayoutManager(linearLayoutManager);
+            descriptionMarkwonView.setAdapter(markwonAdapter);
         }
     }
 }

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/RulesRecyclerViewAdapter.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/RulesRecyclerViewAdapter.java
@@ -66,6 +66,7 @@ public class RulesRecyclerViewAdapter extends RecyclerView.Adapter<RulesRecycler
         this.activity = activity;
         this.slidrInterface = slidrInterface;
         mPrimaryTextColor = customThemeWrapper.getPrimaryTextColor();
+        int spoilerBackgroundColor = mPrimaryTextColor | 0xFF000000;
         markwon = Markwon.builder(activity)
                 .usePlugin(MarkwonInlineParserPlugin.create(plugin -> {
                     plugin.excludeInlineProcessor(AutolinkInlineProcessor.class);
@@ -118,6 +119,8 @@ public class RulesRecyclerViewAdapter extends RecyclerView.Adapter<RulesRecycler
                     return true;
                 })))
                 .usePlugin(LinkifyPlugin.create(Linkify.WEB_URLS))
+                .usePlugin(SpoilerParserPlugin.create(mPrimaryTextColor, spoilerBackgroundColor))
+                .usePlugin(RedditHeadingPlugin.create())
                 .usePlugin(StrikethroughPlugin.create())
                 .usePlugin(TableEntryPlugin.create(activity))
                 .build();

--- a/app/src/main/res/layout/item_rule.xml
+++ b/app/src/main/res/layout/item_rule.xml
@@ -11,14 +11,12 @@
         android:textSize="?attr/title_font_16"
         android:fontFamily="?attr/font_family" />
 
-    <TextView
+    <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/description_markwon_view_item_rule"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:paddingBottom="16dp"
-        android:paddingStart="16dp"
-        android:paddingEnd="16dp"
-        android:textSize="?attr/content_font_default"
-        android:fontFamily="?attr/font_family" />
+        android:paddingBottom="8dp"
+        android:paddingStart="8dp"
+        android:paddingEnd="8dp"/>
 
 </LinearLayout>


### PR DESCRIPTION
Added support for tables, spoilers and headings without space after #.

I've kept horizontal spacing the same, but there is a bit more vertical whitespace. It can be fixed too, but I'm not sure if it matters.
| before | after |
|---|---|
| <img src=https://user-images.githubusercontent.com/6381474/187078809-77293ba9-0628-4cb1-b732-b8681664d88c.jpg> | <img src=https://user-images.githubusercontent.com/6381474/187078811-074aa3c0-7b60-42dd-b490-bfeefc20a8e6.jpg> |

