### PR TITLE
Fixed issue where filters applied to same feed were behaving incorrectly

### DIFF
--- a/app/src/main/java/ml/docilealligator/infinityforreddit/postfilter/PostFilter.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/postfilter/PostFilter.java
@@ -350,12 +350,12 @@ public class PostFilter implements Parcelable {
                 postFilter.containDomains = stringBuilder.toString();
             }
 
-            postFilter.containTextType = p.containTextType || postFilter.containTextType;
-            postFilter.containLinkType = p.containLinkType || postFilter.containLinkType;
-            postFilter.containImageType = p.containImageType || postFilter.containImageType;
-            postFilter.containGifType = p.containGifType || postFilter.containGifType;
-            postFilter.containVideoType = p.containVideoType || postFilter.containVideoType;
-            postFilter.containGalleryType = p.containGalleryType || postFilter.containGalleryType;
+            postFilter.containTextType = p.containTextType && postFilter.containTextType;
+            postFilter.containLinkType = p.containLinkType && postFilter.containLinkType;
+            postFilter.containImageType = p.containImageType && postFilter.containImageType;
+            postFilter.containGifType = p.containGifType && postFilter.containGifType;
+            postFilter.containVideoType = p.containVideoType && postFilter.containVideoType;
+            postFilter.containGalleryType = p.containGalleryType && postFilter.containGalleryType;
         }
 
         return postFilter;


### PR DESCRIPTION
# Summary

Post types are shown in a feed even though they should be excluded with post filters. With a singular post filter, everything behaves as expected. The problem occurs when there are two or more post filters are applied to the same feed.

# Code Changes

In `PostFilter`, within the `mergePostFilter` method, when the `postFilter.containX` is set, it is set with a `&&` operation between the a particular post filter and the overall filter applied. 

# The issue

The issue with the original code is that whenever there are multiple post filters applied to a particular feed, the `mergePostFilter` is being executed. This causes a new postFilter object to be created where the default values of `postFilter.containX` is `True`. The `mergePostFilter` method then start combining the filters with an `||` which will always result in true as it is combining the newly created postFilter with the users postFilters (causing the situation of `postFilter.containX = userInput || True`). By changing this operator to an `&&`, the `mergePostFilter` method works as intended by avoiding the situation described.

# Testing

Confirmed that multiple post filters applied to a particular feed apply filters as intended.

Closes #1056


