### PR TITLE
Ellipsize usernames if they don't fit in a fully collapsed comment

### DIFF
--- a/app/src/main/res/layout/item_comment_fully_collapsed.xml
+++ b/app/src/main/res/layout/item_comment_fully_collapsed.xml
@@ -32,6 +32,7 @@
                 android:layout_weight="1"
                 android:layout_gravity="center_vertical"
                 android:maxLines="1"
+                android:ellipsize="end"
                 android:fontFamily="?attr/font_family"
                 android:paddingStart="8dp"
                 android:paddingTop="12dp"


### PR DESCRIPTION
Possible solution to #1142
If another fix is better, feel free to close 🙂 