### PR TITLE
Load sort type from correct shared preferences

### DIFF
--- a/app/src/main/java/ml/docilealligator/infinityforreddit/fragments/ViewPostDetailFragment.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/fragments/ViewPostDetailFragment.java
@@ -814,11 +814,11 @@ public class ViewPostDetailFragment extends Fragment implements FragmentCommunic
 
     @NonNull
     private SortType.Type loadSortType() {
-        String sortTypeName = mSharedPreferences.getString(SharedPreferencesUtils.SORT_TYPE_POST_COMMENT, SortType.Type.CONFIDENCE.name());
+        String sortTypeName = mSortTypeSharedPreferences.getString(SharedPreferencesUtils.SORT_TYPE_POST_COMMENT, SortType.Type.CONFIDENCE.name());
         if (SortType.Type.BEST.name().equals(sortTypeName)) {
             // migrate from BEST to CONFIDENCE
             // key guaranteed to exist because got non-default value
-            mSharedPreferences.edit()
+            mSortTypeSharedPreferences.edit()
                     .putString(SharedPreferencesUtils.SORT_TYPE_POST_COMMENT, SortType.Type.CONFIDENCE.name())
                     .apply();
             return SortType.Type.CONFIDENCE;


### PR DESCRIPTION
Fixes #1201 

When extracting sort type loading logic the shared preferences that are used to load sort type got accidentally changed to the wrong ones. This resulted in always using the default value which is displayed as Best.

Fortunately the saving code was not changed so only reading has to be fixed.

A stupid and unfortunate bug but also an example of how having a wrapper around preferences could be beneficial