### PR TITLE
add button to export logs to GitHub issue

### DIFF
--- a/app/src/main/java/ml/docilealligator/infinityforreddit/settings/CrashReportsFragment.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/settings/CrashReportsFragment.java
@@ -2,7 +2,10 @@ package ml.docilealligator.infinityforreddit.settings;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
+import android.content.Intent;
 import android.content.res.ColorStateList;
+import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -20,10 +23,16 @@ import androidx.recyclerview.widget.RecyclerView;
 
 import com.crazylegend.crashyreporter.CrashyReporter;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.List;
+
 import javax.inject.Inject;
 
+import ml.docilealligator.infinityforreddit.BuildConfig;
 import ml.docilealligator.infinityforreddit.Infinity;
 import ml.docilealligator.infinityforreddit.R;
+import ml.docilealligator.infinityforreddit.activities.LinkResolverActivity;
 import ml.docilealligator.infinityforreddit.activities.SettingsActivity;
 import ml.docilealligator.infinityforreddit.adapters.CrashReportsRecyclerViewAdapter;
 import ml.docilealligator.infinityforreddit.customtheme.CustomThemeWrapper;
@@ -68,8 +77,38 @@ public class CrashReportsFragment extends Fragment {
             CrashyReporter.INSTANCE.purgeLogs();
             Toast.makeText(activity, R.string.crash_reports_deleted, Toast.LENGTH_SHORT).show();
             return true;
+        } else if (item.getItemId() == R.id.action_export_logs_crash_reports_fragment) {
+            return createGithubIssueWithLogs();
         }
         return false;
+    }
+
+    /**
+     * Fetch the logs from CrashyReporter and open browser to create GitHub issue page.
+     * Issue will have logs, device model, app version, and Android version prefilled.
+     * @return if successful
+     */
+    private boolean createGithubIssueWithLogs() {
+        Intent intent = new Intent(getContext(), LinkResolverActivity.class);
+        String logs, model, appVersion, androidVersion;
+        try {
+            List<String> logLines = CrashyReporter.INSTANCE.getLogsAsStrings();
+            if (logLines == null) {
+                return false;
+            }
+            logs = String.join("\n", logLines);
+            // limit size to 6800 characters to avoid `414 URI Too Long`
+            logs = URLEncoder.encode("```\n" + (logs.length() > 0 ? logs.substring(0, Math.min(6800, logs.length())) : "No logs found.") + "\n```", "UTF-8");
+            model = URLEncoder.encode(Build.MANUFACTURER + " " + Build.MODEL, "UTF-8");
+            appVersion = URLEncoder.encode(BuildConfig.VERSION_NAME, "UTF-8");
+            androidVersion = URLEncoder.encode(Build.VERSION.RELEASE, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            return false;
+        }
+        Uri githubIssueUri = Uri.parse(String.format("https://github.com/Docile-Alligator/Infinity-For-Reddit/issues/new?labels=possible-bug&device=%s&version=%s&android_version=%s&logs=%s&&template=BUG_REPORT.yml", model, appVersion, androidVersion, logs));
+        intent.setData(githubIssueUri);
+        startActivity(intent);
+        return true;
     }
 
     @SuppressLint("RestrictedApi")

--- a/app/src/main/res/menu/crash_reports_fragment.xml
+++ b/app/src/main/res/menu/crash_reports_fragment.xml
@@ -7,4 +7,10 @@
         android:title="@string/action_delete_logs"
         android:icon="@drawable/ic_delete_24dp"
         app:showAsAction="ifRoom" />
+    <item
+        android:id="@+id/action_export_logs_crash_reports_fragment"
+        android:orderInCategory="2"
+        android:title="@string/action_create_github_issue"
+        android:icon="@drawable/ic_open_link_24dp"
+        app:showAsAction="ifRoom" />
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -90,6 +90,7 @@
     <string name="action_open_external_browser">Open in browser</string>
     <string name="action_add_to_post_filter">Add to Post Filter</string>
     <string name="action_delete_logs">Delete Logs</string>
+    <string name="action_create_github_issue">Create GitHub Issue</string>
     <string name="action_share_rpan_link">Share RPAN Link</string>
     <string name="action_share_post_link">Share Post Link</string>
     <string name="action_go_to_wiki">Go to Wiki</string>


### PR DESCRIPTION
I recently noticed an issue (#1160) that contained screenshots of logs. This isn't a great experience from the user's or developer's perspective. I added a button to the Crash Reports screen that allows the user to create a new GitHub issue with the crash logs. It also prefills android version, device details, app version, etc.

# Screenshots
## New Button
<img width="300px" src="https://user-images.githubusercontent.com/12687723/197925191-08ae1a59-f0cc-4465-a0df-c10b73a2eb07.png"/>

## On GitHub
<img width="300px" src="https://user-images.githubusercontent.com/12687723/197925263-cc5a99a6-627e-4e71-90ba-6e9b0156f4d4.png"/>

