### PR TITLE
Fix crash in debug build by using fully qualified class name for layoutmanager

### DIFF
--- a/app/src/main/res/layout-land/fragment_view_post_detail.xml
+++ b/app/src/main/res/layout-land/fragment_view_post_detail.xml
@@ -25,7 +25,7 @@
                 android:layout_weight="1"
                 android:paddingBottom="144dp"
                 android:clipToPadding="false"
-                app:layoutManager=".customviews.LinearLayoutManagerBugFixed"  />
+                app:layoutManager="ml.docilealligator.infinityforreddit.customviews.LinearLayoutManagerBugFixed"  />
 
             <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/comments_recycler_view_view_post_detail_fragment"
@@ -34,7 +34,7 @@
                 android:layout_weight="1"
                 android:paddingBottom="144dp"
                 android:clipToPadding="false"
-                app:layoutManager=".customviews.LinearLayoutManagerBugFixed" />
+                app:layoutManager="ml.docilealligator.infinityforreddit.customviews.LinearLayoutManagerBugFixed" />
 
         </LinearLayout>
 

--- a/app/src/main/res/layout-sw600dp/fragment_view_post_detail.xml
+++ b/app/src/main/res/layout-sw600dp/fragment_view_post_detail.xml
@@ -25,7 +25,7 @@
                 android:layout_weight="1"
                 android:paddingBottom="144dp"
                 android:clipToPadding="false"
-                app:layoutManager=".customviews.LinearLayoutManagerBugFixed" />
+                app:layoutManager="ml.docilealligator.infinityforreddit.customviews.LinearLayoutManagerBugFixed" />
 
             <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/comments_recycler_view_view_post_detail_fragment"
@@ -34,7 +34,7 @@
                 android:layout_weight="1"
                 android:paddingBottom="144dp"
                 android:clipToPadding="false"
-                app:layoutManager=".customviews.LinearLayoutManagerBugFixed" />
+                app:layoutManager="ml.docilealligator.infinityforreddit.customviews.LinearLayoutManagerBugFixed" />
 
         </LinearLayout>
 

--- a/app/src/main/res/layout/activity_custom_theme_listing.xml
+++ b/app/src/main/res/layout/activity_custom_theme_listing.xml
@@ -37,7 +37,7 @@
         android:id="@+id/recycler_view_customize_theme_listing_activity"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        app:layoutManager=".customviews.LinearLayoutManagerBugFixed"
+        app:layoutManager="ml.docilealligator.infinityforreddit.customviews.LinearLayoutManagerBugFixed"
         app:layout_behavior="@string/appbar_scrolling_view_behavior" />
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton

--- a/app/src/main/res/layout/activity_customize_theme.xml
+++ b/app/src/main/res/layout/activity_customize_theme.xml
@@ -38,7 +38,7 @@
         android:id="@+id/recycler_view_customize_theme_activity"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        app:layoutManager=".customviews.LinearLayoutManagerBugFixed"
+        app:layoutManager="ml.docilealligator.infinityforreddit.customviews.LinearLayoutManagerBugFixed"
         app:layout_behavior="@string/appbar_scrolling_view_behavior" />
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_report.xml
+++ b/app/src/main/res/layout/activity_report.xml
@@ -27,7 +27,7 @@
         android:id="@+id/recycler_view_report_activity"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        app:layoutManager=".customviews.LinearLayoutManagerBugFixed"
+        app:layoutManager="ml.docilealligator.infinityforreddit.customviews.LinearLayoutManagerBugFixed"
         app:layout_behavior="@string/appbar_scrolling_view_behavior" />
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_rules.xml
+++ b/app/src/main/res/layout/activity_rules.xml
@@ -45,7 +45,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:clipToPadding="false"
-        app:layoutManager=".customviews.LinearLayoutManagerBugFixed"
+        app:layoutManager="ml.docilealligator.infinityforreddit.customviews.LinearLayoutManagerBugFixed"
         app:layout_behavior="@string/appbar_scrolling_view_behavior" />
 
     <TextView

--- a/app/src/main/res/layout/activity_trending.xml
+++ b/app/src/main/res/layout/activity_trending.xml
@@ -43,7 +43,7 @@
             android:id="@+id/recycler_view_trending_activity"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            app:layoutManager=".customviews.LinearLayoutManagerBugFixed" />
+            app:layoutManager="ml.docilealligator.infinityforreddit.customviews.LinearLayoutManagerBugFixed" />
 
     </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 

--- a/app/src/main/res/layout/exo_rpan_broadcast_playback_control_view.xml
+++ b/app/src/main/res/layout/exo_rpan_broadcast_playback_control_view.xml
@@ -142,7 +142,7 @@
         android:paddingEnd="16dp"
         app:layout_constraintTop_toBottomOf="@id/control_linear_layout"
         app:layout_constraintBottom_toTopOf="@id/time_bar_linear_layout"
-        app:layoutManager=".customviews.LinearLayoutManagerBugFixed" />
+        app:layoutManager="ml.docilealligator.infinityforreddit.customviews.LinearLayoutManagerBugFixed" />
 
     <LinearLayout
         android:id="@+id/time_bar_linear_layout"

--- a/app/src/main/res/layout/fragment_crash_reports.xml
+++ b/app/src/main/res/layout/fragment_crash_reports.xml
@@ -4,5 +4,5 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    app:layoutManager=".customviews.LinearLayoutManagerBugFixed"
+    app:layoutManager="ml.docilealligator.infinityforreddit.customviews.LinearLayoutManagerBugFixed"
     tools:context=".settings.CrashReportsFragment" />

--- a/app/src/main/res/layout/fragment_flair_bottom_sheet.xml
+++ b/app/src/main/res/layout/fragment_flair_bottom_sheet.xml
@@ -29,6 +29,6 @@
         android:id="@+id/recycler_view_bottom_sheet_fragment"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        app:layoutManager=".customviews.LinearLayoutManagerBugFixed" />
+        app:layoutManager="ml.docilealligator.infinityforreddit.customviews.LinearLayoutManagerBugFixed" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_translation.xml
+++ b/app/src/main/res/layout/fragment_translation.xml
@@ -5,5 +5,5 @@
     android:layout_height="match_parent"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/recycler_view_translation_fragment"
-    app:layoutManager=".customviews.LinearLayoutManagerBugFixed"
+    app:layoutManager="ml.docilealligator.infinityforreddit.customviews.LinearLayoutManagerBugFixed"
     tools:context=".settings.TranslationFragment" />

--- a/app/src/main/res/layout/fragment_view_post_detail.xml
+++ b/app/src/main/res/layout/fragment_view_post_detail.xml
@@ -18,7 +18,7 @@
             android:layout_height="match_parent"
             android:paddingBottom="144dp"
             android:clipToPadding="false"
-            app:layoutManager=".customviews.LinearLayoutManagerBugFixed" />
+            app:layoutManager="ml.docilealligator.infinityforreddit.customviews.LinearLayoutManagerBugFixed" />
 
     </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 


### PR DESCRIPTION
When the class name is relative, Android tries to resolve it against applicationId. However it does not match the package because of `.debug` suffix so it tries to load the wrong class. This results in ClassNotFoundException and a crash.

Using fully qualified class name fixes it because the system can use the class name as is.