### PR TITLE
Handle reddit.com/report as a url, not post link

### DIFF
--- a/app/src/main/java/ml/docilealligator/infinityforreddit/activities/LinkResolverActivity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/activities/LinkResolverActivity.java
@@ -174,6 +174,8 @@ public class LinkResolverActivity extends AppCompatActivity {
                             } else if (path.isEmpty()) {
                                 Intent intent = new Intent(this, MainActivity.class);
                                 startActivity(intent);
+                            } else if (path.equals("/report")) {
+                                openInWebView(uri);
                             } else if (path.matches(POST_PATTERN) || path.matches(POST_PATTERN_2)) {
                                 int commentsIndex = segments.lastIndexOf("comments");
                                 if (commentsIndex >= 0 && commentsIndex < segments.size() - 1) {


### PR DESCRIPTION
Handle `www.reddit.com/report` as a URL instead of a regular post. It pulls up this URL in web view.

Ideally, the same functionality the Reddit report page offers can be introduced to the app down the road, but I feel this is a good middle ground for now since the post it currently attempts to pull up is an unwelcome surprise.

<img src="https://user-images.githubusercontent.com/12687723/197913219-f302c834-77e0-4735-a511-5014bc5ebbff.png"  width="300px" />

Closes #757 