### PR TITLE
add backup password below backup settings button

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -585,6 +585,7 @@
     <string name="settings_hide_the_number_of_comments">Hide the Number of Comments</string>
     <string name="settings_show_avatar_on_the_right">Show Avatar on the Right</string>
     <string name="settings_backup_settings_title">Backup Settings</string>
+    <string name="settings_backup_settings_summary">The backup file password is \"123321\".</string>
     <string name="settings_restore_settings_title">Restore Settings</string>
     <string name="settings_credits_love_animation_title">Love Animation</string>
     <string name="settings_swipe_between_posts_title">Swipe Between Posts</string>

--- a/app/src/main/res/xml/advanced_preferences.xml
+++ b/app/src/main/res/xml/advanced_preferences.xml
@@ -40,7 +40,8 @@
 
     <ml.docilealligator.infinityforreddit.customviews.CustomFontPreference
         app:key="backup_settings"
-        app:title="@string/settings_backup_settings_title" />
+        app:title="@string/settings_backup_settings_title"
+        app:summary="@string/settings_backup_settings_summary" />
 
     <ml.docilealligator.infinityforreddit.customviews.CustomFontPreference
         app:key="restore_settings"


### PR DESCRIPTION
When exporting, it should be clear to users what the password is for the backup. I have added it as a summary beneath the "Backup Settings" button.

<img src="https://user-images.githubusercontent.com/12687723/198175463-f499a7d3-6d05-4cee-b56a-0e285ea549b6.png" width="300px"/>


Closes #829.