### PR TITLE
Display comment avatar only if it is the right user

### DIFF
--- a/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/CommentsRecyclerViewAdapter.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/CommentsRecyclerViewAdapter.java
@@ -402,12 +402,16 @@ public class CommentsRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerVi
                 if (comment.getAuthorIconUrl() == null) {
                     mFragment.loadIcon(comment.getAuthor(), (authorName, iconUrl) -> {
                         if (authorName.equals(comment.getAuthor())) {
+                            comment.setAuthorIconUrl(iconUrl);
+                        }
+
+                        Comment currentComment = getCurrentComment(holder);
+                        if (currentComment != null && authorName.equals(currentComment.getAuthor())) {
                             mGlide.load(iconUrl)
                                     .apply(RequestOptions.bitmapTransform(new RoundedCornersTransformation(72, 0)))
                                     .error(mGlide.load(R.drawable.subreddit_default_icon)
                                             .apply(RequestOptions.bitmapTransform(new RoundedCornersTransformation(72, 0))))
                                     .into(((CommentViewHolder) holder).authorIconImageView);
-                            comment.setAuthorIconUrl(iconUrl);
                         }
                     });
                 } else {
@@ -529,12 +533,16 @@ public class CommentsRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerVi
                 if (comment.getAuthorIconUrl() == null) {
                     mFragment.loadIcon(comment.getAuthor(), (authorName, iconUrl) -> {
                         if (authorName.equals(comment.getAuthor())) {
+                            comment.setAuthorIconUrl(iconUrl);
+                        }
+
+                        Comment currentComment = getCurrentComment(holder);
+                        if (currentComment != null && authorName.equals(currentComment.getAuthor())) {
                             mGlide.load(iconUrl)
                                     .apply(RequestOptions.bitmapTransform(new RoundedCornersTransformation(72, 0)))
                                     .error(mGlide.load(R.drawable.subreddit_default_icon)
                                             .apply(RequestOptions.bitmapTransform(new RoundedCornersTransformation(72, 0))))
                                     .into(((CommentFullyCollapsedViewHolder) holder).authorIconImageView);
-                            comment.setAuthorIconUrl(iconUrl);
                         }
                     });
                 } else {


### PR DESCRIPTION
Fixes #1190 

Condition in callback for loading avatar url is almost always true[1]. So it would load avatar even if the viewholder got bound to another comment.

Ideally the solution would be to update the comment just like now, then find current position of the comment and call onItemChanged. However you cannot call onItemChanged from onBindViewHolder and that is a problem because callback can be executed synchronously.

So instead we just check that viewholder is bound to some comment and that bound comment's author matches initially requested author.

[1] The only case I know when it is false is when that comment got deleted and its author got replaced with "[deleted]" before the callback got executed