### PR TITLE
Rewrite spoiler parsing

### DIFF
--- a/app/src/main/java/ml/docilealligator/infinityforreddit/markdown/SpoilerParserPlugin.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/markdown/SpoilerParserPlugin.java
@@ -98,7 +98,7 @@ public class SpoilerParserPlugin extends AbstractMarkwonPlugin {
         //noinspection ComparatorCombinators as it requires api 24+
         Collections.sort(brackets, (lhs, rhs) -> Integer.compare(lhs.position, rhs.position));
 
-        int offset = 2;
+        int offset = 0;
         for (SpoilerBracket bracket: brackets) {
             if (bracket.opening) {
                 int spoilerStart = bracket.position - offset;
@@ -107,7 +107,7 @@ public class SpoilerParserPlugin extends AbstractMarkwonPlugin {
                 }
                 markdownStringBuilder.delete(spoilerStart, spoilerStart + 2);
             } else {
-                int spoilerEnd = bracket.position - offset + 2;
+                int spoilerEnd = bracket.position - offset;
                 markdownStringBuilder.delete(spoilerEnd, spoilerEnd + 2);
                 if (!bracket.nested) {
                     SpoilerSpan spoilerSpan = new SpoilerSpan(textColor, backgroundColor);
@@ -118,7 +118,7 @@ public class SpoilerParserPlugin extends AbstractMarkwonPlugin {
             offset += 2;
         }
 
-        if (offset > 2) {
+        if (offset > 0) {
             textView.setText(markdownStringBuilder);
         }
     }
@@ -159,7 +159,7 @@ public class SpoilerParserPlugin extends AbstractMarkwonPlugin {
                     && i + 1 < length
                     && markdown.charAt(i + 1) == '!'
                     && noCodeIntersection(markdown, i)) {
-                openSpoilerStack.push(i + 2);
+                openSpoilerStack.push(i);
                 i++; // skip '!'
             } else if (openSpoilerStack.size() > 0
                     && currentChar == '!'


### PR DESCRIPTION
Fixes #1099 

Basically there were four cases that broke the code:
```
>! `one` `two` `three` !< - crashes
>! >! one !< >! two !< >! three !< !< - crashes
>! one `two !<` three !< - doesn't show any spoilers, should be one big spoiler
>! one >! two !< three !< - doesn't remove >! !< around two
```

I've left comments in this PR about specific places that broke the code, but I can also break up the commits if you want.

<details>
  <summary>Also tested on</summary>

    text
    >! spoiler !<
    >! start
    end !<

    ```
    code
    >! block !<
    ```

    >! because `code !<`
    
    >!multi
    line!<

    >!new

    line!<

    >! not >! matched !<

    >!
    ```
    around block
    ```
    !<

    >!`code`!<
    
    >!```not block
    ```!<

    >`!` quote !<
    code >`!` bracket !<
    empty >!!<
    >! self >!< intersection !<
    >! other >!< way

</details>

Known problems:
- #1102 Cannot escape spoiler using backslash - backslashes are removed somewhere before `afterSetText`, so fixing it will require a different approach
- #1103 Leading and trailing spaces are not removed - fixable with current parser. But Reddit has some weird whitespace processing, so perfectly matching the behavior will be tricky

@scria1000 fyi
