### PR TITLE
Don't pick up hyperlink text as a link

### DIFF
--- a/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/PostDetailRecyclerViewAdapter.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/PostDetailRecyclerViewAdapter.java
@@ -7,6 +7,7 @@ import android.content.SharedPreferences;
 import android.content.res.ColorStateList;
 import android.content.res.Configuration;
 import android.content.res.Resources;
+import android.graphics.Color;
 import android.graphics.ColorFilter;
 import android.graphics.PorterDuff;
 import android.graphics.drawable.Drawable;
@@ -243,6 +244,7 @@ public class PostDetailRecyclerViewAdapter extends RecyclerView.Adapter<Recycler
                     textView.setTypeface(mActivity.contentTypeface);
                 }
                 textView.setTextColor(markdownColor);
+                textView.setHighlightColor(Color.TRANSPARENT);
                 textView.setOnLongClickListener(view -> {
                     if (textView.getSelectionStart() == -1 && textView.getSelectionEnd() == -1) {
                         CopyTextBottomSheetFragment.show(

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/markdown/SpoilerAwareMovementMethod.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/markdown/SpoilerAwareMovementMethod.java
@@ -66,7 +66,8 @@ public class SpoilerAwareMovementMethod extends BetterLinkMovementMethod {
     private ClickableSpan selectClickableSpan(@NonNull Object[] spans) {
         SpoilerSpan spoilerSpan = null;
         ClickableSpan nonSpoilerSpan = null;
-        for (final Object span : spans) {
+        for (int i = spans.length - 1; i >= 0; i--) {
+            final Object span = spans[i];
             if (span instanceof SpoilerSpan) {
                 spoilerSpan = (SpoilerSpan) span;
             } else if (span instanceof ClickableSpan) {


### PR DESCRIPTION
On latest commit, 
`[textthatcanalsobealink.com](http://actuallink.com)`  -> SpoilerAwareMovementMethod inadvertently gives precedence to the LinkSpan inside the hyperlink text, so when you click the hyperlink it will take you to `text.com` instead. This pull request seems to fix it but Markwon will still be spanning it twice.

Link to reproduce issue:
https://www.reddit.com/r/bizarrebuildings/comments/ycju2m/ch%C3%A2teau_deau_de_gasperich_luxembourg/