### PR TITLE
Fix memory leak on ConnectivityManager

### DIFF
--- a/app/src/main/java/ml/docilealligator/infinityforreddit/utils/Utils.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/utils/Utils.java
@@ -280,7 +280,7 @@ public final class Utils {
     }
 
     public static int getConnectedNetwork(Context context) {
-        ConnectivityManager connMgr = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
+        ConnectivityManager connMgr = (ConnectivityManager) context.getApplicationContext().getSystemService(Context.CONNECTIVITY_SERVICE);
         if (connMgr != null) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                 Network nw = connMgr.getActiveNetwork();
@@ -327,7 +327,7 @@ public final class Utils {
     }
 
     public static boolean isConnectedToWifi(Context context) {
-        ConnectivityManager connMgr = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
+        ConnectivityManager connMgr = (ConnectivityManager) context.getApplicationContext().getSystemService(Context.CONNECTIVITY_SERVICE);
         if (connMgr != null) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                 Network nw = connMgr.getActiveNetwork();
@@ -348,7 +348,7 @@ public final class Utils {
     }
 
     public static boolean isConnectedToCellularData(Context context) {
-        ConnectivityManager connMgr = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
+        ConnectivityManager connMgr = (ConnectivityManager) context.getApplicationContext().getSystemService(Context.CONNECTIVITY_SERVICE);
         if (connMgr != null) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                 Network nw = connMgr.getActiveNetwork();


### PR DESCRIPTION
Leak found using LeakCanary. Steps:
1. Enable the LeakCanary dependency.
1. Open the app.
1. Go to the "All" tab.
1. Open any post, and go back to the post list.

Leak trace:

```
2022-09-04 17:56:05.904 32018-32018/ml.docilealligator.infinityforreddit.debug D/LeakCanary:
    ┬───
    │ GC Root: System class
    │
    ├─ android.net.ConnectivityManager class
    │    Leaking: NO (a class is never leaking)
    │    ↓ static ConnectivityManager.sInstance
    │                                 ~~~~~~~~~
    ├─ android.net.ConnectivityManager instance
    │    Leaking: UNKNOWN
    │    Retaining 114 B in 5 objects
    │    mContext instance of ml.docilealligator.infinityforreddit.activities.ViewPostDetailActivity with mDestroyed = true
    │    ↓ ConnectivityManager.mContext
    │                          ~~~~~~~~
    ╰→ ml.docilealligator.infinityforreddit.activities.ViewPostDetailActivity instance
         Leaking: YES (ObjectWatcher was watching this because ml.docilealligator.infinityforreddit.activities.
         ViewPostDetailActivity received Activity#onDestroy() callback and Activity#mDestroyed is true)
         Retaining 1.8 MB in 27752 objects
         key = 22e99901-9689-4f70-b88c-092a4a7efad9
         watchDurationMillis = 5518
         retainedDurationMillis = 517
         mApplication instance of ml.docilealligator.infinityforreddit.Infinity
         mBase instance of androidx.appcompat.view.ContextThemeWrapper
```

Solution based on [this StackOverflow answer](https://stackoverflow.com/a/41431693)