### PR TITLE
Sort type converters

### DIFF
--- a/app/src/main/java/ml/docilealligator/infinityforreddit/AppModule.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/AppModule.java
@@ -22,6 +22,7 @@ import dagger.Module;
 import dagger.Provides;
 import ml.docilealligator.infinityforreddit.customtheme.CustomThemeWrapper;
 import ml.docilealligator.infinityforreddit.customviews.LoopAvailableExoCreator;
+import ml.docilealligator.infinityforreddit.network.SortTypeConverterFactory;
 import ml.docilealligator.infinityforreddit.utils.APIUtils;
 import ml.docilealligator.infinityforreddit.utils.CustomThemeSharedPreferencesUtils;
 import ml.docilealligator.infinityforreddit.utils.SharedPreferencesUtils;
@@ -50,6 +51,7 @@ class AppModule {
         return new Retrofit.Builder()
                 .baseUrl(APIUtils.OAUTH_API_BASE_URI)
                 .client(okHttpClient)
+                .addConverterFactory(SortTypeConverterFactory.create())
                 .addConverterFactory(ScalarsConverterFactory.create())
                 .addCallAdapterFactory(GuavaCallAdapterFactory.create())
                 .build();
@@ -61,6 +63,7 @@ class AppModule {
     Retrofit provideOauthWithoutAuthenticatorRetrofit() {
         return new Retrofit.Builder()
                 .baseUrl(APIUtils.OAUTH_API_BASE_URI)
+                .addConverterFactory(SortTypeConverterFactory.create())
                 .addConverterFactory(ScalarsConverterFactory.create())
                 .build();
     }
@@ -71,6 +74,7 @@ class AppModule {
     Retrofit provideRetrofit() {
         return new Retrofit.Builder()
                 .baseUrl(APIUtils.API_BASE_URI)
+                .addConverterFactory(SortTypeConverterFactory.create())
                 .addConverterFactory(ScalarsConverterFactory.create())
                 .addCallAdapterFactory(GuavaCallAdapterFactory.create())
                 .build();

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/SortType.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/SortType.java
@@ -1,23 +1,30 @@
 package ml.docilealligator.infinityforreddit;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 public class SortType {
 
-    private Type type;
-    private Time time;
+    @NonNull
+    private final Type type;
+    @Nullable
+    private final Time time;
 
-    public SortType(Type type) {
-        this.type = type;
+    public SortType(@NonNull Type type) {
+        this(type, null);
     }
 
-    public SortType(Type type, Time time) {
+    public SortType(@NonNull Type type, @Nullable Time time) {
         this.type = type;
         this.time = time;
     }
 
+    @NonNull
     public Type getType() {
         return type;
     }
 
+    @Nullable
     public Time getTime() {
         return time;
     }

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/apis/RedditAPI.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/apis/RedditAPI.java
@@ -4,6 +4,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 
 import java.util.Map;
 
+import ml.docilealligator.infinityforreddit.SortType;
 import okhttp3.MultipartBody;
 import okhttp3.RequestBody;
 import retrofit2.Call;
@@ -57,30 +58,30 @@ public interface RedditAPI {
 
     @GET("user/{username}/comments.json?raw_json=1")
     Call<String> getUserComments(@Path("username") String username, @Query("after") String after,
-                                 @Query("sort") String sortType);
+                                 @Query("sort") SortType.Type sortType);
 
     @GET("user/{username}/comments.json?raw_json=1")
     Call<String> getUserComments(@Path("username") String username, @Query("after") String after,
-                                 @Query("sort") String sortType, @Query("t") String sortTime);
+                                 @Query("sort") SortType.Type sortType, @Query("t") SortType.Time sortTime);
 
     @GET("user/{username}/comments.json?raw_json=1")
     Call<String> getUserCommentsOauth(@HeaderMap Map<String, String> headers, @Path("username") String username,
-                                      @Query("after") String after, @Query("sort") String sortType);
+                                      @Query("after") String after, @Query("sort") SortType.Type sortType);
 
     @GET("user/{username}/comments.json?raw_json=1")
     Call<String> getUserCommentsOauth(@HeaderMap Map<String, String> headers, @Path("username") String username,
-                                      @Query("after") String after, @Query("sort") String sortType,
-                                      @Query("t") String sortTime);
+                                      @Query("after") String after, @Query("sort") SortType.Type sortType,
+                                      @Query("t") SortType.Time sortTime);
 
     @GET("user/{username}/{where}.json?&type=comments&raw_json=1&limit=25")
     Call<String> getUserSavedCommentsOauth(@Path("username") String username, @Path("where") String where,
-                                           @Query("after") String lastItem, @Query("sort") String sortType,
+                                           @Query("after") String lastItem, @Query("sort") SortType.Type sortType,
                                            @HeaderMap Map<String, String> headers);
 
     @GET("user/{username}/{where}.json?&type=comments&raw_json=1&limit=25")
     Call<String> getUserSavedCommentsOauth(@Path("username") String username, @Path("where") String where,
-                                           @Query("after") String lastItem, @Query("sort") String sortType,
-                                           @Query("t") String sortTime, @HeaderMap Map<String, String> headers);
+                                           @Query("after") String lastItem, @Query("sort") SortType.Type sortType,
+                                           @Query("t") SortType.Time sortTime, @HeaderMap Map<String, String> headers);
 
     @FormUrlEncoded
     @POST("api/subscribe")
@@ -281,87 +282,87 @@ public interface RedditAPI {
     Call<String> getWikiPage(@Path("subredditName") String subredditName, @Path("wikiPage") String wikiPage);
 
     @GET("{sortType}?raw_json=1")
-    ListenableFuture<Response<String>> getBestPostsListenableFuture(@Path("sortType") String sortType, @Query("after") String lastItem, @HeaderMap Map<String, String> headers);
+    ListenableFuture<Response<String>> getBestPostsListenableFuture(@Path("sortType") SortType.Type sortType, @Query("after") String lastItem, @HeaderMap Map<String, String> headers);
 
     @GET("{sortType}?raw_json=1")
-    ListenableFuture<Response<String>> getBestPostsListenableFuture(@Path("sortType") String sortType, @Query("t") String sortTime,
+    ListenableFuture<Response<String>> getBestPostsListenableFuture(@Path("sortType") SortType.Type sortType, @Query("t") SortType.Time sortTime,
                                                                    @Query("after") String lastItem, @HeaderMap Map<String, String> headers);
 
     @GET("r/{subredditName}/{sortType}.json?raw_json=1&limit=25&always_show_media=1")
-    ListenableFuture<Response<String>> getSubredditBestPostsOauthListenableFuture(@Path("subredditName") String subredditName, @Path("sortType") String sortType,
+    ListenableFuture<Response<String>> getSubredditBestPostsOauthListenableFuture(@Path("subredditName") String subredditName, @Path("sortType") SortType.Type sortType,
                                             @Query("after") String lastItem, @HeaderMap Map<String, String> headers);
 
     @GET("r/{subredditName}/{sortType}.json?raw_json=1&limit=25&always_show_media=1")
-    ListenableFuture<Response<String>> getSubredditBestPostsOauthListenableFuture(@Path("subredditName") String subredditName, @Path("sortType") String sortType,
-                                            @Query("t") String sortTime, @Query("after") String lastItem,
+    ListenableFuture<Response<String>> getSubredditBestPostsOauthListenableFuture(@Path("subredditName") String subredditName, @Path("sortType") SortType.Type sortType,
+                                            @Query("t") SortType.Time sortTime, @Query("after") String lastItem,
                                             @HeaderMap Map<String, String> headers);
 
     @GET("r/{subredditName}/{sortType}.json?raw_json=1&limit=25&always_show_media=1")
-    ListenableFuture<Response<String>> getSubredditBestPostsListenableFuture(@Path("subredditName") String subredditName, @Path("sortType") String sortType,
+    ListenableFuture<Response<String>> getSubredditBestPostsListenableFuture(@Path("subredditName") String subredditName, @Path("sortType") SortType.Type sortType,
                                        @Query("after") String lastItem);
 
     @GET("r/{subredditName}/{sortType}.json?raw_json=1&limit=25&always_show_media=1")
-    ListenableFuture<Response<String>> getSubredditBestPostsListenableFuture(@Path("subredditName") String subredditName, @Path("sortType") String sortType,
-                                       @Query("t") String sortTime, @Query("after") String lastItem);
+    ListenableFuture<Response<String>> getSubredditBestPostsListenableFuture(@Path("subredditName") String subredditName, @Path("sortType") SortType.Type sortType,
+                                       @Query("t") SortType.Time sortTime, @Query("after") String lastItem);
 
     @GET("user/{username}/{where}.json?&type=links&raw_json=1&limit=25")
     ListenableFuture<Response<String>> getUserPostsOauthListenableFuture(@Path("username") String username, @Path("where") String where,
-                                   @Query("after") String lastItem, @Query("sort") String sortType, @HeaderMap Map<String, String> headers);
+                                   @Query("after") String lastItem, @Query("sort") SortType.Type sortType, @HeaderMap Map<String, String> headers);
 
     @GET("user/{username}/{where}.json?&type=links&raw_json=1&limit=25")
     ListenableFuture<Response<String>> getUserPostsOauthListenableFuture(@Path("username") String username, @Path("where") String where,
-                                   @Query("after") String lastItem, @Query("sort") String sortType,
-                                   @Query("t") String sortTime, @HeaderMap Map<String, String> headers);
+                                   @Query("after") String lastItem, @Query("sort") SortType.Type sortType,
+                                   @Query("t") SortType.Time sortTime, @HeaderMap Map<String, String> headers);
 
     @GET("user/{username}/submitted.json?raw_json=1&limit=25")
     ListenableFuture<Response<String>> getUserPostsListenableFuture(@Path("username") String username, @Query("after") String lastItem,
-                              @Query("sort") String sortType);
+                              @Query("sort") SortType.Type sortType);
 
     @GET("user/{username}/submitted.json?raw_json=1&limit=25")
     ListenableFuture<Response<String>> getUserPostsListenableFuture(@Path("username") String username, @Query("after") String lastItem,
-                              @Query("sort") String sortType, @Query("t") String sortTime);
+                              @Query("sort") SortType.Type sortType, @Query("t") SortType.Time sortTime);
 
     @GET("search.json?include_over_18=1&raw_json=1&type=link")
     ListenableFuture<Response<String>> searchPostsOauthListenableFuture(@Query("q") String query, @Query("after") String after,
-                                  @Query("sort") String sort, @Query("source") String source,
+                                  @Query("sort") SortType.Type sort, @Query("source") String source,
                                   @HeaderMap Map<String, String> headers);
 
     @GET("search.json?include_over_18=1&raw_json=1&type=link")
     ListenableFuture<Response<String>> searchPostsOauthListenableFuture(@Query("q") String query, @Query("after") String after,
-                                  @Query("sort") String sort, @Query("t") String sortTime,
+                                  @Query("sort") SortType.Type sort, @Query("t") SortType.Time sortTime,
                                   @Query("source") String source,
                                   @HeaderMap Map<String, String> headers);
 
     @GET("search.json?include_over_18=1&raw_json=1&type=link")
     ListenableFuture<Response<String>> searchPostsListenableFuture(@Query("q") String query, @Query("after") String after,
-                             @Query("sort") String sort, @Query("source") String source);
+                             @Query("sort") SortType.Type sort, @Query("source") String source);
 
     @GET("search.json?include_over_18=1&raw_json=1&type=link")
     ListenableFuture<Response<String>> searchPostsListenableFuture(@Query("q") String query, @Query("after") String after,
-                             @Query("sort") String sort, @Query("t") String sortTime,
+                             @Query("sort") SortType.Type sort, @Query("t") SortType.Time sortTime,
                              @Query("source") String source);
 
     @GET("r/{subredditName}/search.json?include_over_18=1&raw_json=1&type=link&restrict_sr=true")
     ListenableFuture<Response<String>> searchPostsInSpecificSubredditOauthListenableFuture(@Path("subredditName") String subredditName,
-                                                     @Query("q") String query, @Query("sort") String sort,
+                                                     @Query("q") String query, @Query("sort") SortType.Type sort,
                                                      @Query("after") String after,
                                                      @HeaderMap Map<String, String> headers);
 
     @GET("r/{subredditName}/search.json?include_over_18=1&raw_json=1&type=link&restrict_sr=true")
     ListenableFuture<Response<String>> searchPostsInSpecificSubredditOauthListenableFuture(@Path("subredditName") String subredditName,
-                                                     @Query("q") String query, @Query("sort") String sort,
-                                                     @Query("t") String sortTime, @Query("after") String after,
+                                                     @Query("q") String query, @Query("sort") SortType.Type sort,
+                                                     @Query("t") SortType.Time sortTime, @Query("after") String after,
                                                      @HeaderMap Map<String, String> headers);
 
     @GET("r/{subredditName}/search.json?include_over_18=1&raw_json=1&type=link&restrict_sr=true")
     ListenableFuture<Response<String>> searchPostsInSpecificSubredditListenableFuture(@Path("subredditName") String subredditName,
-                                                @Query("q") String query, @Query("sort") String sort,
+                                                @Query("q") String query, @Query("sort") SortType.Type sort,
                                                 @Query("after") String after);
 
     @GET("r/{subredditName}/search.json?include_over_18=1&raw_json=1&type=link&restrict_sr=true")
     ListenableFuture<Response<String>> searchPostsInSpecificSubredditListenableFuture(@Path("subredditName") String subredditName,
-                                                @Query("q") String query, @Query("sort") String sort,
-                                                @Query("t") String sortTime, @Query("after") String after);
+                                                @Query("q") String query, @Query("sort") SortType.Type sort,
+                                                @Query("t") SortType.Time sortTime, @Query("after") String after);
 
     @GET("{multipath}?raw_json=1")
     ListenableFuture<Response<String>> getMultiRedditPostsListenableFuture(@Path(value = "multipath", encoded = true) String multiPath,
@@ -369,11 +370,11 @@ public interface RedditAPI {
 
     @GET("{multipath}?raw_json=1")
     ListenableFuture<Response<String>> getMultiRedditPostsListenableFuture(@Path(value = "multipath", encoded = true) String multiPath,
-                                     @Query("after") String after, @Query("t") String sortTime);
+                                     @Query("after") String after, @Query("t") SortType.Time sortTime);
 
     @GET("{multipath}.json?raw_json=1")
     ListenableFuture<Response<String>> getMultiRedditPostsOauthListenableFuture(@Path(value = "multipath", encoded = true) String multiPath,
-                                          @Query("after") String after, @Query("t") String sortTime,
+                                          @Query("after") String after, @Query("t") SortType.Time sortTime,
                                           @HeaderMap Map<String, String> headers);
 
     @GET("{multipath}.json?raw_json=1")

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/apis/RedditAPI.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/apis/RedditAPI.java
@@ -282,15 +282,8 @@ public interface RedditAPI {
     Call<String> getWikiPage(@Path("subredditName") String subredditName, @Path("wikiPage") String wikiPage);
 
     @GET("{sortType}?raw_json=1")
-    ListenableFuture<Response<String>> getBestPostsListenableFuture(@Path("sortType") SortType.Type sortType, @Query("after") String lastItem, @HeaderMap Map<String, String> headers);
-
-    @GET("{sortType}?raw_json=1")
     ListenableFuture<Response<String>> getBestPostsListenableFuture(@Path("sortType") SortType.Type sortType, @Query("t") SortType.Time sortTime,
                                                                    @Query("after") String lastItem, @HeaderMap Map<String, String> headers);
-
-    @GET("r/{subredditName}/{sortType}.json?raw_json=1&limit=25&always_show_media=1")
-    ListenableFuture<Response<String>> getSubredditBestPostsOauthListenableFuture(@Path("subredditName") String subredditName, @Path("sortType") SortType.Type sortType,
-                                            @Query("after") String lastItem, @HeaderMap Map<String, String> headers);
 
     @GET("r/{subredditName}/{sortType}.json?raw_json=1&limit=25&always_show_media=1")
     ListenableFuture<Response<String>> getSubredditBestPostsOauthListenableFuture(@Path("subredditName") String subredditName, @Path("sortType") SortType.Type sortType,
@@ -299,15 +292,7 @@ public interface RedditAPI {
 
     @GET("r/{subredditName}/{sortType}.json?raw_json=1&limit=25&always_show_media=1")
     ListenableFuture<Response<String>> getSubredditBestPostsListenableFuture(@Path("subredditName") String subredditName, @Path("sortType") SortType.Type sortType,
-                                       @Query("after") String lastItem);
-
-    @GET("r/{subredditName}/{sortType}.json?raw_json=1&limit=25&always_show_media=1")
-    ListenableFuture<Response<String>> getSubredditBestPostsListenableFuture(@Path("subredditName") String subredditName, @Path("sortType") SortType.Type sortType,
                                        @Query("t") SortType.Time sortTime, @Query("after") String lastItem);
-
-    @GET("user/{username}/{where}.json?&type=links&raw_json=1&limit=25")
-    ListenableFuture<Response<String>> getUserPostsOauthListenableFuture(@Path("username") String username, @Path("where") String where,
-                                   @Query("after") String lastItem, @Query("sort") SortType.Type sortType, @HeaderMap Map<String, String> headers);
 
     @GET("user/{username}/{where}.json?&type=links&raw_json=1&limit=25")
     ListenableFuture<Response<String>> getUserPostsOauthListenableFuture(@Path("username") String username, @Path("where") String where,
@@ -316,16 +301,7 @@ public interface RedditAPI {
 
     @GET("user/{username}/submitted.json?raw_json=1&limit=25")
     ListenableFuture<Response<String>> getUserPostsListenableFuture(@Path("username") String username, @Query("after") String lastItem,
-                              @Query("sort") SortType.Type sortType);
-
-    @GET("user/{username}/submitted.json?raw_json=1&limit=25")
-    ListenableFuture<Response<String>> getUserPostsListenableFuture(@Path("username") String username, @Query("after") String lastItem,
                               @Query("sort") SortType.Type sortType, @Query("t") SortType.Time sortTime);
-
-    @GET("search.json?include_over_18=1&raw_json=1&type=link")
-    ListenableFuture<Response<String>> searchPostsOauthListenableFuture(@Query("q") String query, @Query("after") String after,
-                                  @Query("sort") SortType.Type sort, @Query("source") String source,
-                                  @HeaderMap Map<String, String> headers);
 
     @GET("search.json?include_over_18=1&raw_json=1&type=link")
     ListenableFuture<Response<String>> searchPostsOauthListenableFuture(@Query("q") String query, @Query("after") String after,
@@ -335,18 +311,8 @@ public interface RedditAPI {
 
     @GET("search.json?include_over_18=1&raw_json=1&type=link")
     ListenableFuture<Response<String>> searchPostsListenableFuture(@Query("q") String query, @Query("after") String after,
-                             @Query("sort") SortType.Type sort, @Query("source") String source);
-
-    @GET("search.json?include_over_18=1&raw_json=1&type=link")
-    ListenableFuture<Response<String>> searchPostsListenableFuture(@Query("q") String query, @Query("after") String after,
                              @Query("sort") SortType.Type sort, @Query("t") SortType.Time sortTime,
                              @Query("source") String source);
-
-    @GET("r/{subredditName}/search.json?include_over_18=1&raw_json=1&type=link&restrict_sr=true")
-    ListenableFuture<Response<String>> searchPostsInSpecificSubredditOauthListenableFuture(@Path("subredditName") String subredditName,
-                                                     @Query("q") String query, @Query("sort") SortType.Type sort,
-                                                     @Query("after") String after,
-                                                     @HeaderMap Map<String, String> headers);
 
     @GET("r/{subredditName}/search.json?include_over_18=1&raw_json=1&type=link&restrict_sr=true")
     ListenableFuture<Response<String>> searchPostsInSpecificSubredditOauthListenableFuture(@Path("subredditName") String subredditName,
@@ -357,16 +323,7 @@ public interface RedditAPI {
     @GET("r/{subredditName}/search.json?include_over_18=1&raw_json=1&type=link&restrict_sr=true")
     ListenableFuture<Response<String>> searchPostsInSpecificSubredditListenableFuture(@Path("subredditName") String subredditName,
                                                 @Query("q") String query, @Query("sort") SortType.Type sort,
-                                                @Query("after") String after);
-
-    @GET("r/{subredditName}/search.json?include_over_18=1&raw_json=1&type=link&restrict_sr=true")
-    ListenableFuture<Response<String>> searchPostsInSpecificSubredditListenableFuture(@Path("subredditName") String subredditName,
-                                                @Query("q") String query, @Query("sort") SortType.Type sort,
                                                 @Query("t") SortType.Time sortTime, @Query("after") String after);
-
-    @GET("{multipath}?raw_json=1")
-    ListenableFuture<Response<String>> getMultiRedditPostsListenableFuture(@Path(value = "multipath", encoded = true) String multiPath,
-                                     @Query("after") String after);
 
     @GET("{multipath}?raw_json=1")
     ListenableFuture<Response<String>> getMultiRedditPostsListenableFuture(@Path(value = "multipath", encoded = true) String multiPath,
@@ -376,10 +333,6 @@ public interface RedditAPI {
     ListenableFuture<Response<String>> getMultiRedditPostsOauthListenableFuture(@Path(value = "multipath", encoded = true) String multiPath,
                                           @Query("after") String after, @Query("t") SortType.Time sortTime,
                                           @HeaderMap Map<String, String> headers);
-
-    @GET("{multipath}.json?raw_json=1")
-    ListenableFuture<Response<String>> getMultiRedditPostsOauthListenableFuture(@Path(value = "multipath", encoded = true) String multiPath,
-                                          @Query("after") String after, @HeaderMap Map<String, String> headers);
 
     @GET("{sortType}?raw_json=1")
     Call<String> getBestPosts(@Path("sortType") String sortType, @Query("after") String lastItem, @HeaderMap Map<String, String> headers);

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/comment/CommentDataSource.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/comment/CommentDataSource.java
@@ -80,27 +80,27 @@ public class CommentDataSource extends PageKeyedDataSource<String, Comment> {
         if (areSavedComments) {
             if (sortType.getTime() != null) {
                 commentsCall = api.getUserSavedCommentsOauth(username, PostPagingSource.USER_WHERE_SAVED,
-                        null, sortType.getType().value, sortType.getTime().value,
+                        null, sortType.getType(), sortType.getTime(),
                         APIUtils.getOAuthHeader(accessToken));
             } else {
                 commentsCall = api.getUserSavedCommentsOauth(username, PostPagingSource.USER_WHERE_SAVED,
-                        null, sortType.getType().value, APIUtils.getOAuthHeader(accessToken));
+                        null, sortType.getType(), APIUtils.getOAuthHeader(accessToken));
             }
         } else {
             if (accessToken == null) {
                 if (sortType.getTime() != null) {
-                    commentsCall = api.getUserComments(username, null, sortType.getType().value,
-                            sortType.getTime().value);
+                    commentsCall = api.getUserComments(username, null, sortType.getType(),
+                            sortType.getTime());
                 } else {
-                    commentsCall = api.getUserComments(username, null, sortType.getType().value);
+                    commentsCall = api.getUserComments(username, null, sortType.getType());
                 }
             } else {
                 if (sortType.getTime() != null) {
                     commentsCall = api.getUserCommentsOauth(APIUtils.getOAuthHeader(accessToken), username,
-                            null, sortType.getType().value, sortType.getTime().value);
+                            null, sortType.getType(), sortType.getTime());
                 } else {
                     commentsCall = api.getUserCommentsOauth(APIUtils.getOAuthHeader(accessToken), username,
-                            null, sortType.getType().value);
+                            null, sortType.getType());
                 }
             }
         }
@@ -159,26 +159,26 @@ public class CommentDataSource extends PageKeyedDataSource<String, Comment> {
         if (areSavedComments) {
             if (sortType.getTime() != null) {
                 commentsCall = api.getUserSavedCommentsOauth(username, PostPagingSource.USER_WHERE_SAVED, params.key,
-                        sortType.getType().value, sortType.getTime().value, APIUtils.getOAuthHeader(accessToken));
+                        sortType.getType(), sortType.getTime(), APIUtils.getOAuthHeader(accessToken));
             } else {
                 commentsCall = api.getUserSavedCommentsOauth(username, PostPagingSource.USER_WHERE_SAVED, params.key,
-                        sortType.getType().value, APIUtils.getOAuthHeader(accessToken));
+                        sortType.getType(), APIUtils.getOAuthHeader(accessToken));
             }
         } else {
             if (accessToken == null) {
                 if (sortType.getTime() != null) {
-                    commentsCall = api.getUserComments(username, params.key, sortType.getType().value,
-                            sortType.getTime().value);
+                    commentsCall = api.getUserComments(username, params.key, sortType.getType(),
+                            sortType.getTime());
                 } else {
-                    commentsCall = api.getUserComments(username, params.key, sortType.getType().value);
+                    commentsCall = api.getUserComments(username, params.key, sortType.getType());
                 }
             } else {
                 if (sortType.getTime() != null) {
                     commentsCall = api.getUserCommentsOauth(APIUtils.getOAuthHeader(accessToken),
-                            username, params.key, sortType.getType().value, sortType.getTime().value);
+                            username, params.key, sortType.getType(), sortType.getTime());
                 } else {
                     commentsCall = api.getUserCommentsOauth(APIUtils.getOAuthHeader(accessToken),
-                            username, params.key, sortType.getType().value);
+                            username, params.key, sortType.getType());
                 }
             }
         }

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/comment/CommentDataSource.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/comment/CommentDataSource.java
@@ -78,30 +78,16 @@ public class CommentDataSource extends PageKeyedDataSource<String, Comment> {
         RedditAPI api = retrofit.create(RedditAPI.class);
         Call<String> commentsCall;
         if (areSavedComments) {
-            if (sortType.getTime() != null) {
-                commentsCall = api.getUserSavedCommentsOauth(username, PostPagingSource.USER_WHERE_SAVED,
-                        null, sortType.getType(), sortType.getTime(),
-                        APIUtils.getOAuthHeader(accessToken));
-            } else {
-                commentsCall = api.getUserSavedCommentsOauth(username, PostPagingSource.USER_WHERE_SAVED,
-                        null, sortType.getType(), APIUtils.getOAuthHeader(accessToken));
-            }
+            commentsCall = api.getUserSavedCommentsOauth(username, PostPagingSource.USER_WHERE_SAVED,
+                    null, sortType.getType(), sortType.getTime(),
+                    APIUtils.getOAuthHeader(accessToken));
         } else {
             if (accessToken == null) {
-                if (sortType.getTime() != null) {
-                    commentsCall = api.getUserComments(username, null, sortType.getType(),
-                            sortType.getTime());
-                } else {
-                    commentsCall = api.getUserComments(username, null, sortType.getType());
-                }
+                commentsCall = api.getUserComments(username, null, sortType.getType(),
+                        sortType.getTime());
             } else {
-                if (sortType.getTime() != null) {
-                    commentsCall = api.getUserCommentsOauth(APIUtils.getOAuthHeader(accessToken), username,
-                            null, sortType.getType(), sortType.getTime());
-                } else {
-                    commentsCall = api.getUserCommentsOauth(APIUtils.getOAuthHeader(accessToken), username,
-                            null, sortType.getType());
-                }
+                commentsCall = api.getUserCommentsOauth(APIUtils.getOAuthHeader(accessToken), username,
+                        null, sortType.getType(), sortType.getTime());
             }
         }
         commentsCall.enqueue(new Callback<String>() {
@@ -157,29 +143,15 @@ public class CommentDataSource extends PageKeyedDataSource<String, Comment> {
         RedditAPI api = retrofit.create(RedditAPI.class);
         Call<String> commentsCall;
         if (areSavedComments) {
-            if (sortType.getTime() != null) {
-                commentsCall = api.getUserSavedCommentsOauth(username, PostPagingSource.USER_WHERE_SAVED, params.key,
-                        sortType.getType(), sortType.getTime(), APIUtils.getOAuthHeader(accessToken));
-            } else {
-                commentsCall = api.getUserSavedCommentsOauth(username, PostPagingSource.USER_WHERE_SAVED, params.key,
-                        sortType.getType(), APIUtils.getOAuthHeader(accessToken));
-            }
+            commentsCall = api.getUserSavedCommentsOauth(username, PostPagingSource.USER_WHERE_SAVED, params.key,
+                    sortType.getType(), sortType.getTime(), APIUtils.getOAuthHeader(accessToken));
         } else {
             if (accessToken == null) {
-                if (sortType.getTime() != null) {
-                    commentsCall = api.getUserComments(username, params.key, sortType.getType(),
-                            sortType.getTime());
-                } else {
-                    commentsCall = api.getUserComments(username, params.key, sortType.getType());
-                }
+                commentsCall = api.getUserComments(username, params.key, sortType.getType(),
+                        sortType.getTime());
             } else {
-                if (sortType.getTime() != null) {
-                    commentsCall = api.getUserCommentsOauth(APIUtils.getOAuthHeader(accessToken),
-                            username, params.key, sortType.getType(), sortType.getTime());
-                } else {
-                    commentsCall = api.getUserCommentsOauth(APIUtils.getOAuthHeader(accessToken),
-                            username, params.key, sortType.getType());
-                }
+                commentsCall = api.getUserCommentsOauth(APIUtils.getOAuthHeader(accessToken),
+                        username, params.key, sortType.getType(), sortType.getTime());
             }
         }
         commentsCall.enqueue(new Callback<String>() {

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/network/SortTypeConverter.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/network/SortTypeConverter.java
@@ -1,0 +1,29 @@
+package ml.docilealligator.infinityforreddit.network;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.io.IOException;
+
+import ml.docilealligator.infinityforreddit.SortType;
+import retrofit2.Converter;
+
+/**
+ * A {@link Converter} for {@link SortType.Type sort type} and {@link SortType.Time sort time} to
+ * {@link String} parameters
+ */
+public class SortTypeConverter<T> implements Converter<T, String> {
+    /* package */ static SortTypeConverter<Object> INSTANCE = new SortTypeConverter<>();
+
+    @Nullable
+    @Override
+    public String convert(@NonNull T value) throws IOException {
+        if (value instanceof SortType.Type) {
+            return ((SortType.Type) value).value;
+        } else if (value instanceof SortType.Time) {
+            return ((SortType.Time) value).value;
+        } else {
+            return null;
+        }
+    }
+}

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/network/SortTypeConverterFactory.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/network/SortTypeConverterFactory.java
@@ -1,0 +1,30 @@
+package ml.docilealligator.infinityforreddit.network;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+import ml.docilealligator.infinityforreddit.SortType;
+import retrofit2.Converter;
+import retrofit2.Retrofit;
+
+/**
+ * A {@link Converter.Factory} for {@link SortType.Type sort type} and {@link SortType.Time sort time} to
+ * {@link String} parameters
+ */
+public class SortTypeConverterFactory extends Converter.Factory {
+    public static SortTypeConverterFactory create() {
+        return new SortTypeConverterFactory();
+    }
+
+    @Nullable
+    @Override
+    public Converter<?, String> stringConverter(@NonNull Type type, @NonNull Annotation[] annotations, @NonNull Retrofit retrofit) {
+        if (type == SortType.Type.class || type == SortType.Time.class) {
+            return SortTypeConverter.INSTANCE;
+        }
+        return null;
+    }
+}

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/post/PostPagingSource.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/post/PostPagingSource.java
@@ -214,12 +214,8 @@ public class PostPagingSource extends ListenableFuturePagingSource<String, Post>
         } else {
             afterKey = loadParams.getKey();
         }
-        if (sortType.getTime() != null) {
-            bestPost = api.getBestPostsListenableFuture(sortType.getType(), sortType.getTime(), afterKey,
-                    APIUtils.getOAuthHeader(accessToken));
-        } else {
-            bestPost = api.getBestPostsListenableFuture(sortType.getType(), afterKey, APIUtils.getOAuthHeader(accessToken));
-        }
+        bestPost = api.getBestPostsListenableFuture(sortType.getType(), sortType.getTime(), afterKey,
+                APIUtils.getOAuthHeader(accessToken));
 
         ListenableFuture<LoadResult<String, Post>> pageFuture = Futures.transform(bestPost, this::transformData, executor);
 
@@ -234,19 +230,10 @@ public class PostPagingSource extends ListenableFuturePagingSource<String, Post>
     private ListenableFuture<LoadResult<String, Post>> loadSubredditPosts(@NonNull LoadParams<String> loadParams, RedditAPI api) {
         ListenableFuture<Response<String>> subredditPost;
         if (accessToken == null) {
-            if (sortType.getTime() != null) {
-                subredditPost = api.getSubredditBestPostsListenableFuture(subredditOrUserName, sortType.getType(), sortType.getTime(), loadParams.getKey());
-            } else {
-                subredditPost = api.getSubredditBestPostsListenableFuture(subredditOrUserName, sortType.getType(), loadParams.getKey());
-            }
+            subredditPost = api.getSubredditBestPostsListenableFuture(subredditOrUserName, sortType.getType(), sortType.getTime(), loadParams.getKey());
         } else {
-            if (sortType.getTime() != null) {
-                subredditPost = api.getSubredditBestPostsOauthListenableFuture(subredditOrUserName, sortType.getType(),
-                        sortType.getTime(), loadParams.getKey(), APIUtils.getOAuthHeader(accessToken));
-            } else {
-                subredditPost = api.getSubredditBestPostsOauthListenableFuture(subredditOrUserName, sortType.getType(),
-                        loadParams.getKey(), APIUtils.getOAuthHeader(accessToken));
-            }
+            subredditPost = api.getSubredditBestPostsOauthListenableFuture(subredditOrUserName, sortType.getType(),
+                    sortType.getTime(), loadParams.getKey(), APIUtils.getOAuthHeader(accessToken));
         }
 
         ListenableFuture<LoadResult<String, Post>> pageFuture = Futures.transform(subredditPost, this::transformData, executor);
@@ -262,20 +249,11 @@ public class PostPagingSource extends ListenableFuturePagingSource<String, Post>
     private ListenableFuture<LoadResult<String, Post>> loadUserPosts(@NonNull LoadParams<String> loadParams, RedditAPI api) {
         ListenableFuture<Response<String>> userPosts;
         if (accessToken == null) {
-            if (sortType.getTime() != null) {
-                userPosts = api.getUserPostsListenableFuture(subredditOrUserName, loadParams.getKey(), sortType.getType(),
-                        sortType.getTime());
-            } else {
-                userPosts = api.getUserPostsListenableFuture(subredditOrUserName, loadParams.getKey(), sortType.getType());
-            }
+            userPosts = api.getUserPostsListenableFuture(subredditOrUserName, loadParams.getKey(), sortType.getType(),
+                    sortType.getTime());
         } else {
-            if (sortType.getTime() != null) {
-                userPosts = api.getUserPostsOauthListenableFuture(subredditOrUserName, userWhere, loadParams.getKey(), sortType.getType(),
-                        sortType.getTime(), APIUtils.getOAuthHeader(accessToken));
-            } else {
-                userPosts = api.getUserPostsOauthListenableFuture(subredditOrUserName, userWhere, loadParams.getKey(), sortType.getType(),
-                        APIUtils.getOAuthHeader(accessToken));
-            }
+            userPosts = api.getUserPostsOauthListenableFuture(subredditOrUserName, userWhere, loadParams.getKey(), sortType.getType(),
+                    sortType.getTime(), APIUtils.getOAuthHeader(accessToken));
         }
 
         ListenableFuture<LoadResult<String, Post>> pageFuture = Futures.transform(userPosts, this::transformData, executor);
@@ -292,40 +270,20 @@ public class PostPagingSource extends ListenableFuturePagingSource<String, Post>
         ListenableFuture<Response<String>> searchPosts;
         if (subredditOrUserName == null) {
             if (accessToken == null) {
-                if (sortType.getTime() != null) {
-                    searchPosts = api.searchPostsListenableFuture(query, loadParams.getKey(), sortType.getType(), sortType.getTime(),
-                            trendingSource);
-                } else {
-                    searchPosts = api.searchPostsListenableFuture(query, loadParams.getKey(), sortType.getType(), trendingSource);
-                }
+                searchPosts = api.searchPostsListenableFuture(query, loadParams.getKey(), sortType.getType(), sortType.getTime(),
+                        trendingSource);
             } else {
-                if (sortType.getTime() != null) {
-                    searchPosts = api.searchPostsOauthListenableFuture(query, loadParams.getKey(), sortType.getType(),
-                            sortType.getTime(), trendingSource, APIUtils.getOAuthHeader(accessToken));
-                } else {
-                    searchPosts = api.searchPostsOauthListenableFuture(query, loadParams.getKey(), sortType.getType(), trendingSource,
-                            APIUtils.getOAuthHeader(accessToken));
-                }
+                searchPosts = api.searchPostsOauthListenableFuture(query, loadParams.getKey(), sortType.getType(),
+                        sortType.getTime(), trendingSource, APIUtils.getOAuthHeader(accessToken));
             }
         } else {
             if (accessToken == null) {
-                if (sortType.getTime() != null) {
-                    searchPosts = api.searchPostsInSpecificSubredditListenableFuture(subredditOrUserName, query,
-                            sortType.getType(), sortType.getTime(), loadParams.getKey());
-                } else {
-                    searchPosts = api.searchPostsInSpecificSubredditListenableFuture(subredditOrUserName, query,
-                            sortType.getType(), loadParams.getKey());
-                }
+                searchPosts = api.searchPostsInSpecificSubredditListenableFuture(subredditOrUserName, query,
+                        sortType.getType(), sortType.getTime(), loadParams.getKey());
             } else {
-                if (sortType.getTime() != null) {
-                    searchPosts = api.searchPostsInSpecificSubredditOauthListenableFuture(subredditOrUserName, query,
-                            sortType.getType(), sortType.getTime(), loadParams.getKey(),
-                            APIUtils.getOAuthHeader(accessToken));
-                } else {
-                    searchPosts = api.searchPostsInSpecificSubredditOauthListenableFuture(subredditOrUserName, query,
-                            sortType.getType(), loadParams.getKey(),
-                            APIUtils.getOAuthHeader(accessToken));
-                }
+                searchPosts = api.searchPostsInSpecificSubredditOauthListenableFuture(subredditOrUserName, query,
+                        sortType.getType(), sortType.getTime(), loadParams.getKey(),
+                        APIUtils.getOAuthHeader(accessToken));
             }
         }
 
@@ -342,19 +300,10 @@ public class PostPagingSource extends ListenableFuturePagingSource<String, Post>
     private ListenableFuture<LoadResult<String, Post>> loadMultiRedditPosts(@NonNull LoadParams<String> loadParams, RedditAPI api) {
         ListenableFuture<Response<String>> multiRedditPosts;
         if (accessToken == null) {
-            if (sortType.getTime() != null) {
-                multiRedditPosts = api.getMultiRedditPostsListenableFuture(multiRedditPath, loadParams.getKey(), sortType.getTime());
-            } else {
-                multiRedditPosts = api.getMultiRedditPostsListenableFuture(multiRedditPath, loadParams.getKey());
-            }
+            multiRedditPosts = api.getMultiRedditPostsListenableFuture(multiRedditPath, loadParams.getKey(), sortType.getTime());
         } else {
-            if (sortType.getTime() != null) {
-                multiRedditPosts = api.getMultiRedditPostsOauthListenableFuture(multiRedditPath, loadParams.getKey(),
-                        sortType.getTime(), APIUtils.getOAuthHeader(accessToken));
-            } else {
-                multiRedditPosts = api.getMultiRedditPostsOauthListenableFuture(multiRedditPath, loadParams.getKey(),
-                        APIUtils.getOAuthHeader(accessToken));
-            }
+            multiRedditPosts = api.getMultiRedditPostsOauthListenableFuture(multiRedditPath, loadParams.getKey(),
+                    sortType.getTime(), APIUtils.getOAuthHeader(accessToken));
         }
 
         ListenableFuture<LoadResult<String, Post>> pageFuture = Futures.transform(multiRedditPosts, this::transformData, executor);
@@ -369,11 +318,7 @@ public class PostPagingSource extends ListenableFuturePagingSource<String, Post>
 
     private ListenableFuture<LoadResult<String, Post>> loadAnonymousHomePosts(@NonNull LoadParams<String> loadParams, RedditAPI api) {
         ListenableFuture<Response<String>> anonymousHomePosts;
-        if (sortType.getTime() != null) {
-            anonymousHomePosts = api.getSubredditBestPostsListenableFuture(subredditOrUserName, sortType.getType(), sortType.getTime(), loadParams.getKey());
-        } else {
-            anonymousHomePosts = api.getSubredditBestPostsListenableFuture(subredditOrUserName, sortType.getType(), loadParams.getKey());
-        }
+        anonymousHomePosts = api.getSubredditBestPostsListenableFuture(subredditOrUserName, sortType.getType(), sortType.getTime(), loadParams.getKey());
 
         ListenableFuture<LoadResult<String, Post>> pageFuture = Futures.transform(anonymousHomePosts, this::transformData, executor);
 

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/post/PostPagingSource.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/post/PostPagingSource.java
@@ -215,10 +215,10 @@ public class PostPagingSource extends ListenableFuturePagingSource<String, Post>
             afterKey = loadParams.getKey();
         }
         if (sortType.getTime() != null) {
-            bestPost = api.getBestPostsListenableFuture(sortType.getType().value, sortType.getTime().value, afterKey,
+            bestPost = api.getBestPostsListenableFuture(sortType.getType(), sortType.getTime(), afterKey,
                     APIUtils.getOAuthHeader(accessToken));
         } else {
-            bestPost = api.getBestPostsListenableFuture(sortType.getType().value, afterKey, APIUtils.getOAuthHeader(accessToken));
+            bestPost = api.getBestPostsListenableFuture(sortType.getType(), afterKey, APIUtils.getOAuthHeader(accessToken));
         }
 
         ListenableFuture<LoadResult<String, Post>> pageFuture = Futures.transform(bestPost, this::transformData, executor);
@@ -235,16 +235,16 @@ public class PostPagingSource extends ListenableFuturePagingSource<String, Post>
         ListenableFuture<Response<String>> subredditPost;
         if (accessToken == null) {
             if (sortType.getTime() != null) {
-                subredditPost = api.getSubredditBestPostsListenableFuture(subredditOrUserName, sortType.getType().value, sortType.getTime().value, loadParams.getKey());
+                subredditPost = api.getSubredditBestPostsListenableFuture(subredditOrUserName, sortType.getType(), sortType.getTime(), loadParams.getKey());
             } else {
-                subredditPost = api.getSubredditBestPostsListenableFuture(subredditOrUserName, sortType.getType().value, loadParams.getKey());
+                subredditPost = api.getSubredditBestPostsListenableFuture(subredditOrUserName, sortType.getType(), loadParams.getKey());
             }
         } else {
             if (sortType.getTime() != null) {
-                subredditPost = api.getSubredditBestPostsOauthListenableFuture(subredditOrUserName, sortType.getType().value,
-                        sortType.getTime().value, loadParams.getKey(), APIUtils.getOAuthHeader(accessToken));
+                subredditPost = api.getSubredditBestPostsOauthListenableFuture(subredditOrUserName, sortType.getType(),
+                        sortType.getTime(), loadParams.getKey(), APIUtils.getOAuthHeader(accessToken));
             } else {
-                subredditPost = api.getSubredditBestPostsOauthListenableFuture(subredditOrUserName, sortType.getType().value,
+                subredditPost = api.getSubredditBestPostsOauthListenableFuture(subredditOrUserName, sortType.getType(),
                         loadParams.getKey(), APIUtils.getOAuthHeader(accessToken));
             }
         }
@@ -263,17 +263,17 @@ public class PostPagingSource extends ListenableFuturePagingSource<String, Post>
         ListenableFuture<Response<String>> userPosts;
         if (accessToken == null) {
             if (sortType.getTime() != null) {
-                userPosts = api.getUserPostsListenableFuture(subredditOrUserName, loadParams.getKey(), sortType.getType().value,
-                        sortType.getTime().value);
+                userPosts = api.getUserPostsListenableFuture(subredditOrUserName, loadParams.getKey(), sortType.getType(),
+                        sortType.getTime());
             } else {
-                userPosts = api.getUserPostsListenableFuture(subredditOrUserName, loadParams.getKey(), sortType.getType().value);
+                userPosts = api.getUserPostsListenableFuture(subredditOrUserName, loadParams.getKey(), sortType.getType());
             }
         } else {
             if (sortType.getTime() != null) {
-                userPosts = api.getUserPostsOauthListenableFuture(subredditOrUserName, userWhere, loadParams.getKey(), sortType.getType().value,
-                        sortType.getTime().value, APIUtils.getOAuthHeader(accessToken));
+                userPosts = api.getUserPostsOauthListenableFuture(subredditOrUserName, userWhere, loadParams.getKey(), sortType.getType(),
+                        sortType.getTime(), APIUtils.getOAuthHeader(accessToken));
             } else {
-                userPosts = api.getUserPostsOauthListenableFuture(subredditOrUserName, userWhere, loadParams.getKey(), sortType.getType().value,
+                userPosts = api.getUserPostsOauthListenableFuture(subredditOrUserName, userWhere, loadParams.getKey(), sortType.getType(),
                         APIUtils.getOAuthHeader(accessToken));
             }
         }
@@ -293,17 +293,17 @@ public class PostPagingSource extends ListenableFuturePagingSource<String, Post>
         if (subredditOrUserName == null) {
             if (accessToken == null) {
                 if (sortType.getTime() != null) {
-                    searchPosts = api.searchPostsListenableFuture(query, loadParams.getKey(), sortType.getType().value, sortType.getTime().value,
+                    searchPosts = api.searchPostsListenableFuture(query, loadParams.getKey(), sortType.getType(), sortType.getTime(),
                             trendingSource);
                 } else {
-                    searchPosts = api.searchPostsListenableFuture(query, loadParams.getKey(), sortType.getType().value, trendingSource);
+                    searchPosts = api.searchPostsListenableFuture(query, loadParams.getKey(), sortType.getType(), trendingSource);
                 }
             } else {
                 if (sortType.getTime() != null) {
-                    searchPosts = api.searchPostsOauthListenableFuture(query, loadParams.getKey(), sortType.getType().value,
-                            sortType.getTime().value, trendingSource, APIUtils.getOAuthHeader(accessToken));
+                    searchPosts = api.searchPostsOauthListenableFuture(query, loadParams.getKey(), sortType.getType(),
+                            sortType.getTime(), trendingSource, APIUtils.getOAuthHeader(accessToken));
                 } else {
-                    searchPosts = api.searchPostsOauthListenableFuture(query, loadParams.getKey(), sortType.getType().value, trendingSource,
+                    searchPosts = api.searchPostsOauthListenableFuture(query, loadParams.getKey(), sortType.getType(), trendingSource,
                             APIUtils.getOAuthHeader(accessToken));
                 }
             }
@@ -311,19 +311,19 @@ public class PostPagingSource extends ListenableFuturePagingSource<String, Post>
             if (accessToken == null) {
                 if (sortType.getTime() != null) {
                     searchPosts = api.searchPostsInSpecificSubredditListenableFuture(subredditOrUserName, query,
-                            sortType.getType().value, sortType.getTime().value, loadParams.getKey());
+                            sortType.getType(), sortType.getTime(), loadParams.getKey());
                 } else {
                     searchPosts = api.searchPostsInSpecificSubredditListenableFuture(subredditOrUserName, query,
-                            sortType.getType().value, loadParams.getKey());
+                            sortType.getType(), loadParams.getKey());
                 }
             } else {
                 if (sortType.getTime() != null) {
                     searchPosts = api.searchPostsInSpecificSubredditOauthListenableFuture(subredditOrUserName, query,
-                            sortType.getType().value, sortType.getTime().value, loadParams.getKey(),
+                            sortType.getType(), sortType.getTime(), loadParams.getKey(),
                             APIUtils.getOAuthHeader(accessToken));
                 } else {
                     searchPosts = api.searchPostsInSpecificSubredditOauthListenableFuture(subredditOrUserName, query,
-                            sortType.getType().value, loadParams.getKey(),
+                            sortType.getType(), loadParams.getKey(),
                             APIUtils.getOAuthHeader(accessToken));
                 }
             }
@@ -343,14 +343,14 @@ public class PostPagingSource extends ListenableFuturePagingSource<String, Post>
         ListenableFuture<Response<String>> multiRedditPosts;
         if (accessToken == null) {
             if (sortType.getTime() != null) {
-                multiRedditPosts = api.getMultiRedditPostsListenableFuture(multiRedditPath, loadParams.getKey(), sortType.getTime().value);
+                multiRedditPosts = api.getMultiRedditPostsListenableFuture(multiRedditPath, loadParams.getKey(), sortType.getTime());
             } else {
                 multiRedditPosts = api.getMultiRedditPostsListenableFuture(multiRedditPath, loadParams.getKey());
             }
         } else {
             if (sortType.getTime() != null) {
                 multiRedditPosts = api.getMultiRedditPostsOauthListenableFuture(multiRedditPath, loadParams.getKey(),
-                        sortType.getTime().value, APIUtils.getOAuthHeader(accessToken));
+                        sortType.getTime(), APIUtils.getOAuthHeader(accessToken));
             } else {
                 multiRedditPosts = api.getMultiRedditPostsOauthListenableFuture(multiRedditPath, loadParams.getKey(),
                         APIUtils.getOAuthHeader(accessToken));
@@ -370,9 +370,9 @@ public class PostPagingSource extends ListenableFuturePagingSource<String, Post>
     private ListenableFuture<LoadResult<String, Post>> loadAnonymousHomePosts(@NonNull LoadParams<String> loadParams, RedditAPI api) {
         ListenableFuture<Response<String>> anonymousHomePosts;
         if (sortType.getTime() != null) {
-            anonymousHomePosts = api.getSubredditBestPostsListenableFuture(subredditOrUserName, sortType.getType().value, sortType.getTime().value, loadParams.getKey());
+            anonymousHomePosts = api.getSubredditBestPostsListenableFuture(subredditOrUserName, sortType.getType(), sortType.getTime(), loadParams.getKey());
         } else {
-            anonymousHomePosts = api.getSubredditBestPostsListenableFuture(subredditOrUserName, sortType.getType().value, loadParams.getKey());
+            anonymousHomePosts = api.getSubredditBestPostsListenableFuture(subredditOrUserName, sortType.getType(), loadParams.getKey());
         }
 
         ListenableFuture<LoadResult<String, Post>> pageFuture = Futures.transform(anonymousHomePosts, this::transformData, executor);


### PR DESCRIPTION
From #1171 

This is the easy part because enums were already passed all the way to the request site. In other places strings are extracted earlier in call chain so changing them to enums is more difficult