### PR TITLE
Improve wiki link handling

### DIFF
--- a/app/src/main/java/ml/docilealligator/infinityforreddit/activities/LinkResolverActivity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/activities/LinkResolverActivity.java
@@ -50,7 +50,7 @@ public class LinkResolverActivity extends AppCompatActivity {
     private static final String IMGUR_ALBUM_PATTERN = "/(album|a)/\\w+/?";
     private static final String IMGUR_IMAGE_PATTERN = "/\\w+/?";
     private static final String RPAN_BROADCAST_PATTERN = "/rpan/r/[\\w-]+/\\w+/?\\w+/?";
-    private static final String WIKI_PATTERN = "^(/[rR]/[\\w-]+/(wiki|w)?(?:/?[\\w-]+)+)$";
+    private static final String WIKI_PATTERN = "/[rR]/[\\w-]+/(wiki|w)?(?:/?[\\w-]+)+";
     private static final String GOOGLE_AMP_PATTERN = "/amp/s/amp.reddit.com/.*";
     private static final String STREAMABLE_PATTERN = "/\\w+/?";
 

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/activities/LinkResolverActivity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/activities/LinkResolverActivity.java
@@ -50,7 +50,7 @@ public class LinkResolverActivity extends AppCompatActivity {
     private static final String IMGUR_ALBUM_PATTERN = "/(album|a)/\\w+/?";
     private static final String IMGUR_IMAGE_PATTERN = "/\\w+/?";
     private static final String RPAN_BROADCAST_PATTERN = "/rpan/r/[\\w-]+/\\w+/?\\w+/?";
-    private static final String WIKI_PATTERN = "/[rR]/[\\w-]+/(wiki|w)?(?:/?[\\w-]+)+";
+    private static final String WIKI_PATTERN = "/[rR]/[\\w-]+/(wiki|w)(?:/[\\w-]+)*";
     private static final String GOOGLE_AMP_PATTERN = "/amp/s/amp.reddit.com/.*";
     private static final String STREAMABLE_PATTERN = "/\\w+/?";
 

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/activities/LinkResolverActivity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/activities/LinkResolverActivity.java
@@ -50,7 +50,7 @@ public class LinkResolverActivity extends AppCompatActivity {
     private static final String IMGUR_ALBUM_PATTERN = "/(album|a)/\\w+/?";
     private static final String IMGUR_IMAGE_PATTERN = "/\\w+/?";
     private static final String RPAN_BROADCAST_PATTERN = "/rpan/r/[\\w-]+/\\w+/?\\w+/?";
-    private static final String WIKI_PATTERN = "/[rR]/[\\w-]+/(wiki|w)?(?:/\\w+)+";
+    private static final String WIKI_PATTERN = "/[rR]/[\\w-]+/(wiki|w)?(?:/?[\\w-]+)+";
     private static final String GOOGLE_AMP_PATTERN = "/amp/s/amp.reddit.com/.*";
     private static final String STREAMABLE_PATTERN = "/\\w+/?";
 
@@ -204,7 +204,7 @@ public class LinkResolverActivity extends AppCompatActivity {
                                     deepLinkError(uri);
                                 }
                             } else if (path.matches(WIKI_PATTERN)) {
-                                final String wikiPage = path.substring(path.lastIndexOf("/wiki/") + 6);
+                                String wikiPage = path.endsWith("/wiki") ? "index" : path.substring(path.lastIndexOf("/wiki/") + 6);
                                 Intent intent = new Intent(this, WikiActivity.class);
                                 intent.putExtra(WikiActivity.EXTRA_SUBREDDIT_NAME, segments.get(1));
                                 intent.putExtra(WikiActivity.EXTRA_WIKI_PATH, wikiPage);

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/activities/LinkResolverActivity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/activities/LinkResolverActivity.java
@@ -50,7 +50,7 @@ public class LinkResolverActivity extends AppCompatActivity {
     private static final String IMGUR_ALBUM_PATTERN = "/(album|a)/\\w+/?";
     private static final String IMGUR_IMAGE_PATTERN = "/\\w+/?";
     private static final String RPAN_BROADCAST_PATTERN = "/rpan/r/[\\w-]+/\\w+/?\\w+/?";
-    private static final String WIKI_PATTERN = "/[rR]/[\\w-]+/(wiki|w)?(?:/?[\\w-]+)+";
+    private static final String WIKI_PATTERN = "^(/[rR]/[\\w-]+/(wiki|w)?(?:/?[\\w-]+)+)$";
     private static final String GOOGLE_AMP_PATTERN = "/amp/s/amp.reddit.com/.*";
     private static final String STREAMABLE_PATTERN = "/\\w+/?";
 
@@ -204,7 +204,17 @@ public class LinkResolverActivity extends AppCompatActivity {
                                     deepLinkError(uri);
                                 }
                             } else if (path.matches(WIKI_PATTERN)) {
-                                String wikiPage = path.endsWith("/wiki") ? "index" : path.substring(path.lastIndexOf("/wiki/") + 6);
+                                String[] pathSegments = path.split("/");
+                                String wikiPage;
+                                if (pathSegments.length == 4) {
+                                    wikiPage = "index";
+                                } else {
+                                    int lengthThroughWiki = 0;
+                                    for (int i = 1; i <= 3; ++i) {
+                                        lengthThroughWiki += pathSegments[i].length() + 1;
+                                    }
+                                    wikiPage = path.substring(lengthThroughWiki);
+                                }
                                 Intent intent = new Intent(this, WikiActivity.class);
                                 intent.putExtra(WikiActivity.EXTRA_SUBREDDIT_NAME, segments.get(1));
                                 intent.putExtra(WikiActivity.EXTRA_WIKI_PATH, wikiPage);


### PR DESCRIPTION
Closes #830.

A few issues with wiki links have been resolved:
* Wiki pages denoted by `/w` were not handled properly.
* Wiki pages with `/wiki` in them multiple times would not resolve.
* Wiki pages with a dash in them were not matched by regex.
* Links to the default wiki page for a subreddit did not redirect properly.

# Testing
I'd recommend sending yourself a message with links for easy test data.

**Regular wiki page**
https://www.reddit.com/r/science/wiki/rules/

**Wiki page with multiple slashes**
https://www.reddit.com/r/bodyweightfitness/w/exercises/handstand

** Wiki pages with dashes **
https://www.reddit.com/r/bodyweightfitness/w/exercises/l-sit
https://www.reddit.com/r/bodyweightfitness/wiki/exercises/l-sit

**Links ending in `w` or `wiki` resolve to the default wiki page `/index`**
https://www.reddit.com/r/bodyweightfitness/w/
https://www.reddit.com/r/bodyweightfitness/wiki/