### PR TITLE
Add some contrast to subreddit and user detail toolbars

### DIFF
--- a/app/src/main/java/ml/docilealligator/infinityforreddit/activities/BaseActivity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/activities/BaseActivity.java
@@ -12,6 +12,7 @@ import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.graphics.Color;
 import android.graphics.Typeface;
+import android.graphics.drawable.GradientDrawable;
 import android.os.Build;
 import android.os.Bundle;
 import android.view.Menu;
@@ -314,6 +315,10 @@ public abstract class BaseActivity extends AppCompatActivity implements CustomFo
         }
         if (setToolbarBackgroundColor) {
             toolbar.setBackgroundColor(customThemeWrapper.getColorPrimary());
+        } else if (!isImmersiveInterface()) {
+            int[] colors = {customThemeWrapper.getColorPrimary(), Color.TRANSPARENT};
+            GradientDrawable gradientDrawable = new GradientDrawable(GradientDrawable.Orientation.TOP_BOTTOM, colors);
+            toolbar.setBackground(gradientDrawable);
         }
         toolbar.setTitleTextColor(customThemeWrapper.getToolbarPrimaryTextAndIconColor());
         toolbar.setSubtitleTextColor(customThemeWrapper.getToolbarSecondaryTextColor());


### PR DESCRIPTION
Add a gradient from the primary theme color to transparent so that if a subreddit or user profile has a very light background, the usually light text and buttons are not obscured or in some cases invisible.

The gradients don't appear for immersive mode so that the app remains immersive.

A toolbar with the primary color and some opacity applied might work too, or a preference to let a user choose to apply the primary color even for these toolbars would be nice. This is just an example. Some people dislike gradients, so feel free to decline 🙂 

Before:
![before](https://user-images.githubusercontent.com/494446/197103902-1f4d062b-b70c-4b0f-9fc5-5728d5b55d58.png)

After:
![dark_with_light_banner](https://user-images.githubusercontent.com/494446/197102906-e233d37f-f654-4b91-98ca-780ce3084838.png)

With light theme and color:
![light_theme](https://user-images.githubusercontent.com/494446/197102765-43c66dec-79b4-4b0a-a397-8098ef4520dc.png)
