### PR TITLE
Switch loading more comments to /morechildren endpoint

### DIFF
--- a/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/CommentsRecyclerViewAdapter.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/CommentsRecyclerViewAdapter.java
@@ -597,8 +597,8 @@ public class CommentsRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerVi
                         Retrofit retrofit = mAccessToken == null ? mRetrofit : mOauthRetrofit;
                         FetchComment.fetchMoreComment(mExecutor, new Handler(), retrofit, mAccessToken,
                                 parentComment.getMoreChildrenFullnames(),
-                                parentComment.getMoreChildrenStartingIndex(), parentComment.getDepth() + 1,
-                                mExpandChildren, new FetchComment.FetchMoreCommentListener() {
+                                parentComment.getMoreChildrenStartingIndex(),
+                                mExpandChildren, mPost.getFullName(), new FetchComment.FetchMoreCommentListener() {
                                     @Override
                                     public void onFetchMoreCommentSuccess(ArrayList<Comment> expandedComments,
                                                                           int childrenStartingIndex) {

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/CommentsRecyclerViewAdapter.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/CommentsRecyclerViewAdapter.java
@@ -597,16 +597,14 @@ public class CommentsRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerVi
                         Retrofit retrofit = mAccessToken == null ? mRetrofit : mOauthRetrofit;
                         FetchComment.fetchMoreComment(mExecutor, new Handler(), retrofit, mAccessToken,
                                 parentComment.getMoreChildrenIds(),
-                                parentComment.getMoreChildrenStartingIndex(),
                                 mExpandChildren, mPost.getFullName(), new FetchComment.FetchMoreCommentListener() {
                                     @Override
-                                    public void onFetchMoreCommentSuccess(ArrayList<Comment> expandedComments,
-                                                                          int childrenStartingIndex) {
+                                    public void onFetchMoreCommentSuccess(ArrayList<Comment> expandedComments, ArrayList<String> moreChildrenIds) {
                                         if (mVisibleComments.size() > parentPosition
                                                 && parentComment.getFullName().equals(mVisibleComments.get(parentPosition).getFullName())) {
                                             if (mVisibleComments.get(parentPosition).isExpanded()) {
-                                                if (mVisibleComments.get(parentPosition).getChildren().size() > childrenStartingIndex) {
-                                                    mVisibleComments.get(parentPosition).setMoreChildrenStartingIndex(childrenStartingIndex);
+                                                if (!moreChildrenIds.isEmpty()) {
+                                                    mVisibleComments.get(parentPosition).setMoreChildrenIds(moreChildrenIds);
                                                     mVisibleComments.get(parentPosition).getChildren().get(mVisibleComments.get(parentPosition).getChildren().size() - 1)
                                                             .setLoadingMoreChildren(false);
                                                     mVisibleComments.get(parentPosition).getChildren().get(mVisibleComments.get(parentPosition).getChildren().size() - 1)
@@ -662,7 +660,7 @@ public class CommentsRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerVi
                                                     }
                                                 }
                                             } else {
-                                                if (mVisibleComments.get(parentPosition).hasReply() && mVisibleComments.get(parentPosition).getChildren().size() <= childrenStartingIndex) {
+                                                if (mVisibleComments.get(parentPosition).hasReply() && moreChildrenIds.isEmpty()) {
                                                     mVisibleComments.get(parentPosition).getChildren()
                                                             .remove(mVisibleComments.get(parentPosition).getChildren().size() - 1);
                                                     mVisibleComments.get(parentPosition).removeMoreChildrenIds();

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/CommentsRecyclerViewAdapter.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/CommentsRecyclerViewAdapter.java
@@ -596,7 +596,7 @@ public class CommentsRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerVi
 
                         Retrofit retrofit = mAccessToken == null ? mRetrofit : mOauthRetrofit;
                         FetchComment.fetchMoreComment(mExecutor, new Handler(), retrofit, mAccessToken,
-                                parentComment.getMoreChildrenFullnames(),
+                                parentComment.getMoreChildrenIds(),
                                 parentComment.getMoreChildrenStartingIndex(),
                                 mExpandChildren, mPost.getFullName(), new FetchComment.FetchMoreCommentListener() {
                                     @Override
@@ -635,7 +635,7 @@ public class CommentsRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerVi
                                                 } else {
                                                     mVisibleComments.get(parentPosition).getChildren()
                                                             .remove(mVisibleComments.get(parentPosition).getChildren().size() - 1);
-                                                    mVisibleComments.get(parentPosition).removeMoreChildrenFullnames();
+                                                    mVisibleComments.get(parentPosition).removeMoreChildrenIds();
 
                                                     int placeholderPosition = commentPosition;
                                                     if (mVisibleComments.get(commentPosition).getFullName().equals(parentComment.getFullName())) {
@@ -665,7 +665,7 @@ public class CommentsRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerVi
                                                 if (mVisibleComments.get(parentPosition).hasReply() && mVisibleComments.get(parentPosition).getChildren().size() <= childrenStartingIndex) {
                                                     mVisibleComments.get(parentPosition).getChildren()
                                                             .remove(mVisibleComments.get(parentPosition).getChildren().size() - 1);
-                                                    mVisibleComments.get(parentPosition).removeMoreChildrenFullnames();
+                                                    mVisibleComments.get(parentPosition).removeMoreChildrenIds();
                                                 }
                                             }
 

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/CommentsRecyclerViewAdapter.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/CommentsRecyclerViewAdapter.java
@@ -595,9 +595,10 @@ public class CommentsRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerVi
                         ((LoadMoreChildCommentsViewHolder) holder).placeholderTextView.setText(R.string.loading);
 
                         Retrofit retrofit = mAccessToken == null ? mRetrofit : mOauthRetrofit;
+                        String sortType = mCommentRecyclerViewAdapterCallback.getSortType();
                         FetchComment.fetchMoreComment(mExecutor, new Handler(), retrofit, mAccessToken,
                                 parentComment.getMoreChildrenIds(),
-                                mExpandChildren, mPost.getFullName(), new FetchComment.FetchMoreCommentListener() {
+                                mExpandChildren, mPost.getFullName(), sortType, new FetchComment.FetchMoreCommentListener() {
                                     @Override
                                     public void onFetchMoreCommentSuccess(ArrayList<Comment> expandedComments, ArrayList<String> moreChildrenIds) {
                                         if (mVisibleComments.size() > parentPosition
@@ -1129,6 +1130,8 @@ public class CommentsRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerVi
         void retryFetchingComments();
 
         void retryFetchingMoreComments();
+
+        String getSortType();
     }
 
     public class CommentViewHolder extends RecyclerView.ViewHolder {

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/apis/RedditAPI.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/apis/RedditAPI.java
@@ -428,9 +428,9 @@ public interface RedditAPI {
 
     @FormUrlEncoded
     @POST("/api/morechildren.json?raw_json=1&api_type=json")
-    Call<String> moreChildren(@Field("link_id") String linkId, @Field("children") String children);
+    Call<String> moreChildren(@Field("link_id") String linkId, @Field("children") String children, @Field("sort") String sort);
 
     @FormUrlEncoded
     @POST("/api/morechildren.json?raw_json=1&api_type=json")
-    Call<String> moreChildrenOauth(@Field("link_id") String linkId, @Field("children") String children, @HeaderMap Map<String, String> headers);
+    Call<String> moreChildrenOauth(@Field("link_id") String linkId, @Field("children") String children, @Field("sort") String sort, @HeaderMap Map<String, String> headers);
 }

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/apis/RedditAPI.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/apis/RedditAPI.java
@@ -424,4 +424,10 @@ public interface RedditAPI {
     @FormUrlEncoded
     @POST("/api/site_admin")
     Call<String> postSiteAdmin(@HeaderMap Map<String, String> headers, @FieldMap Map<String, String> params);
+
+    @GET("/api/morechildren.json?raw_json=1&api_type=json")
+    Call<String> moreChildren(@Query("link_id") String linkId, @Query("children") String children);
+
+    @GET("/api/morechildren.json?raw_json=1&api_type=json")
+    Call<String> moreChildrenOauth(@Query("link_id") String linkId, @Query("children") String children, @HeaderMap Map<String, String> headers);
 }

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/apis/RedditAPI.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/apis/RedditAPI.java
@@ -10,6 +10,7 @@ import retrofit2.Call;
 import retrofit2.Response;
 import retrofit2.http.Body;
 import retrofit2.http.DELETE;
+import retrofit2.http.Field;
 import retrofit2.http.FieldMap;
 import retrofit2.http.FormUrlEncoded;
 import retrofit2.http.GET;
@@ -425,9 +426,11 @@ public interface RedditAPI {
     @POST("/api/site_admin")
     Call<String> postSiteAdmin(@HeaderMap Map<String, String> headers, @FieldMap Map<String, String> params);
 
-    @GET("/api/morechildren.json?raw_json=1&api_type=json")
-    Call<String> moreChildren(@Query("link_id") String linkId, @Query("children") String children);
+    @FormUrlEncoded
+    @POST("/api/morechildren.json?raw_json=1&api_type=json")
+    Call<String> moreChildren(@Field("link_id") String linkId, @Field("children") String children);
 
-    @GET("/api/morechildren.json?raw_json=1&api_type=json")
-    Call<String> moreChildrenOauth(@Query("link_id") String linkId, @Query("children") String children, @HeaderMap Map<String, String> headers);
+    @FormUrlEncoded
+    @POST("/api/morechildren.json?raw_json=1&api_type=json")
+    Call<String> moreChildrenOauth(@Field("link_id") String linkId, @Field("children") String children, @HeaderMap Map<String, String> headers);
 }

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/comment/Comment.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/comment/Comment.java
@@ -54,7 +54,6 @@ public class Comment implements Parcelable {
     private boolean hasExpandedBefore;
     private ArrayList<Comment> children;
     private ArrayList<String> moreChildrenIds;
-    private int moreChildrenStartingIndex;
     private int placeholderType;
     private boolean isLoadingMoreChildren;
     private boolean loadMoreChildrenFailed;
@@ -91,7 +90,6 @@ public class Comment implements Parcelable {
         this.saved = saved;
         this.isExpanded = false;
         this.hasExpandedBefore = false;
-        moreChildrenStartingIndex = 0;
         placeholderType = NOT_PLACEHOLDER;
     }
 
@@ -143,7 +141,6 @@ public class Comment implements Parcelable {
         in.readTypedList(children, Comment.CREATOR);
         moreChildrenIds = new ArrayList<>();
         in.readStringList(moreChildrenIds);
-        moreChildrenStartingIndex = in.readInt();
         placeholderType = in.readInt();
         isLoadingMoreChildren = in.readByte() != 0;
         loadMoreChildrenFailed = in.readByte() != 0;
@@ -361,14 +358,6 @@ public class Comment implements Parcelable {
         moreChildrenIds.clear();
     }
 
-    public int getMoreChildrenStartingIndex() {
-        return moreChildrenStartingIndex;
-    }
-
-    public void setMoreChildrenStartingIndex(int moreChildrenStartingIndex) {
-        this.moreChildrenStartingIndex = moreChildrenStartingIndex;
-    }
-
     public int getPlaceholderType() {
         return placeholderType;
     }
@@ -424,7 +413,6 @@ public class Comment implements Parcelable {
         parcel.writeByte((byte) (hasExpandedBefore ? 1 : 0));
         parcel.writeTypedList(children);
         parcel.writeStringList(moreChildrenIds);
-        parcel.writeInt(moreChildrenStartingIndex);
         parcel.writeInt(placeholderType);
         parcel.writeByte((byte) (isLoadingMoreChildren ? 1 : 0));
         parcel.writeByte((byte) (loadMoreChildrenFailed ? 1 : 0));

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/comment/Comment.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/comment/Comment.java
@@ -53,7 +53,7 @@ public class Comment implements Parcelable {
     private boolean isExpanded;
     private boolean hasExpandedBefore;
     private ArrayList<Comment> children;
-    private ArrayList<String> moreChildrenFullnames;
+    private ArrayList<String> moreChildrenIds;
     private int moreChildrenStartingIndex;
     private int placeholderType;
     private boolean isLoadingMoreChildren;
@@ -141,8 +141,8 @@ public class Comment implements Parcelable {
         hasExpandedBefore = in.readByte() != 0;
         children = new ArrayList<>();
         in.readTypedList(children, Comment.CREATOR);
-        moreChildrenFullnames = new ArrayList<>();
-        in.readStringList(moreChildrenFullnames);
+        moreChildrenIds = new ArrayList<>();
+        in.readStringList(moreChildrenIds);
         moreChildrenStartingIndex = in.readInt();
         placeholderType = in.readInt();
         isLoadingMoreChildren = in.readByte() != 0;
@@ -345,20 +345,20 @@ public class Comment implements Parcelable {
         children.add(position, comment);
     }
 
-    public ArrayList<String> getMoreChildrenFullnames() {
-        return moreChildrenFullnames;
+    public ArrayList<String> getMoreChildrenIds() {
+        return moreChildrenIds;
     }
 
-    public void setMoreChildrenFullnames(ArrayList<String> moreChildrenFullnames) {
-        this.moreChildrenFullnames = moreChildrenFullnames;
+    public void setMoreChildrenIds(ArrayList<String> moreChildrenIds) {
+        this.moreChildrenIds = moreChildrenIds;
     }
 
-    public boolean hasMoreChildrenFullnames() {
-        return moreChildrenFullnames != null;
+    public boolean hasMoreChildrenIds() {
+        return moreChildrenIds != null;
     }
 
-    public void removeMoreChildrenFullnames() {
-        moreChildrenFullnames.clear();
+    public void removeMoreChildrenIds() {
+        moreChildrenIds.clear();
     }
 
     public int getMoreChildrenStartingIndex() {
@@ -423,7 +423,7 @@ public class Comment implements Parcelable {
         parcel.writeByte((byte) (isExpanded ? 1 : 0));
         parcel.writeByte((byte) (hasExpandedBefore ? 1 : 0));
         parcel.writeTypedList(children);
-        parcel.writeStringList(moreChildrenFullnames);
+        parcel.writeStringList(moreChildrenIds);
         parcel.writeInt(moreChildrenStartingIndex);
         parcel.writeInt(placeholderType);
         parcel.writeByte((byte) (isLoadingMoreChildren ? 1 : 0));

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/comment/FetchComment.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/comment/FetchComment.java
@@ -72,6 +72,7 @@ public class FetchComment {
                                         @Nullable String accessToken,
                                         ArrayList<String> allChildren,
                                         boolean expandChildren, String postFullName,
+                                        String sortType,
                                         FetchMoreCommentListener fetchMoreCommentListener) {
         if (allChildren == null) {
             return;
@@ -86,9 +87,10 @@ public class FetchComment {
         RedditAPI api = retrofit.create(RedditAPI.class);
         Call<String> moreComments;
         if (accessToken == null) {
-            moreComments = api.moreChildren(postFullName, childrenIds);
+            moreComments = api.moreChildren(postFullName, childrenIds, sortType);
         } else {
-            moreComments = api.moreChildrenOauth(postFullName, childrenIds, APIUtils.getOAuthHeader(accessToken));
+            moreComments = api.moreChildrenOauth(postFullName, childrenIds,
+                    sortType, APIUtils.getOAuthHeader(accessToken));
         }
 
         moreComments.enqueue(new Callback<String>() {

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/comment/FetchComment.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/comment/FetchComment.java
@@ -46,9 +46,9 @@ public class FetchComment {
                             expandChildren, new ParseComment.ParseCommentListener() {
                                 @Override
                                 public void onParseCommentSuccess(ArrayList<Comment> expandedComments,
-                                                                  String parentId, ArrayList<String> moreChildrenFullnames) {
+                                                                  String parentId, ArrayList<String> moreChildrenIds) {
                                     fetchCommentListener.onFetchCommentSuccess(expandedComments, parentId,
-                                            moreChildrenFullnames);
+                                            moreChildrenIds);
                                 }
 
                                 @Override
@@ -84,8 +84,8 @@ public class FetchComment {
             if (allChildren.size() <= startingIndex + i) {
                 break;
             }
-            String child = allChildren.get(startingIndex + i);
-            stringBuilder.append(child.substring(3)).append(",");
+            String childId = allChildren.get(startingIndex + i);
+            stringBuilder.append(childId).append(",");
         }
 
         if (stringBuilder.length() == 0) {
@@ -110,7 +110,7 @@ public class FetchComment {
                             expandChildren, new ParseComment.ParseCommentListener() {
                                 @Override
                                 public void onParseCommentSuccess(ArrayList<Comment> expandedComments,
-                                                                  String parentId, ArrayList<String> moreChildrenFullnames) {
+                                                                  String parentId, ArrayList<String> moreChildrenIds) {
                                     fetchMoreCommentListener.onFetchMoreCommentSuccess(expandedComments,
                                             startingIndex + 100);
                                 }

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/comment/ParseComment.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/comment/ParseComment.java
@@ -6,6 +6,7 @@ import static ml.docilealligator.infinityforreddit.comment.Comment.VOTE_TYPE_UPV
 
 import android.os.Handler;
 import android.text.Html;
+import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -225,7 +226,7 @@ public class ParseComment {
             } else {
                 c.setExpanded(true);
             }
-            if (c.hasMoreChildrenIds() && c.getMoreChildrenIds().size() > c.getMoreChildrenStartingIndex()) {
+            if (c.hasMoreChildrenIds() && !c.getMoreChildrenIds().isEmpty()) {
                 //Add a load more placeholder
                 Comment placeholder = new Comment(c.getFullName(), c.getDepth() + 1, Comment.PLACEHOLDER_LOAD_MORE_COMMENTS);
                 visibleComments.add(placeholder);

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/fragments/ViewPostDetailFragment.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/fragments/ViewPostDetailFragment.java
@@ -200,8 +200,6 @@ public class ViewPostDetailFragment extends Fragment implements FragmentCommunic
     @State
     ArrayList<String> children;
     @State
-    int mChildrenStartingIndex = 0;
-    @State
     boolean loadMoreChildrenSuccess = true;
     @State
     boolean hasMoreChildren;
@@ -765,7 +763,6 @@ public class ViewPostDetailFragment extends Fragment implements FragmentCommunic
     public void changeSortType(SortType sortType) {
         mFetchPostInfoLinearLayout.setVisibility(View.GONE);
         mGlide.clear(mFetchPostInfoImageView);
-        mChildrenStartingIndex = 0;
         if (children != null) {
             children.clear();
         }
@@ -1502,13 +1499,13 @@ public class ViewPostDetailFragment extends Fragment implements FragmentCommunic
         isLoadingMoreChildren = true;
 
         Retrofit retrofit = mAccessToken == null ? mRetrofit : mOauthRetrofit;
-        FetchComment.fetchMoreComment(mExecutor, new Handler(), retrofit, mAccessToken, children, mChildrenStartingIndex,
+        FetchComment.fetchMoreComment(mExecutor, new Handler(), retrofit, mAccessToken, children,
                 mExpandChildren, mPost.getFullName(), new FetchComment.FetchMoreCommentListener() {
                     @Override
-                    public void onFetchMoreCommentSuccess(ArrayList<Comment> expandedComments, int childrenStartingIndex) {
-                        hasMoreChildren = childrenStartingIndex < children.size();
+                    public void onFetchMoreCommentSuccess(ArrayList<Comment> expandedComments, ArrayList<String> moreChildrenIds) {
+                        children = moreChildrenIds;
+                        hasMoreChildren = !children.isEmpty();
                         mCommentsAdapter.addComments(expandedComments, hasMoreChildren);
-                        mChildrenStartingIndex = childrenStartingIndex;
                         isLoadingMoreChildren = false;
                         loadMoreChildrenSuccess = true;
                     }
@@ -1525,7 +1522,6 @@ public class ViewPostDetailFragment extends Fragment implements FragmentCommunic
     public void refresh(boolean fetchPost, boolean fetchComments) {
         if (mPostAdapter != null && !isRefreshing) {
             isRefreshing = true;
-            mChildrenStartingIndex = 0;
 
             mFetchPostInfoLinearLayout.setVisibility(View.GONE);
             mGlide.clear(mFetchPostInfoImageView);

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/fragments/ViewPostDetailFragment.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/fragments/ViewPostDetailFragment.java
@@ -1273,8 +1273,8 @@ public class ViewPostDetailFragment extends Fragment implements FragmentCommunic
                                 ParseComment.parseComment(mExecutor, new Handler(), response.body(), new ArrayList<>(),
                                         mExpandChildren, new ParseComment.ParseCommentListener() {
                                             @Override
-                                            public void onParseCommentSuccess(ArrayList<Comment> expandedComments, String parentId, ArrayList<String> moreChildrenFullnames) {
-                                                ViewPostDetailFragment.this.children = moreChildrenFullnames;
+                                            public void onParseCommentSuccess(ArrayList<Comment> expandedComments, String parentId, ArrayList<String> moreChildrenIds) {
+                                                ViewPostDetailFragment.this.children = moreChildrenIds;
 
                                                 hasMoreChildren = children.size() != 0;
                                                 mCommentsAdapter.addComments(expandedComments, hasMoreChildren);

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/fragments/ViewPostDetailFragment.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/fragments/ViewPostDetailFragment.java
@@ -1503,7 +1503,7 @@ public class ViewPostDetailFragment extends Fragment implements FragmentCommunic
 
         Retrofit retrofit = mAccessToken == null ? mRetrofit : mOauthRetrofit;
         FetchComment.fetchMoreComment(mExecutor, new Handler(), retrofit, mAccessToken, children, mChildrenStartingIndex,
-                0, mExpandChildren, new FetchComment.FetchMoreCommentListener() {
+                mExpandChildren, mPost.getFullName(), new FetchComment.FetchMoreCommentListener() {
                     @Override
                     public void onFetchMoreCommentSuccess(ArrayList<Comment> expandedComments, int childrenStartingIndex) {
                         hasMoreChildren = childrenStartingIndex < children.size();

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/fragments/ViewPostDetailFragment.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/fragments/ViewPostDetailFragment.java
@@ -574,6 +574,11 @@ public class ViewPostDetailFragment extends Fragment implements FragmentCommunic
 
                             fetchMoreComments();
                         }
+
+                        @Override
+                        public String getSortType() {
+                            return sortType;
+                        }
                     });
             if (mCommentsRecyclerView != null) {
                 mRecyclerView.setAdapter(mPostAdapter);
@@ -1255,6 +1260,11 @@ public class ViewPostDetailFragment extends Fragment implements FragmentCommunic
 
                                             fetchMoreComments();
                                         }
+
+                                        @Override
+                                        public String getSortType() {
+                                            return sortType;
+                                        }
                                     });
                             if (mCommentsRecyclerView != null) {
                                 mRecyclerView.setAdapter(mPostAdapter);
@@ -1500,7 +1510,7 @@ public class ViewPostDetailFragment extends Fragment implements FragmentCommunic
 
         Retrofit retrofit = mAccessToken == null ? mRetrofit : mOauthRetrofit;
         FetchComment.fetchMoreComment(mExecutor, new Handler(), retrofit, mAccessToken, children,
-                mExpandChildren, mPost.getFullName(), new FetchComment.FetchMoreCommentListener() {
+                mExpandChildren, mPost.getFullName(), sortType, new FetchComment.FetchMoreCommentListener() {
                     @Override
                     public void onFetchMoreCommentSuccess(ArrayList<Comment> expandedComments, ArrayList<String> moreChildrenIds) {
                         children = moreChildrenIds;


### PR DESCRIPTION
Summary: switched loading more comments from /info to /morechildren to get replies to those comments and to support sorting. Changed logic to send all children ids and store only ids that are not loaded yet, removing the need for `mChildrenStartingIndex`.

Fixes #800 

- Load more comments from /morechildren endpoint

  Previous implementation requested comments from /api/info which returned the comments themselves but did not include any information about their children. Also /api/info does not allow to specify sort type. On the other hand /morechildren supports sort type and it will be added in a later commit.

  I am not proud of this implementation, but I had to fight with both Reddit api response and existing code. The problem with api response is that it is a flat list of comments, not a tree structure. So the tree has to be rebuilt on our end. And the problem with existing code is that it merges "more children" node into its parent but then adds a placeholder anyways.

  The code relies on the fact that parent comment will be located before any of its children in the response. The code sequentially processes comments, tries to find their parents and either adds them to the tree or puts in a "top-level" array which will be handled by outside code.

  One possible problem is the removal of `depth` argument from parsing as I couldn't find a way to fit it in the new logic. However I also didn't experience any problems with it during my testing and the response seems to always contain depth key. Moreover current depth handling logic in ParseComment#parseCommentRecursion is broken because it does not increment depth when making a recursive call.

- Store moreChildren ids instead of fullnames

  /morechildren endpoint accepts ids instead of fullnames so there is no point in converting ids to fullnames and back

- Send all comment ids to Reddit so it can select what to display itself

  Sending all ids allows Reddit to sort them properly. Since the number of comments can be very bing, it requires using POST request instead of GET.

  This commit changes the meaning of Comment#moreChildrenIds field, now it stores only ids of comments that are not yet loaded. This simplifies the code and removes the need for Comment#moreChildrenStartingIndex

- Fetch more comments with current sort type