### PR TITLE
Fix memory leak on BigImageViewer

### DIFF
--- a/app/src/main/java/ml/docilealligator/infinityforreddit/activities/ViewImageOrGifActivity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/activities/ViewImageOrGifActivity.java
@@ -146,7 +146,7 @@ public class ViewImageOrGifActivity extends AppCompatActivity implements SetAsWa
         getTheme().applyStyle(ContentFontFamily.valueOf(mSharedPreferences
                 .getString(SharedPreferencesUtils.CONTENT_FONT_FAMILY_KEY, ContentFontFamily.Default.name())).getResId(), true);
 
-        BigImageViewer.initialize(GlideImageLoader.with(this));
+        BigImageViewer.initialize(GlideImageLoader.with(this.getApplicationContext()));
 
         setContentView(R.layout.activity_view_image_or_gif);
 

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/activities/ViewPostDetailActivity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/activities/ViewPostDetailActivity.java
@@ -150,7 +150,7 @@ public class ViewPostDetailActivity extends BaseActivity implements SortTypeSele
 
         super.onCreate(savedInstanceState);
 
-        BigImageViewer.initialize(GlideImageLoader.with(this));
+        BigImageViewer.initialize(GlideImageLoader.with(this.getApplicationContext()));
 
         setContentView(R.layout.activity_view_post_detail);
 

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/fragments/ViewRedditGalleryImageOrGifFragment.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/fragments/ViewRedditGalleryImageOrGifFragment.java
@@ -122,7 +122,7 @@ public class ViewRedditGalleryImageOrGifFragment extends Fragment {
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
-        BigImageViewer.initialize(GlideImageLoader.with(activity));
+        BigImageViewer.initialize(GlideImageLoader.with(activity.getApplicationContext()));
 
         View rootView = inflater.inflate(R.layout.fragment_view_reddit_gallery_image_or_gif, container, false);
 


### PR DESCRIPTION
Leak found using LeakCanary. Steps:
1. Enable the LeakCanary dependency.
1. Open the app.
1. Open any post image, and go back.

According to `Piasy/BigImageViewer` documentation, [Initialize section](https://github.com/Piasy/BigImageViewer/blob/9cc045e8146dc8833a487576745f17158bae4a4a/README.md#initialize), the app context must be used to avoid memory leaks.

Leak trace:

```
2022-09-04 19:51:38.154 13332-13332/ml.docilealligator.infinityforreddit.debug D/LeakCanary:
    ┬───
    │ GC Root: Thread object
    │
    ├─ android.os.HandlerThread instance
    │    Leaking: NO (PathClassLoader↓ is not leaking)
    │    Thread name: 'LeakCanary-Heap-Dump'
    │    ↓ Thread.contextClassLoader
    ├─ dalvik.system.PathClassLoader instance
    │    Leaking: NO (BigImageViewer↓ is not leaking and A ClassLoader is never leaking)
    │    ↓ ClassLoader.runtimeInternalObjects
    ├─ java.lang.Object[] array
    │    Leaking: NO (BigImageViewer↓ is not leaking)
    │    ↓ Object[257]
    ├─ com.github.piasy.biv.BigImageViewer class
    │    Leaking: NO (a class is never leaking)
    │    ↓ static BigImageViewer.sInstance
    │                            ~~~~~~~~~
    ├─ com.github.piasy.biv.BigImageViewer instance
    │    Leaking: UNKNOWN
    │    Retaining 969.9 kB in 14812 objects
    │    ↓ BigImageViewer.mImageLoader
    │                     ~~~~~~~~~~~~
    ├─ com.github.piasy.biv.loader.glide.GlideImageLoader instance
    │    Leaking: UNKNOWN
    │    Retaining 969.9 kB in 14811 objects
    │    ↓ GlideImageLoader.mRequestManager
    │                       ~~~~~~~~~~~~~~~
    ├─ com.bumptech.glide.RequestManager instance
    │    Leaking: UNKNOWN
    │    Retaining 969.9 kB in 14808 objects
    │    context instance of ml.docilealligator.infinityforreddit.activities.ViewPostDetailActivity with mDestroyed = true
    │    ↓ RequestManager.context
    │                     ~~~~~~~
    ╰→ ml.docilealligator.infinityforreddit.activities.ViewPostDetailActivity instance
         Leaking: YES (ObjectWatcher was watching this because ml.docilealligator.infinityforreddit.activities.
         ViewPostDetailActivity received Activity#onDestroy() callback and Activity#mDestroyed is true)
         Retaining 966.2 kB in 14703 objects
         key = f69c74cc-521e-4f6c-b5c8-8f787e27df75
         watchDurationMillis = 5547
         retainedDurationMillis = 541
         mApplication instance of ml.docilealligator.infinityforreddit.Infinity
         mBase instance of androidx.appcompat.view.ContextThemeWrapper
```