### PR TITLE
wait to load security settings until successful authentication

### DIFF
--- a/app/src/main/java/ml/docilealligator/infinityforreddit/customviews/CustomFontPreferenceFragmentCompat.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/customviews/CustomFontPreferenceFragmentCompat.java
@@ -8,6 +8,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceFragmentCompat;
+import androidx.preference.PreferenceScreen;
 
 import ml.docilealligator.infinityforreddit.CustomFontReceiver;
 import ml.docilealligator.infinityforreddit.CustomThemeWrapperReceiver;
@@ -20,9 +21,13 @@ public abstract class CustomFontPreferenceFragmentCompat extends PreferenceFragm
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
 
-        int preferenceCount = getPreferenceScreen().getPreferenceCount();
+        PreferenceScreen preferenceScreen = getPreferenceScreen();
+        if (preferenceScreen == null)
+            return;
+
+        int preferenceCount = preferenceScreen.getPreferenceCount();
         for (int i = 0; i < preferenceCount; i++) {
-            Preference preference = getPreferenceScreen().getPreference(i);
+            Preference preference = preferenceScreen.getPreference(i);
             if (preference instanceof CustomThemeWrapperReceiver) {
                 ((CustomThemeWrapperReceiver) preference).setCustomThemeWrapper(activity.customThemeWrapper);
             }

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/settings/SecurityPreferenceFragment.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/settings/SecurityPreferenceFragment.java
@@ -34,8 +34,14 @@ public class SecurityPreferenceFragment extends CustomFontPreferenceFragmentComp
     @Named("default")
     SharedPreferences sharedPreferences;
 
+    String rootKey;
+
     @Override
     public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
+        this.rootKey = rootKey;
+    }
+
+    private void createPreferences() {
         PreferenceManager preferenceManager = getPreferenceManager();
         preferenceManager.setSharedPreferencesName(SharedPreferencesUtils.SECURITY_SHARED_PREFERENCES_FILE);
         setPreferencesFromResource(R.xml.security_preferences, rootKey);
@@ -80,6 +86,12 @@ public class SecurityPreferenceFragment extends CustomFontPreferenceFragmentComp
         Executor executor = ContextCompat.getMainExecutor(activity);
         BiometricPrompt biometricPrompt = new BiometricPrompt(SecurityPreferenceFragment.this,
                 executor, new BiometricPrompt.AuthenticationCallback() {
+            @Override
+            public void onAuthenticationSucceeded(@NonNull BiometricPrompt.AuthenticationResult result) {
+                super.onAuthenticationSucceeded(result);
+                createPreferences();
+            }
+
             @Override
             public void onAuthenticationError(int errorCode, @NonNull CharSequence errString) {
                 activity.onBackPressed();


### PR DESCRIPTION
When a user loads the security settings page, the only way to get the settings to load is through successful authentication. Prior to authentication, the screen stays blank.

This fixes a few problems:
1. Users being able to see the settings on this page without privileged access.
2. Users being able to modify the settings on this page without privileged access (#1195).

Closes #1195.

# Video demo

1. Successful fingerprint (goes into screen)
2. Clicking out (goes back, no settings loaded)
3. Navigating away (goes back, no settings loaded)

![video demo](https://user-images.githubusercontent.com/12687723/199137060-3c6d8276-e7e8-4e4d-b7a5-244d6f836d16.gif)
