### PR TITLE
Store only first level replies as children

### DIFF
--- a/app/src/main/java/ml/docilealligator/infinityforreddit/RedgifsAccessTokenAuthenticator.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/RedgifsAccessTokenAuthenticator.java
@@ -1,7 +1,6 @@
 package ml.docilealligator.infinityforreddit;
 
 import android.content.SharedPreferences;
-import android.util.Log;
 
 import androidx.annotation.NonNull;
 

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/activities/AccountSavedThingActivity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/activities/AccountSavedThingActivity.java
@@ -244,11 +244,6 @@ public class AccountSavedThingActivity extends BaseActivity implements ActivityT
     }
 
     @Override
-    public void toggleViewPagerSwipeLock(boolean lock) {
-        binding.accountSavedThingViewPager2.setUserInputEnabled(!lock);
-    }
-
-    @Override
     public void postLayoutSelected(int postLayout) {
         if (sectionsPagerAdapter != null) {
             mPostLayoutSharedPreferences.edit().putInt(SharedPreferencesUtils.POST_LAYOUT_USER_POST_BASE + mAccountName, postLayout).apply();

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/activities/AccountSavedThingActivity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/activities/AccountSavedThingActivity.java
@@ -244,6 +244,11 @@ public class AccountSavedThingActivity extends BaseActivity implements ActivityT
     }
 
     @Override
+    public void toggleViewPagerSwipeLock(boolean lock) {
+        binding.accountSavedThingViewPager2.setUserInputEnabled(!lock);
+    }
+
+    @Override
     public void postLayoutSelected(int postLayout) {
         if (sectionsPagerAdapter != null) {
             mPostLayoutSharedPreferences.edit().putInt(SharedPreferencesUtils.POST_LAYOUT_USER_POST_BASE + mAccountName, postLayout).apply();

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/activities/BaseActivity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/activities/BaseActivity.java
@@ -400,8 +400,4 @@ public abstract class BaseActivity extends AppCompatActivity implements CustomFo
     public void unlockSwipeRightToGoBack() {
 
     }
-
-    public void toggleViewPagerSwipeLock(boolean lock) {
-
-    }
 }

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/activities/BaseActivity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/activities/BaseActivity.java
@@ -400,4 +400,8 @@ public abstract class BaseActivity extends AppCompatActivity implements CustomFo
     public void unlockSwipeRightToGoBack() {
 
     }
+
+    public void toggleViewPagerSwipeLock(boolean lock) {
+
+    }
 }

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/activities/ViewRedditGalleryActivity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/activities/ViewRedditGalleryActivity.java
@@ -169,14 +169,14 @@ public class ViewRedditGalleryActivity extends AppCompatActivity implements SetA
             haulerView.setDragEnabled(false);
         }
 
-        setupViewPager();
+        setupViewPager(savedInstanceState);
     }
 
     public boolean isUseBottomAppBar() {
         return useBottomAppBar;
     }
 
-    private void setupViewPager() {
+    private void setupViewPager(Bundle savedInstanceState) {
         if (!useBottomAppBar) {
             setToolbarTitle(0);
             viewPager.addOnPageChangeListener(new ViewPager.SimpleOnPageChangeListener() {
@@ -189,6 +189,9 @@ public class ViewRedditGalleryActivity extends AppCompatActivity implements SetA
         sectionsPagerAdapter = new SectionsPagerAdapter(getSupportFragmentManager());
         viewPager.setAdapter(sectionsPagerAdapter);
         viewPager.setOffscreenPageLimit(3);
+        if (savedInstanceState == null) {
+            viewPager.setCurrentItem(getIntent().getIntExtra(EXTRA_GALLERY_ITEM_INDEX, 0), false);
+        }
     }
 
     private void setToolbarTitle(int position) {

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/CommentsRecyclerViewAdapter.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/CommentsRecyclerViewAdapter.java
@@ -612,7 +612,9 @@ public class CommentsRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerVi
                                 parentComment.getMoreChildrenIds(),
                                 mExpandChildren, mPost.getFullName(), sortType, new FetchComment.FetchMoreCommentListener() {
                                     @Override
-                                    public void onFetchMoreCommentSuccess(ArrayList<Comment> expandedComments, ArrayList<String> moreChildrenIds) {
+                                    public void onFetchMoreCommentSuccess(ArrayList<Comment> topLevelComments,
+                                                                          ArrayList<Comment> expandedComments,
+                                                                          ArrayList<String> moreChildrenIds) {
                                         if (mVisibleComments.size() > parentPosition
                                                 && parentComment.getFullName().equals(mVisibleComments.get(parentPosition).getFullName())) {
                                             if (mVisibleComments.get(parentPosition).isExpanded()) {
@@ -680,7 +682,7 @@ public class CommentsRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerVi
                                                 }
                                             }
 
-                                            mVisibleComments.get(parentPosition).addChildren(expandedComments);
+                                            mVisibleComments.get(parentPosition).addChildren(topLevelComments);
                                             if (mIsSingleCommentThreadMode) {
                                                 notifyItemChanged(parentPosition + 1);
                                             } else {
@@ -717,7 +719,7 @@ public class CommentsRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerVi
                                                             .setLoadingMoreChildren(false);
                                                     mVisibleComments.get(i).getChildren().get(mVisibleComments.get(i).getChildren().size() - 1)
                                                             .setLoadMoreChildrenFailed(false);
-                                                    mVisibleComments.get(i).addChildren(expandedComments);
+                                                    mVisibleComments.get(i).addChildren(topLevelComments);
                                                     if (mIsSingleCommentThreadMode) {
                                                         notifyItemChanged(i + 1);
                                                     } else {

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/HistoryPostRecyclerViewAdapter.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/HistoryPostRecyclerViewAdapter.java
@@ -1318,12 +1318,12 @@ public class HistoryPostRecyclerViewAdapter extends PagingDataAdapter<Post, Recy
 
                 switch (post.getPostType()) {
                     case Post.IMAGE_TYPE: {
-                        ((PostGalleryViewHolder) holder).imageView.setVisibility(View.VISIBLE);
-                        ((PostGalleryViewHolder) holder).progressBar.setVisibility(View.VISIBLE);
-
                         Post.Preview preview = getSuitablePreview(post.getPreviews());
                         ((PostGalleryViewHolder) holder).preview = preview;
                         if (preview != null) {
+                            ((PostGalleryViewHolder) holder).imageView.setVisibility(View.VISIBLE);
+                            ((PostGalleryViewHolder) holder).progressBar.setVisibility(View.VISIBLE);
+
                             if (mFixedHeightPreviewInCard || (preview.getPreviewWidth() <= 0 || preview.getPreviewHeight() <= 0)) {
                                 int height = (int) (400 * mScale);
                                 ((PostGalleryViewHolder) holder).imageView.setScaleType(ImageView.ScaleType.CENTER_CROP);
@@ -1391,14 +1391,14 @@ public class HistoryPostRecyclerViewAdapter extends PagingDataAdapter<Post, Recy
                         break;
                     }
                     case Post.VIDEO_TYPE: {
-                        ((PostGalleryViewHolder) holder).imageView.setVisibility(View.VISIBLE);
-                        ((PostGalleryViewHolder) holder).progressBar.setVisibility(View.VISIBLE);
-                        ((PostGalleryViewHolder) holder).videoOrGifIndicatorImageView.setVisibility(View.VISIBLE);
-                        ((PostGalleryViewHolder) holder).videoOrGifIndicatorImageView.setImageDrawable(ContextCompat.getDrawable(mActivity, R.drawable.ic_play_circle_36dp));
-
                         Post.Preview preview = getSuitablePreview(post.getPreviews());
                         ((PostGalleryViewHolder) holder).preview = preview;
                         if (preview != null) {
+                            ((PostGalleryViewHolder) holder).imageView.setVisibility(View.VISIBLE);
+                            ((PostGalleryViewHolder) holder).progressBar.setVisibility(View.VISIBLE);
+                            ((PostGalleryViewHolder) holder).videoOrGifIndicatorImageView.setVisibility(View.VISIBLE);
+                            ((PostGalleryViewHolder) holder).videoOrGifIndicatorImageView.setImageDrawable(ContextCompat.getDrawable(mActivity, R.drawable.ic_play_circle_36dp));
+
                             if (mFixedHeightPreviewInCard || (preview.getPreviewWidth() <= 0 || preview.getPreviewHeight() <= 0)) {
                                 int height = (int) (400 * mScale);
                                 ((PostGalleryViewHolder) holder).imageView.setScaleType(ImageView.ScaleType.CENTER_CROP);
@@ -1421,14 +1421,14 @@ public class HistoryPostRecyclerViewAdapter extends PagingDataAdapter<Post, Recy
                         break;
                     }
                     case Post.LINK_TYPE: {
-                        ((PostGalleryViewHolder) holder).imageView.setVisibility(View.VISIBLE);
-                        ((PostGalleryViewHolder) holder).progressBar.setVisibility(View.VISIBLE);
-                        ((PostGalleryViewHolder) holder).videoOrGifIndicatorImageView.setVisibility(View.VISIBLE);
-                        ((PostGalleryViewHolder) holder).videoOrGifIndicatorImageView.setImageDrawable(ContextCompat.getDrawable(mActivity, R.drawable.ic_link_post_type_indicator));
-
                         Post.Preview preview = getSuitablePreview(post.getPreviews());
                         ((PostGalleryViewHolder) holder).preview = preview;
                         if (preview != null) {
+                            ((PostGalleryViewHolder) holder).imageView.setVisibility(View.VISIBLE);
+                            ((PostGalleryViewHolder) holder).progressBar.setVisibility(View.VISIBLE);
+                            ((PostGalleryViewHolder) holder).videoOrGifIndicatorImageView.setVisibility(View.VISIBLE);
+                            ((PostGalleryViewHolder) holder).videoOrGifIndicatorImageView.setImageDrawable(ContextCompat.getDrawable(mActivity, R.drawable.ic_link_post_type_indicator));
+
                             if (mFixedHeightPreviewInCard || (preview.getPreviewWidth() <= 0 || preview.getPreviewHeight() <= 0)) {
                                 int height = (int) (400 * mScale);
                                 ((PostGalleryViewHolder) holder).imageView.setScaleType(ImageView.ScaleType.CENTER_CROP);
@@ -1461,14 +1461,14 @@ public class HistoryPostRecyclerViewAdapter extends PagingDataAdapter<Post, Recy
                         break;
                     }
                     case Post.GALLERY_TYPE: {
-                        ((PostGalleryViewHolder) holder).imageView.setVisibility(View.VISIBLE);
-                        ((PostGalleryViewHolder) holder).progressBar.setVisibility(View.VISIBLE);
-                        ((PostGalleryViewHolder) holder).videoOrGifIndicatorImageView.setVisibility(View.VISIBLE);
-                        ((PostGalleryViewHolder) holder).videoOrGifIndicatorImageView.setImageDrawable(ContextCompat.getDrawable(mActivity, R.drawable.ic_gallery_24dp));
-
                         Post.Preview preview = getSuitablePreview(post.getPreviews());
                         ((PostGalleryViewHolder) holder).preview = preview;
                         if (preview != null) {
+                            ((PostGalleryViewHolder) holder).imageView.setVisibility(View.VISIBLE);
+                            ((PostGalleryViewHolder) holder).progressBar.setVisibility(View.VISIBLE);
+                            ((PostGalleryViewHolder) holder).videoOrGifIndicatorImageView.setVisibility(View.VISIBLE);
+                            ((PostGalleryViewHolder) holder).videoOrGifIndicatorImageView.setImageDrawable(ContextCompat.getDrawable(mActivity, R.drawable.ic_gallery_24dp));
+
                             if (mFixedHeightPreviewInCard || (preview.getPreviewWidth() <= 0 || preview.getPreviewHeight() <= 0)) {
                                 int height = (int) (400 * mScale);
                                 ((PostGalleryViewHolder) holder).imageView.setScaleType(ImageView.ScaleType.CENTER_CROP);

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/PostGalleryTypeImageRecyclerViewAdapter.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/PostGalleryTypeImageRecyclerViewAdapter.java
@@ -37,19 +37,16 @@ public class PostGalleryTypeImageRecyclerViewAdapter extends RecyclerView.Adapte
     private ArrayList<Post.Gallery> galleryImages;
     private boolean blurImage;
     private float ratio;
-    private OnItemClickListener onItemClickListener;
 
     public PostGalleryTypeImageRecyclerViewAdapter(RequestManager glide, Typeface typeface,
                                                    SaveMemoryCenterInisdeDownsampleStrategy saveMemoryCenterInisdeDownsampleStrategy,
-                                                   int mColorAccent, int mPrimaryTextColor, float scale,
-                                                   OnItemClickListener onItemClickListener) {
+                                                   int mColorAccent, int mPrimaryTextColor, float scale) {
         this.glide = glide;
         this.typeface = typeface;
         this.saveMemoryCenterInisdeDownsampleStrategy = saveMemoryCenterInisdeDownsampleStrategy;
         this.mColorAccent = mColorAccent;
         this.mPrimaryTextColor = mPrimaryTextColor;
         this.mScale = scale;
-        this.onItemClickListener = onItemClickListener;
     }
 
     @NonNull
@@ -137,19 +134,11 @@ public class PostGalleryTypeImageRecyclerViewAdapter extends RecyclerView.Adapte
             binding.progressBarItemGalleryImageInPostFeed.setIndeterminateTintList(ColorStateList.valueOf(mColorAccent));
             binding.errorTextViewItemGalleryImageInPostFeed.setTextColor(mPrimaryTextColor);
 
-            binding.imageViewItemGalleryImageInPostFeed.setOnClickListener(view -> {
-                onItemClickListener.onClick(getBindingAdapterPosition());
-            });
-
             binding.errorTextViewItemGalleryImageInPostFeed.setOnClickListener(view -> {
                 binding.progressBarItemGalleryImageInPostFeed.setVisibility(View.VISIBLE);
                 binding.errorTextViewItemGalleryImageInPostFeed.setVisibility(View.GONE);
                 loadImage(this);
             });
         }
-    }
-
-    public interface OnItemClickListener {
-        void onClick(int galleryItemIndex);
     }
 }

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/PostRecyclerViewAdapter.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/PostRecyclerViewAdapter.java
@@ -87,6 +87,7 @@ import ml.docilealligator.infinityforreddit.customtheme.CustomThemeWrapper;
 import ml.docilealligator.infinityforreddit.customviews.AspectRatioGifImageView;
 import ml.docilealligator.infinityforreddit.customviews.SwipeLockInterface;
 import ml.docilealligator.infinityforreddit.customviews.SwipeLockLinearLayoutManager;
+import ml.docilealligator.infinityforreddit.databinding.ItemPostCard2GalleryTypeBinding;
 import ml.docilealligator.infinityforreddit.databinding.ItemPostGalleryTypeBinding;
 import ml.docilealligator.infinityforreddit.events.PostUpdateEventToPostDetailFragment;
 import ml.docilealligator.infinityforreddit.fragments.PostFragment;
@@ -120,7 +121,8 @@ public class PostRecyclerViewAdapter extends PagingDataAdapter<Post, RecyclerVie
     private static final int VIEW_TYPE_POST_GALLERY = 6;
     private static final int VIEW_TYPE_POST_CARD_2_VIDEO_AUTOPLAY_TYPE = 7;
     private static final int VIEW_TYPE_POST_CARD_2_WITH_PREVIEW_TYPE = 8;
-    private static final int VIEW_TYPE_POST_CARD_2_TEXT_TYPE = 9;
+    private static final int VIEW_TYPE_POST_CARD_2_GALLERY_TYPE = 9;
+    private static final int VIEW_TYPE_POST_CARD_2_TEXT_TYPE = 10;
 
     private static final DiffUtil.ItemCallback<Post> DIFF_CALLBACK = new DiffUtil.ItemCallback<Post>() {
         @Override
@@ -429,8 +431,9 @@ public class PostRecyclerViewAdapter extends PagingDataAdapter<Post, RecyclerVie
                         return VIEW_TYPE_POST_CARD_2_WITH_PREVIEW_TYPE;
                     case Post.GIF_TYPE:
                     case Post.IMAGE_TYPE:
-                    case Post.GALLERY_TYPE:
                         return VIEW_TYPE_POST_CARD_2_WITH_PREVIEW_TYPE;
+                    case Post.GALLERY_TYPE:
+                        return VIEW_TYPE_POST_CARD_2_GALLERY_TYPE;
                     case Post.LINK_TYPE:
                     case Post.NO_PREVIEW_LINK_TYPE:
                         switch (mDefaultLinkPostLayout) {
@@ -479,6 +482,8 @@ public class PostRecyclerViewAdapter extends PagingDataAdapter<Post, RecyclerVie
             return new PostCard2VideoAutoplayViewHolder(LayoutInflater.from(parent.getContext()).inflate(mLegacyAutoplayVideoControllerUI ? R.layout.item_post_card_2_video_autoplay_legacy_controller : R.layout.item_post_card_2_video_autoplay, parent, false));
         } else if (viewType == VIEW_TYPE_POST_CARD_2_WITH_PREVIEW_TYPE) {
             return new PostCard2WithPreviewViewHolder(LayoutInflater.from(parent.getContext()).inflate(R.layout.item_post_card_2_with_preview, parent, false));
+        } else if (viewType == VIEW_TYPE_POST_CARD_2_GALLERY_TYPE) {
+            return new PostCard2GalleryTypeViewHolder(ItemPostCard2GalleryTypeBinding.inflate(LayoutInflater.from(parent.getContext()), parent, false));
         } else {
             //VIEW_TYPE_POST_CARD_2_TEXT_TYPE
             return new PostCard2TextTypeViewHolder(LayoutInflater.from(parent.getContext()).inflate(R.layout.item_post_card_2_text, parent, false));
@@ -858,25 +863,25 @@ public class PostRecyclerViewAdapter extends PagingDataAdapter<Post, RecyclerVie
                             }
                         }
                     }
-                } else if (holder instanceof PostGalleryTypeViewHolder) {
+                } else if (holder instanceof PostBaseGalleryTypeViewHolder) {
                     if (mDataSavingMode && mDisableImagePreview) {
-                        ((PostGalleryTypeViewHolder) holder).binding.noPreviewImageViewItemPostGalleryType.setVisibility(View.VISIBLE);
-                        ((PostGalleryTypeViewHolder) holder).binding.noPreviewImageViewItemPostGalleryType.setImageResource(R.drawable.ic_gallery_24dp);
+                        ((PostBaseGalleryTypeViewHolder) holder).noPreviewImageView.setVisibility(View.VISIBLE);
+                        ((PostBaseGalleryTypeViewHolder) holder).noPreviewImageView.setImageResource(R.drawable.ic_gallery_24dp);
                     } else {
-                        ((PostGalleryTypeViewHolder) holder).binding.galleryFrameLayoutItemPostGalleryType.setVisibility(View.VISIBLE);
-                        ((PostGalleryTypeViewHolder) holder).binding.imageIndexTextViewItemPostGalleryType.setText(mActivity.getString(R.string.image_index_in_gallery, 1, post.getGallery().size()));
+                        ((PostBaseGalleryTypeViewHolder) holder).frameLayout.setVisibility(View.VISIBLE);
+                        ((PostBaseGalleryTypeViewHolder) holder).imageIndexTextView.setText(mActivity.getString(R.string.image_index_in_gallery, 1, post.getGallery().size()));
                         Post.Preview preview = getSuitablePreview(post.getPreviews());
                         if (preview != null) {
                             if (mFixedHeightPreviewInCard || (preview.getPreviewWidth() <= 0 || preview.getPreviewHeight() <= 0)) {
-                                ((PostGalleryTypeViewHolder) holder).adapter.setRatio(-1);
+                                ((PostBaseGalleryTypeViewHolder) holder).adapter.setRatio(-1);
                             } else {
-                                ((PostGalleryTypeViewHolder) holder).adapter.setRatio((float) preview.getPreviewHeight() / preview.getPreviewWidth());
+                                ((PostBaseGalleryTypeViewHolder) holder).adapter.setRatio((float) preview.getPreviewHeight() / preview.getPreviewWidth());
                             }
                         } else {
-                            ((PostGalleryTypeViewHolder) holder).adapter.setRatio(-1);
+                            ((PostBaseGalleryTypeViewHolder) holder).adapter.setRatio(-1);
                         }
-                        ((PostGalleryTypeViewHolder) holder).adapter.setGalleryImages(post.getGallery());
-                        ((PostGalleryTypeViewHolder) holder).adapter.setBlurImage(
+                        ((PostBaseGalleryTypeViewHolder) holder).adapter.setGalleryImages(post.getGallery());
+                        ((PostBaseGalleryTypeViewHolder) holder).adapter.setBlurImage(
                                 (post.isNSFW() && mNeedBlurNsfw && !(mDoNotBlurNsfwInNsfwSubreddits && mFragment != null && mFragment.getIsNsfwSubreddit())) || (post.isSpoiler() && mNeedBlurSpoiler));
                     }
                 } else if (holder instanceof PostTextTypeViewHolder) {
@@ -1890,9 +1895,9 @@ public class PostRecyclerViewAdapter extends PagingDataAdapter<Post, RecyclerVie
                 ((PostWithPreviewTypeViewHolder) holder).progressBar.setVisibility(View.GONE);
                 ((PostWithPreviewTypeViewHolder) holder).videoOrGifIndicatorImageView.setVisibility(View.GONE);
                 ((PostWithPreviewTypeViewHolder) holder).linkTextView.setVisibility(View.GONE);
-            } else if (holder instanceof PostGalleryTypeViewHolder) {
-                ((PostGalleryTypeViewHolder) holder).binding.galleryFrameLayoutItemPostGalleryType.setVisibility(View.GONE);
-                ((PostGalleryTypeViewHolder) holder).binding.noPreviewImageViewItemPostGalleryType.setVisibility(View.GONE);
+            } else if (holder instanceof PostBaseGalleryTypeViewHolder) {
+                ((PostBaseGalleryTypeViewHolder) holder).frameLayout.setVisibility(View.GONE);
+                ((PostBaseGalleryTypeViewHolder) holder).noPreviewImageView.setVisibility(View.GONE);
             } else if (holder instanceof PostTextTypeViewHolder) {
                 ((PostTextTypeViewHolder) holder).contentTextView.setText("");
                 ((PostTextTypeViewHolder) holder).contentTextView.setTextColor(mPostContentColor);
@@ -3104,46 +3109,81 @@ public class PostRecyclerViewAdapter extends PagingDataAdapter<Post, RecyclerVie
         }
     }
 
-    public class PostGalleryTypeViewHolder extends PostBaseViewHolder {
-        ItemPostGalleryTypeBinding binding;
+    public class PostBaseGalleryTypeViewHolder extends PostBaseViewHolder {
+        FrameLayout frameLayout;
+        RecyclerView galleryRecyclerView;
+        CustomTextView imageIndexTextView;
+        ImageView noPreviewImageView;
+
         PostGalleryTypeImageRecyclerViewAdapter adapter;
         private boolean swipeLocked;
 
-        PostGalleryTypeViewHolder(ItemPostGalleryTypeBinding binding) {
-            super(binding.getRoot());
-            this.binding = binding;
+        PostBaseGalleryTypeViewHolder(View rootView,
+                                      AspectRatioGifImageView iconGifImageView,
+                                      TextView subredditTextView,
+                                      TextView userTextView,
+                                      ImageView stickiedPostImageView,
+                                      TextView postTimeTextView,
+                                      TextView titleTextView,
+                                      CustomTextView typeTextView,
+                                      ImageView archivedImageView,
+                                      ImageView lockedImageView,
+                                      ImageView crosspostImageView,
+                                      CustomTextView nsfwTextView,
+                                      CustomTextView spoilerTextView,
+                                      CustomTextView flairTextView,
+                                      CustomTextView awardsTextView,
+                                      FrameLayout frameLayout,
+                                      RecyclerView galleryRecyclerView,
+                                      CustomTextView imageIndexTextView,
+                                      ImageView noPreviewImageView,
+                                      ConstraintLayout bottomConstraintLayout,
+                                      ImageView upvoteButton,
+                                      TextView scoreTextView,
+                                      ImageView downvoteButton,
+                                      TextView commentsCountTextView,
+                                      ImageView saveButton,
+                                      ImageView shareButton,
+                                      boolean itemViewIsNotCardView) {
+            super(rootView);
             setBaseView(
-                    binding.iconGifImageViewItemPostGalleryType,
-                    binding.subredditNameTextViewItemPostGalleryType,
-                    binding.userTextViewItemPostGalleryType,
-                    binding.stickiedPostImageViewItemPostGalleryType,
-                    binding.postTimeTextViewItemPostGalleryType,
-                    binding.titleTextViewItemPostGalleryType,
-                    binding.typeTextViewItemPostGalleryType,
-                    binding.archivedImageViewItemPostGalleryType,
-                    binding.lockedImageViewItemPostGalleryType,
-                    binding.crosspostImageViewItemPostGalleryType,
-                    binding.nsfwTextViewItemPostGalleryType,
-                    binding.spoilerTextViewItemPostGalleryType,
-                    binding.flairTextViewItemPostGalleryType,
-                    binding.awardsTextViewItemPostGalleryType,
-                    binding.bottomConstraintLayoutItemPostGalleryType,
-                    binding.upvoteButtonItemPostGalleryType,
-                    binding.scoreTextViewItemPostGalleryType,
-                    binding.downvoteButtonItemPostGalleryType,
-                    binding.commentsCountTextViewItemPostGalleryType,
-                    binding.saveButtonItemPostGalleryType,
-                    binding.shareButtonItemPostGalleryType);
+                    iconGifImageView,
+                    subredditTextView,
+                    userTextView,
+                    stickiedPostImageView,
+                    postTimeTextView,
+                    titleTextView,
+                    typeTextView,
+                    archivedImageView,
+                    lockedImageView,
+                    crosspostImageView,
+                    nsfwTextView,
+                    spoilerTextView,
+                    flairTextView,
+                    awardsTextView,
+                    bottomConstraintLayout,
+                    upvoteButton,
+                    scoreTextView,
+                    downvoteButton,
+                    commentsCountTextView,
+                    saveButton,
+                    shareButton,
+                    itemViewIsNotCardView);
 
-            binding.imageIndexTextViewItemPostGalleryType.setTextColor(mMediaIndicatorIconTint);
-            binding.imageIndexTextViewItemPostGalleryType.setBackgroundColor(mMediaIndicatorBackgroundColor);
-            binding.imageIndexTextViewItemPostGalleryType.setBorderColor(mMediaIndicatorBackgroundColor);
+            this.frameLayout = frameLayout;
+            this.galleryRecyclerView = galleryRecyclerView;
+            this.imageIndexTextView = imageIndexTextView;
+            this.noPreviewImageView = noPreviewImageView;
+
+            imageIndexTextView.setTextColor(mMediaIndicatorIconTint);
+            imageIndexTextView.setBackgroundColor(mMediaIndicatorBackgroundColor);
+            imageIndexTextView.setBorderColor(mMediaIndicatorBackgroundColor);
 
             adapter = new PostGalleryTypeImageRecyclerViewAdapter(mGlide, mActivity.typeface,
                     mSaveMemoryCenterInsideDownsampleStrategy, mColorAccent, mPrimaryTextColor, mScale);
-            binding.galleryRecyclerViewItemPostGalleryType.setAdapter(adapter);
-            new PagerSnapHelper().attachToRecyclerView(binding.galleryRecyclerViewItemPostGalleryType);
-            binding.galleryRecyclerViewItemPostGalleryType.setRecycledViewPool(mGalleryRecycledViewPool);
+            galleryRecyclerView.setAdapter(adapter);
+            new PagerSnapHelper().attachToRecyclerView(galleryRecyclerView);
+            galleryRecyclerView.setRecycledViewPool(mGalleryRecycledViewPool);
             SwipeLockLinearLayoutManager layoutManager = new SwipeLockLinearLayoutManager(
                     mActivity, RecyclerView.HORIZONTAL, false, new SwipeLockInterface() {
                 @Override
@@ -3160,12 +3200,11 @@ public class PostRecyclerViewAdapter extends PagingDataAdapter<Post, RecyclerVie
 
                 @Override
                 public void setSwipeLocked(boolean swipeLocked) {
-                    PostGalleryTypeViewHolder.this.swipeLocked = swipeLocked;
-                    mActivity.toggleViewPagerSwipeLock(swipeLocked);
+                    PostBaseGalleryTypeViewHolder.this.swipeLocked = swipeLocked;
                 }
             });
-            binding.galleryRecyclerViewItemPostGalleryType.setLayoutManager(layoutManager);
-            binding.galleryRecyclerViewItemPostGalleryType.addOnScrollListener(new RecyclerView.OnScrollListener() {
+            galleryRecyclerView.setLayoutManager(layoutManager);
+            galleryRecyclerView.addOnScrollListener(new RecyclerView.OnScrollListener() {
                 @Override
                 public void onScrollStateChanged(@NonNull RecyclerView recyclerView, int newState) {
                     super.onScrollStateChanged(recyclerView, newState);
@@ -3174,10 +3213,10 @@ public class PostRecyclerViewAdapter extends PagingDataAdapter<Post, RecyclerVie
                 @Override
                 public void onScrolled(@NonNull RecyclerView recyclerView, int dx, int dy) {
                     super.onScrolled(recyclerView, dx, dy);
-                    binding.imageIndexTextViewItemPostGalleryType.setText(mActivity.getString(R.string.image_index_in_gallery, layoutManager.findFirstVisibleItemPosition() + 1, post.getGallery().size()));
+                    imageIndexTextView.setText(mActivity.getString(R.string.image_index_in_gallery, layoutManager.findFirstVisibleItemPosition() + 1, post.getGallery().size()));
                 }
             });
-            binding.galleryRecyclerViewItemPostGalleryType.addOnItemTouchListener(new RecyclerView.OnItemTouchListener() {
+            galleryRecyclerView.addOnItemTouchListener(new RecyclerView.OnItemTouchListener() {
                 private float downX;
                 private float downY;
                 private boolean dragged;
@@ -3197,7 +3236,6 @@ public class PostRecyclerViewAdapter extends PagingDataAdapter<Post, RecyclerVie
                             }
                             break;
                         case MotionEvent.ACTION_UP:
-                        case MotionEvent.ACTION_CANCEL:
                             if (!dragged) {
                                 int index = layoutManager.findFirstVisibleItemPosition();
                                 int position = getBindingAdapterPosition();
@@ -3227,16 +3265,16 @@ public class PostRecyclerViewAdapter extends PagingDataAdapter<Post, RecyclerVie
                 }
             });
 
-            binding.getRoot().setOnTouchListener((view, motionEvent) -> {
+            rootView.setOnTouchListener((view, motionEvent) -> {
                 swipeLocked = false;
                 return false;
             });
-            binding.bottomConstraintLayoutItemPostGalleryType.setOnTouchListener((view, motionEvent) -> {
+            bottomConstraintLayout.setOnTouchListener((view, motionEvent) -> {
                 swipeLocked = false;
                 return false;
             });
 
-            binding.noPreviewImageViewItemPostGalleryType.setOnClickListener(view -> {
+            noPreviewImageView.setOnClickListener(view -> {
                 int position = getBindingAdapterPosition();
                 if (position < 0) {
                     return;
@@ -3250,6 +3288,39 @@ public class PostRecyclerViewAdapter extends PagingDataAdapter<Post, RecyclerVie
 
         public boolean isSwipeLocked() {
             return swipeLocked;
+        }
+    }
+
+    public class PostGalleryTypeViewHolder extends PostBaseGalleryTypeViewHolder {
+
+        PostGalleryTypeViewHolder(ItemPostGalleryTypeBinding binding) {
+            super(binding.getRoot(),
+                    binding.iconGifImageViewItemPostGalleryType,
+                    binding.subredditNameTextViewItemPostGalleryType,
+                    binding.userTextViewItemPostGalleryType,
+                    binding.stickiedPostImageViewItemPostGalleryType,
+                    binding.postTimeTextViewItemPostGalleryType,
+                    binding.titleTextViewItemPostGalleryType,
+                    binding.typeTextViewItemPostGalleryType,
+                    binding.archivedImageViewItemPostGalleryType,
+                    binding.lockedImageViewItemPostGalleryType,
+                    binding.crosspostImageViewItemPostGalleryType,
+                    binding.nsfwTextViewItemPostGalleryType,
+                    binding.spoilerTextViewItemPostGalleryType,
+                    binding.flairTextViewItemPostGalleryType,
+                    binding.awardsTextViewItemPostGalleryType,
+                    binding.galleryFrameLayoutItemPostGalleryType,
+                    binding.galleryRecyclerViewItemPostGalleryType,
+                    binding.imageIndexTextViewItemPostGalleryType,
+                    binding.noPreviewImageViewItemPostGalleryType,
+                    binding.bottomConstraintLayoutItemPostGalleryType,
+                    binding.upvoteButtonItemPostGalleryType,
+                    binding.scoreTextViewItemPostGalleryType,
+                    binding.downvoteButtonItemPostGalleryType,
+                    binding.commentsCountTextViewItemPostGalleryType,
+                    binding.saveButtonItemPostGalleryType,
+                    binding.shareButtonItemPostGalleryType,
+                    false);
         }
     }
 
@@ -4568,6 +4639,41 @@ public class PostRecyclerViewAdapter extends PagingDataAdapter<Post, RecyclerVie
                     return false;
                 }
             };
+        }
+    }
+
+    public class PostCard2GalleryTypeViewHolder extends PostBaseGalleryTypeViewHolder {
+
+        PostCard2GalleryTypeViewHolder(ItemPostCard2GalleryTypeBinding binding) {
+            super(binding.getRoot(),
+                    binding.iconGifImageViewItemPostCard2GalleryType,
+                    binding.subredditNameTextViewItemPostCard2GalleryType,
+                    binding.userTextViewItemPostCard2GalleryType,
+                    binding.stickiedPostImageViewItemPostCard2GalleryType,
+                    binding.postTimeTextViewItemPostCard2GalleryType,
+                    binding.titleTextViewItemPostCard2GalleryType,
+                    binding.typeTextViewItemPostCard2GalleryType,
+                    binding.archivedImageViewItemPostCard2GalleryType,
+                    binding.lockedImageViewItemPostCard2GalleryType,
+                    binding.crosspostImageViewItemPostCard2GalleryType,
+                    binding.nsfwTextViewItemPostCard2GalleryType,
+                    binding.spoilerCustomTextViewItemPostCard2GalleryType,
+                    binding.flairCustomTextViewItemPostCard2GalleryType,
+                    binding.awardsTextViewItemPostCard2GalleryType,
+                    binding.galleryFrameLayoutItemPostCard2GalleryType,
+                    binding.galleryRecyclerViewItemPostCard2GalleryType,
+                    binding.imageIndexTextViewItemPostCard2GalleryType,
+                    binding.noPreviewImageViewItemPostCard2GalleryType,
+                    binding.bottomConstraintLayoutItemPostCard2GalleryType,
+                    binding.upvoteButtonItemPostCard2GalleryType,
+                    binding.scoreTextViewItemPostCard2GalleryType,
+                    binding.downvoteButtonItemPostCard2GalleryType,
+                    binding.commentsCountTextViewItemPostCard2GalleryType,
+                    binding.saveButtonItemPostCard2GalleryType,
+                    binding.shareButtonItemPostCard2GalleryType,
+                    true);
+
+            binding.dividerItemPostCard2GalleryType.setBackgroundColor(mDividerColor);
         }
     }
 

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/PostRecyclerViewAdapter.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/PostRecyclerViewAdapter.java
@@ -11,9 +11,7 @@ import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.Bundle;
 import android.os.Handler;
-import android.util.Log;
 import android.view.LayoutInflater;
-import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.FrameLayout;
@@ -863,7 +861,8 @@ public class PostRecyclerViewAdapter extends PagingDataAdapter<Post, RecyclerVie
                         ((PostGalleryTypeViewHolder) holder).binding.noPreviewImageViewItemPostGalleryType.setVisibility(View.VISIBLE);
                         ((PostGalleryTypeViewHolder) holder).binding.noPreviewImageViewItemPostGalleryType.setImageResource(R.drawable.ic_gallery_24dp);
                     } else {
-                        ((PostGalleryTypeViewHolder) holder).binding.galleryRecyclerViewItemPostGalleryType.setVisibility(View.VISIBLE);
+                        ((PostGalleryTypeViewHolder) holder).binding.galleryFrameLayoutItemPostGalleryType.setVisibility(View.VISIBLE);
+                        ((PostGalleryTypeViewHolder) holder).binding.imageIndexTextViewItemPostGalleryType.setText(mActivity.getString(R.string.image_index_in_gallery, 1, post.getGallery().size()));
                         Post.Preview preview = getSuitablePreview(post.getPreviews());
                         if (preview != null) {
                             if (mFixedHeightPreviewInCard || (preview.getPreviewWidth() <= 0 || preview.getPreviewHeight() <= 0)) {
@@ -1890,7 +1889,7 @@ public class PostRecyclerViewAdapter extends PagingDataAdapter<Post, RecyclerVie
                 ((PostWithPreviewTypeViewHolder) holder).videoOrGifIndicatorImageView.setVisibility(View.GONE);
                 ((PostWithPreviewTypeViewHolder) holder).linkTextView.setVisibility(View.GONE);
             } else if (holder instanceof PostGalleryTypeViewHolder) {
-                ((PostGalleryTypeViewHolder) holder).binding.galleryRecyclerViewItemPostGalleryType.setVisibility(View.GONE);
+                ((PostGalleryTypeViewHolder) holder).binding.galleryFrameLayoutItemPostGalleryType.setVisibility(View.GONE);
                 ((PostGalleryTypeViewHolder) holder).binding.noPreviewImageViewItemPostGalleryType.setVisibility(View.GONE);
             } else if (holder instanceof PostTextTypeViewHolder) {
                 ((PostTextTypeViewHolder) holder).contentTextView.setText("");
@@ -3134,6 +3133,10 @@ public class PostRecyclerViewAdapter extends PagingDataAdapter<Post, RecyclerVie
                     binding.saveButtonItemPostGalleryType,
                     binding.shareButtonItemPostGalleryType);
 
+            binding.imageIndexTextViewItemPostGalleryType.setTextColor(mMediaIndicatorIconTint);
+            binding.imageIndexTextViewItemPostGalleryType.setBackgroundColor(mMediaIndicatorBackgroundColor);
+            binding.imageIndexTextViewItemPostGalleryType.setBorderColor(mMediaIndicatorBackgroundColor);
+
             adapter = new PostGalleryTypeImageRecyclerViewAdapter(mGlide, mActivity.typeface,
                     mSaveMemoryCenterInsideDownsampleStrategy, mColorAccent, mPrimaryTextColor, mScale,
                     galleryItemIndex -> {
@@ -3149,7 +3152,7 @@ public class PostRecyclerViewAdapter extends PagingDataAdapter<Post, RecyclerVie
             binding.galleryRecyclerViewItemPostGalleryType.setAdapter(adapter);
             new PagerSnapHelper().attachToRecyclerView(binding.galleryRecyclerViewItemPostGalleryType);
             binding.galleryRecyclerViewItemPostGalleryType.setRecycledViewPool(mGalleryRecycledViewPool);
-            binding.galleryRecyclerViewItemPostGalleryType.setLayoutManager(new SwipeLockLinearLayoutManager(
+            SwipeLockLinearLayoutManager layoutManager = new SwipeLockLinearLayoutManager(
                     mActivity, RecyclerView.HORIZONTAL, false, new SwipeLockInterface() {
                 @Override
                 public void lockSwipe() {
@@ -3167,17 +3170,28 @@ public class PostRecyclerViewAdapter extends PagingDataAdapter<Post, RecyclerVie
                 public void setSwipeLocked(boolean swipeLocked) {
                     PostGalleryTypeViewHolder.this.swipeLocked = swipeLocked;
                 }
-            }));
+            });
+            binding.galleryRecyclerViewItemPostGalleryType.setLayoutManager(layoutManager);
+            binding.galleryRecyclerViewItemPostGalleryType.addOnScrollListener(new RecyclerView.OnScrollListener() {
+                @Override
+                public void onScrollStateChanged(@NonNull RecyclerView recyclerView, int newState) {
+                    super.onScrollStateChanged(recyclerView, newState);
+                }
+
+                @Override
+                public void onScrolled(@NonNull RecyclerView recyclerView, int dx, int dy) {
+                    super.onScrolled(recyclerView, dx, dy);
+                    binding.imageIndexTextViewItemPostGalleryType.setText(mActivity.getString(R.string.image_index_in_gallery, layoutManager.findFirstVisibleItemPosition() + 1, post.getGallery().size()));
+                }
+            });
+
             binding.getRoot().setOnTouchListener((view, motionEvent) -> {
                 swipeLocked = false;
                 return false;
             });
-            binding.bottomConstraintLayoutItemPostGalleryType.setOnTouchListener(new View.OnTouchListener() {
-                @Override
-                public boolean onTouch(View view, MotionEvent motionEvent) {
-                    swipeLocked = false;
-                    return false;
-                }
+            binding.bottomConstraintLayoutItemPostGalleryType.setOnTouchListener((view, motionEvent) -> {
+                swipeLocked = false;
+                return false;
             });
 
             binding.noPreviewImageViewItemPostGalleryType.setOnClickListener(view -> {

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/PostRecyclerViewAdapter.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/PostRecyclerViewAdapter.java
@@ -1400,12 +1400,12 @@ public class PostRecyclerViewAdapter extends PagingDataAdapter<Post, RecyclerVie
 
                 switch (post.getPostType()) {
                     case Post.IMAGE_TYPE: {
-                        ((PostGalleryViewHolder) holder).imageView.setVisibility(View.VISIBLE);
-                        ((PostGalleryViewHolder) holder).progressBar.setVisibility(View.VISIBLE);
-
                         Post.Preview preview = getSuitablePreview(post.getPreviews());
                         ((PostGalleryViewHolder) holder).preview = preview;
                         if (preview != null) {
+                            ((PostGalleryViewHolder) holder).imageView.setVisibility(View.VISIBLE);
+                            ((PostGalleryViewHolder) holder).progressBar.setVisibility(View.VISIBLE);
+
                             if (mFixedHeightPreviewInCard || (preview.getPreviewWidth() <= 0 || preview.getPreviewHeight() <= 0)) {
                                 int height = (int) (400 * mScale);
                                 ((PostGalleryViewHolder) holder).imageView.setScaleType(ImageView.ScaleType.CENTER_CROP);
@@ -1473,14 +1473,14 @@ public class PostRecyclerViewAdapter extends PagingDataAdapter<Post, RecyclerVie
                         break;
                     }
                     case Post.VIDEO_TYPE: {
-                        ((PostGalleryViewHolder) holder).imageView.setVisibility(View.VISIBLE);
-                        ((PostGalleryViewHolder) holder).progressBar.setVisibility(View.VISIBLE);
-                        ((PostGalleryViewHolder) holder).videoOrGifIndicatorImageView.setVisibility(View.VISIBLE);
-                        ((PostGalleryViewHolder) holder).videoOrGifIndicatorImageView.setImageDrawable(ContextCompat.getDrawable(mActivity, R.drawable.ic_play_circle_36dp));
-
                         Post.Preview preview = getSuitablePreview(post.getPreviews());
                         ((PostGalleryViewHolder) holder).preview = preview;
                         if (preview != null) {
+                            ((PostGalleryViewHolder) holder).imageView.setVisibility(View.VISIBLE);
+                            ((PostGalleryViewHolder) holder).progressBar.setVisibility(View.VISIBLE);
+                            ((PostGalleryViewHolder) holder).videoOrGifIndicatorImageView.setVisibility(View.VISIBLE);
+                            ((PostGalleryViewHolder) holder).videoOrGifIndicatorImageView.setImageDrawable(ContextCompat.getDrawable(mActivity, R.drawable.ic_play_circle_36dp));
+
                             if (mFixedHeightPreviewInCard || (preview.getPreviewWidth() <= 0 || preview.getPreviewHeight() <= 0)) {
                                 int height = (int) (400 * mScale);
                                 ((PostGalleryViewHolder) holder).imageView.setScaleType(ImageView.ScaleType.CENTER_CROP);
@@ -1503,14 +1503,14 @@ public class PostRecyclerViewAdapter extends PagingDataAdapter<Post, RecyclerVie
                         break;
                     }
                     case Post.LINK_TYPE: {
-                        ((PostGalleryViewHolder) holder).imageView.setVisibility(View.VISIBLE);
-                        ((PostGalleryViewHolder) holder).progressBar.setVisibility(View.VISIBLE);
-                        ((PostGalleryViewHolder) holder).videoOrGifIndicatorImageView.setVisibility(View.VISIBLE);
-                        ((PostGalleryViewHolder) holder).videoOrGifIndicatorImageView.setImageDrawable(ContextCompat.getDrawable(mActivity, R.drawable.ic_link_post_type_indicator));
-
                         Post.Preview preview = getSuitablePreview(post.getPreviews());
                         ((PostGalleryViewHolder) holder).preview = preview;
                         if (preview != null) {
+                            ((PostGalleryViewHolder) holder).imageView.setVisibility(View.VISIBLE);
+                            ((PostGalleryViewHolder) holder).progressBar.setVisibility(View.VISIBLE);
+                            ((PostGalleryViewHolder) holder).videoOrGifIndicatorImageView.setVisibility(View.VISIBLE);
+                            ((PostGalleryViewHolder) holder).videoOrGifIndicatorImageView.setImageDrawable(ContextCompat.getDrawable(mActivity, R.drawable.ic_link_post_type_indicator));
+
                             if (mFixedHeightPreviewInCard || (preview.getPreviewWidth() <= 0 || preview.getPreviewHeight() <= 0)) {
                                 int height = (int) (400 * mScale);
                                 ((PostGalleryViewHolder) holder).imageView.setScaleType(ImageView.ScaleType.CENTER_CROP);
@@ -1543,14 +1543,14 @@ public class PostRecyclerViewAdapter extends PagingDataAdapter<Post, RecyclerVie
                         break;
                     }
                     case Post.GALLERY_TYPE: {
-                        ((PostGalleryViewHolder) holder).imageView.setVisibility(View.VISIBLE);
-                        ((PostGalleryViewHolder) holder).progressBar.setVisibility(View.VISIBLE);
-                        ((PostGalleryViewHolder) holder).videoOrGifIndicatorImageView.setVisibility(View.VISIBLE);
-                        ((PostGalleryViewHolder) holder).videoOrGifIndicatorImageView.setImageDrawable(ContextCompat.getDrawable(mActivity, R.drawable.ic_gallery_24dp));
-
                         Post.Preview preview = getSuitablePreview(post.getPreviews());
                         ((PostGalleryViewHolder) holder).preview = preview;
                         if (preview != null) {
+                            ((PostGalleryViewHolder) holder).imageView.setVisibility(View.VISIBLE);
+                            ((PostGalleryViewHolder) holder).progressBar.setVisibility(View.VISIBLE);
+                            ((PostGalleryViewHolder) holder).videoOrGifIndicatorImageView.setVisibility(View.VISIBLE);
+                            ((PostGalleryViewHolder) holder).videoOrGifIndicatorImageView.setImageDrawable(ContextCompat.getDrawable(mActivity, R.drawable.ic_gallery_24dp));
+
                             if (mFixedHeightPreviewInCard || (preview.getPreviewWidth() <= 0 || preview.getPreviewHeight() <= 0)) {
                                 int height = (int) (400 * mScale);
                                 ((PostGalleryViewHolder) holder).imageView.setScaleType(ImageView.ScaleType.CENTER_CROP);

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/comment/Comment.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/comment/Comment.java
@@ -5,6 +5,7 @@ import android.os.Parcelable;
 
 import java.util.ArrayList;
 
+import ml.docilealligator.infinityforreddit.BuildConfig;
 import ml.docilealligator.infinityforreddit.utils.APIUtils;
 
 public class Comment implements Parcelable {
@@ -313,13 +314,9 @@ public class Comment implements Parcelable {
         return children;
     }
 
-    public void setChildren(ArrayList<Comment> children) {
-        this.children = children;
-    }
-
     public void addChildren(ArrayList<Comment> moreChildren) {
         if (children == null || children.size() == 0) {
-            setChildren(moreChildren);
+            children = moreChildren;
         } else {
             if (children.size() > 1 && children.get(children.size() - 1).placeholderType == PLACEHOLDER_LOAD_MORE_COMMENTS) {
                 children.addAll(children.size() - 2, moreChildren);
@@ -328,11 +325,13 @@ public class Comment implements Parcelable {
             }
         }
         childCount += moreChildren == null ? 0 : moreChildren.size();
+        assertChildrenDepth();
     }
 
     public void addChild(Comment comment) {
         addChild(comment, 0);
         childCount++;
+        assertChildrenDepth();
     }
 
     public void addChild(Comment comment, int position) {
@@ -340,6 +339,17 @@ public class Comment implements Parcelable {
             children = new ArrayList<>();
         }
         children.add(position, comment);
+        assertChildrenDepth();
+    }
+
+    private void assertChildrenDepth() {
+        if (BuildConfig.DEBUG) {
+            for (Comment child: children) {
+                if (child.depth != depth + 1) {
+                    throw new IllegalStateException("Child depth is not one more than parent depth");
+                }
+            }
+        }
     }
 
     public ArrayList<String> getMoreChildrenIds() {

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/comment/FetchComment.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/comment/FetchComment.java
@@ -42,7 +42,7 @@ public class FetchComment {
             @Override
             public void onResponse(@NonNull Call<String> call, @NonNull Response<String> response) {
                 if (response.isSuccessful()) {
-                    ParseComment.parseComment(executor, handler, response.body(), new ArrayList<>(),
+                    ParseComment.parseComment(executor, handler, response.body(),
                             expandChildren, new ParseComment.ParseCommentListener() {
                                 @Override
                                 public void onParseCommentSuccess(ArrayList<Comment> expandedComments,
@@ -97,7 +97,7 @@ public class FetchComment {
             @Override
             public void onResponse(@NonNull Call<String> call, @NonNull Response<String> response) {
                 if (response.isSuccessful()) {
-                    ParseComment.parseMoreComment(executor, handler, response.body(), new ArrayList<>(),
+                    ParseComment.parseMoreComment(executor, handler, response.body(),
                             expandChildren, new ParseComment.ParseCommentListener() {
                                 @Override
                                 public void onParseCommentSuccess(ArrayList<Comment> expandedComments,

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/comment/FetchComment.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/comment/FetchComment.java
@@ -45,7 +45,8 @@ public class FetchComment {
                     ParseComment.parseComment(executor, handler, response.body(),
                             expandChildren, new ParseComment.ParseCommentListener() {
                                 @Override
-                                public void onParseCommentSuccess(ArrayList<Comment> expandedComments,
+                                public void onParseCommentSuccess(ArrayList<Comment> topLevelComments,
+                                                                  ArrayList<Comment> expandedComments,
                                                                   String parentId, ArrayList<String> moreChildrenIds) {
                                     fetchCommentListener.onFetchCommentSuccess(expandedComments, parentId,
                                             moreChildrenIds);
@@ -100,9 +101,11 @@ public class FetchComment {
                     ParseComment.parseMoreComment(executor, handler, response.body(),
                             expandChildren, new ParseComment.ParseCommentListener() {
                                 @Override
-                                public void onParseCommentSuccess(ArrayList<Comment> expandedComments,
+                                public void onParseCommentSuccess(ArrayList<Comment> topLevelComments,
+                                                                  ArrayList<Comment> expandedComments,
                                                                   String parentId, ArrayList<String> moreChildrenIds) {
-                                    fetchMoreCommentListener.onFetchMoreCommentSuccess(expandedComments, moreChildrenIds);
+                                    fetchMoreCommentListener.onFetchMoreCommentSuccess(
+                                            topLevelComments,expandedComments, moreChildrenIds);
                                 }
 
                                 @Override
@@ -129,7 +132,9 @@ public class FetchComment {
     }
 
     public interface FetchMoreCommentListener {
-        void onFetchMoreCommentSuccess(ArrayList<Comment> expandedComments,  ArrayList<String> moreChildrenIds);
+        void onFetchMoreCommentSuccess(ArrayList<Comment> topLevelComments,
+                                       ArrayList<Comment> expandedComments,
+                                       ArrayList<String> moreChildrenIds);
 
         void onFetchMoreCommentFailed();
     }

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/comment/ParseComment.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/comment/ParseComment.java
@@ -11,6 +11,7 @@ import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import org.checkerframework.checker.units.qual.A;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -24,7 +25,7 @@ import ml.docilealligator.infinityforreddit.utils.Utils;
 
 public class ParseComment {
     public static void parseComment(Executor executor, Handler handler, String response,
-                                    ArrayList<Comment> commentData, boolean expandChildren,
+                                    boolean expandChildren,
                                     ParseCommentListener parseCommentListener) {
         executor.execute(() -> {
             try {
@@ -40,10 +41,11 @@ public class ParseComment {
                 parseCommentRecursion(childrenArray, newComments, moreChildrenIds, 0);
                 expandChildren(newComments, expandedNewComments, expandChildren);
 
+                ArrayList<Comment> commentData;
                 if (expandChildren) {
-                    commentData.addAll(expandedNewComments);
+                    commentData = expandedNewComments;
                 } else {
-                    commentData.addAll(newComments);
+                    commentData = newComments;
                 }
 
                 handler.post(() -> parseCommentListener.onParseCommentSuccess(commentData, parentId, moreChildrenIds));
@@ -54,8 +56,7 @@ public class ParseComment {
         });
     }
 
-    static void parseMoreComment(Executor executor, Handler handler, String response,
-                                 ArrayList<Comment> commentData, boolean expandChildren,
+    static void parseMoreComment(Executor executor, Handler handler, String response, boolean expandChildren,
                                  ParseCommentListener parseCommentListener) {
         executor.execute(() -> {
             try {
@@ -126,10 +127,11 @@ public class ParseComment {
                 updateChildrenCount(newComments);
                 expandChildren(newComments, expandedNewComments, expandChildren);
 
+                ArrayList<Comment> commentData;
                 if (expandChildren) {
-                    commentData.addAll(expandedNewComments);
+                    commentData = expandedNewComments;
                 } else {
-                    commentData.addAll(newComments);
+                    commentData = newComments;
                 }
 
                 handler.post(() -> parseCommentListener.onParseCommentSuccess(commentData, null, moreChildrenIds));

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/comment/ParseComment.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/comment/ParseComment.java
@@ -48,7 +48,7 @@ public class ParseComment {
                     commentData = newComments;
                 }
 
-                handler.post(() -> parseCommentListener.onParseCommentSuccess(commentData, parentId, moreChildrenIds));
+                handler.post(() -> parseCommentListener.onParseCommentSuccess(newComments, commentData, parentId, moreChildrenIds));
             } catch (JSONException e) {
                 e.printStackTrace();
                 handler.post(parseCommentListener::onParseCommentFailed);
@@ -134,7 +134,7 @@ public class ParseComment {
                     commentData = newComments;
                 }
 
-                handler.post(() -> parseCommentListener.onParseCommentSuccess(commentData, null, moreChildrenIds));
+                handler.post(() -> parseCommentListener.onParseCommentSuccess(newComments, commentData, null, moreChildrenIds));
             } catch (JSONException e) {
                 e.printStackTrace();
                 handler.post(parseCommentListener::onParseCommentFailed);
@@ -367,7 +367,7 @@ public class ParseComment {
     }
 
     public interface ParseCommentListener {
-        void onParseCommentSuccess(ArrayList<Comment> expandedComments, String parentId,
+        void onParseCommentSuccess(ArrayList<Comment> topLevelComments, ArrayList<Comment> expandedComments, String parentId,
                                    ArrayList<String> moreChildrenIds);
 
         void onParseCommentFailed();

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/customviews/SwipeLockFrameLayout.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/customviews/SwipeLockFrameLayout.java
@@ -38,7 +38,7 @@ public class SwipeLockFrameLayout extends FrameLayout implements SwipeLockView {
     @Override
     public boolean onInterceptTouchEvent(MotionEvent ev) {
         updateSwipeLock(ev);
-        return false;
+        return locked;
     }
 
     @SuppressLint("ClickableViewAccessibility") // we are just listening to touch events

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/customviews/SwipeLockFrameLayout.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/customviews/SwipeLockFrameLayout.java
@@ -38,7 +38,7 @@ public class SwipeLockFrameLayout extends FrameLayout implements SwipeLockView {
     @Override
     public boolean onInterceptTouchEvent(MotionEvent ev) {
         updateSwipeLock(ev);
-        return true;
+        return false;
     }
 
     @SuppressLint("ClickableViewAccessibility") // we are just listening to touch events

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/fragments/PostFragment.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/fragments/PostFragment.java
@@ -1058,8 +1058,8 @@ public class PostFragment extends Fragment implements FragmentCommunicator {
                 if (!(viewHolder instanceof PostRecyclerViewAdapter.PostBaseViewHolder) &&
                         !(viewHolder instanceof PostRecyclerViewAdapter.PostCompactBaseViewHolder)) {
                     return makeMovementFlags(0, 0);
-                } else if (viewHolder instanceof PostRecyclerViewAdapter.PostGalleryTypeViewHolder) {
-                    if (((PostRecyclerViewAdapter.PostGalleryTypeViewHolder) viewHolder).isSwipeLocked()) {
+                } else if (viewHolder instanceof PostRecyclerViewAdapter.PostBaseGalleryTypeViewHolder) {
+                    if (((PostRecyclerViewAdapter.PostBaseGalleryTypeViewHolder) viewHolder).isSwipeLocked()) {
                         return makeMovementFlags(0, 0);
                     }
 

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/fragments/PostFragment.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/fragments/PostFragment.java
@@ -16,6 +16,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.CountDownTimer;
 import android.os.Handler;
+import android.util.Log;
 import android.view.HapticFeedbackConstants;
 import android.view.KeyEvent;
 import android.view.LayoutInflater;

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/fragments/ViewPostDetailFragment.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/fragments/ViewPostDetailFragment.java
@@ -1347,7 +1347,7 @@ public class ViewPostDetailFragment extends Fragment implements FragmentCommunic
                             if (mRespectSubredditRecommendedSortType) {
                                 fetchCommentsRespectRecommendedSort(false);
                             } else {
-                                ParseComment.parseComment(mExecutor, new Handler(), response.body(), new ArrayList<>(),
+                                ParseComment.parseComment(mExecutor, new Handler(), response.body(),
                                         mExpandChildren, new ParseComment.ParseCommentListener() {
                                             @Override
                                             public void onParseCommentSuccess(ArrayList<Comment> expandedComments, String parentId, ArrayList<String> moreChildrenIds) {

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/fragments/ViewPostDetailFragment.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/fragments/ViewPostDetailFragment.java
@@ -1350,7 +1350,7 @@ public class ViewPostDetailFragment extends Fragment implements FragmentCommunic
                                 ParseComment.parseComment(mExecutor, new Handler(), response.body(),
                                         mExpandChildren, new ParseComment.ParseCommentListener() {
                                             @Override
-                                            public void onParseCommentSuccess(ArrayList<Comment> expandedComments, String parentId, ArrayList<String> moreChildrenIds) {
+                                            public void onParseCommentSuccess(ArrayList<Comment> topLevelComments, ArrayList<Comment> expandedComments, String parentId, ArrayList<String> moreChildrenIds) {
                                                 ViewPostDetailFragment.this.children = moreChildrenIds;
 
                                                 hasMoreChildren = children.size() != 0;
@@ -1577,7 +1577,9 @@ public class ViewPostDetailFragment extends Fragment implements FragmentCommunic
         FetchComment.fetchMoreComment(mExecutor, new Handler(), retrofit, mAccessToken, children,
                 mExpandChildren, mPost.getFullName(), sortType, new FetchComment.FetchMoreCommentListener() {
                     @Override
-                    public void onFetchMoreCommentSuccess(ArrayList<Comment> expandedComments, ArrayList<String> moreChildrenIds) {
+                    public void onFetchMoreCommentSuccess(ArrayList<Comment> topLevelComments,
+                                                          ArrayList<Comment> expandedComments,
+                                                          ArrayList<String> moreChildrenIds) {
                         children = moreChildrenIds;
                         hasMoreChildren = !children.isEmpty();
                         mCommentsAdapter.addComments(expandedComments, hasMoreChildren);

--- a/app/src/main/res/layout/item_post_card_2_gallery_type.xml
+++ b/app/src/main/res/layout/item_post_card_2_gallery_type.xml
@@ -1,0 +1,309 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:paddingTop="16dp"
+    android:clickable="true"
+    android:focusable="true"
+    android:background="?attr/selectableItemBackground"
+    android:orientation="vertical">
+
+    <com.google.android.material.card.MaterialCardView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
+        app:cardElevation="2dp"
+        app:cardCornerRadius="8dp"
+        style="?attr/materialCardViewElevatedStyle">
+
+        <FrameLayout
+            android:id="@+id/gallery_frame_layout_item_post_card_2_gallery_type"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:visibility="gone">
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/gallery_recycler_view_item_post_card_2_gallery_type"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal" />
+
+            <com.libRG.CustomTextView
+                android:id="@+id/image_index_text_view_item_post_card_2_gallery_type"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_margin="16dp"
+                android:textSize="?attr/font_12"
+                android:fontFamily="?attr/font_family"
+                android:padding="4dp"
+                app:lib_setRadius="6dp"
+                app:lib_setRoundedView="true"
+                app:lib_setShape="rectangle" />
+
+        </FrameLayout>
+
+        <ImageView
+            android:id="@+id/no_preview_image_view_item_post_card_2_gallery_type"
+            android:layout_width="match_parent"
+            android:layout_height="150dp"
+            android:scaleType="center"
+            android:visibility="gone" />
+
+    </com.google.android.material.card.MaterialCardView>
+
+    <TextView
+        android:id="@+id/title_text_view_item_post_card_2_gallery_type"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp"
+        android:textSize="?attr/title_font_18"
+        android:fontFamily="?attr/title_font_family" />
+
+    <com.nex3z.flowlayout.FlowLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="16dp"
+        app:flRowVerticalGravity="center"
+        app:flChildSpacing="16dp"
+        app:flChildSpacingForLastRow="align"
+        app:flRowSpacing="8dp">
+
+        <com.libRG.CustomTextView
+            android:id="@+id/type_text_view_item_post_card_2_gallery_type"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:padding="4dp"
+            android:text="@string/gallery"
+            android:textSize="?attr/font_12"
+            android:fontFamily="?attr/font_family"
+            app:lib_setRadius="6dp"
+            app:lib_setRoundedView="true"
+            app:lib_setShape="rectangle" />
+
+        <com.libRG.CustomTextView
+            android:id="@+id/spoiler_custom_text_view_item_post_card_2_gallery_type"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:text="@string/spoiler"
+            android:textSize="?attr/font_12"
+            android:fontFamily="?attr/font_family"
+            android:padding="4dp"
+            android:visibility="gone"
+            app:lib_setRadius="6dp"
+            app:lib_setRoundedView="true"
+            app:lib_setShape="rectangle" />
+
+        <com.libRG.CustomTextView
+            android:id="@+id/nsfw_text_view_item_post_card_2_gallery_type"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:padding="4dp"
+            android:text="@string/nsfw"
+            android:textSize="?attr/font_12"
+            android:fontFamily="?attr/font_family"
+            android:visibility="gone"
+            app:lib_setRadius="6dp"
+            app:lib_setRoundedView="true"
+            app:lib_setShape="rectangle" />
+
+        <com.libRG.CustomTextView
+            android:id="@+id/flair_custom_text_view_item_post_card_2_gallery_type"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:textSize="?attr/font_12"
+            android:fontFamily="?attr/font_family"
+            android:padding="4dp"
+            android:visibility="gone"
+            app:lib_setRadius="6dp"
+            app:lib_setRoundedView="true"
+            app:lib_setShape="rectangle" />
+
+        <com.libRG.CustomTextView
+            android:id="@+id/awards_text_view_item_post_card_2_gallery_type"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:padding="4dp"
+            android:textSize="?attr/font_12"
+            android:fontFamily="?attr/font_family"
+            android:visibility="gone"
+            app:lib_setRadius="6dp"
+            app:lib_setRoundedView="true"
+            app:lib_setShape="rectangle" />
+
+        <ImageView
+            android:id="@+id/archived_image_view_item_post_card_2_gallery_type"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:src="@drawable/ic_archive_outline"
+            android:visibility="gone" />
+
+        <ImageView
+            android:id="@+id/locked_image_view_item_post_card_2_gallery_type"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:src="@drawable/ic_outline_lock_24dp"
+            android:visibility="gone" />
+
+        <ImageView
+            android:id="@+id/crosspost_image_view_item_post_card_2_gallery_type"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:src="@drawable/crosspost"
+            android:visibility="gone" />
+
+        <ImageView
+            android:id="@+id/stickied_post_image_view_item_post_card_2_gallery_type"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:visibility="gone"
+            tools:visibility="visible" />
+
+        <TextView
+            android:id="@+id/link_text_view_item_post_card_2_gallery_type"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="?attr/font_12"
+            android:fontFamily="?attr/font_family"
+            android:visibility="gone" />
+
+        <TextView
+            android:id="@+id/post_time_text_view_item_post_card_2_gallery_type"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="?attr/font_default"
+            android:fontFamily="?attr/font_family" />
+
+    </com.nex3z.flowlayout.FlowLayout>
+
+    <com.nex3z.flowlayout.FlowLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp"
+        app:flRowVerticalGravity="center"
+        app:flChildSpacing="16dp"
+        app:flChildSpacingForLastRow="align"
+        app:flRowSpacing="8dp">
+
+        <ml.docilealligator.infinityforreddit.customviews.AspectRatioGifImageView
+            android:id="@+id/icon_gif_image_view_item_post_card_2_gallery_type"
+            android:layout_width="24dp"
+            android:layout_height="24dp" />
+
+        <TextView
+            android:id="@+id/subreddit_name_text_view_item_post_card_2_gallery_type"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="?attr/font_default"
+            android:fontFamily="?attr/font_family" />
+
+        <TextView
+            android:id="@+id/user_text_view_item_post_card_2_gallery_type"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="?attr/font_default"
+            android:fontFamily="?attr/font_family" />
+
+    </com.nex3z.flowlayout.FlowLayout>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/bottom_constraint_layout_item_post_card_2_gallery_type"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <ImageView
+            android:id="@+id/upvote_button_item_post_card_2_gallery_type"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:padding="12dp"
+            android:src="@drawable/ic_arrow_upward_grey_24dp"
+            android:background="?actionBarItemBackground"
+            android:clickable="true"
+            android:focusable="true"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent" />
+
+        <TextView
+            android:id="@+id/score_text_view_item_post_card_2_gallery_type"
+            android:layout_width="64dp"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:textSize="?attr/font_12"
+            android:textStyle="bold"
+            android:fontFamily="?attr/font_family"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toEndOf="@id/upvote_button_item_post_card_2_gallery_type" />
+
+        <ImageView
+            android:id="@+id/downvote_button_item_post_card_2_gallery_type"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:padding="12dp"
+            android:src="@drawable/ic_arrow_downward_grey_24dp"
+            android:background="?actionBarItemBackground"
+            android:clickable="true"
+            android:focusable="true"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toEndOf="@id/score_text_view_item_post_card_2_gallery_type" />
+
+        <TextView
+            android:id="@+id/comments_count_text_view_item_post_card_2_gallery_type"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:padding="12dp"
+            android:gravity="center_vertical"
+            android:textSize="?attr/font_12"
+            android:textStyle="bold"
+            android:fontFamily="?attr/font_family"
+            android:drawableStart="@drawable/ic_comment_grey_24dp"
+            android:drawablePadding="12dp"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toEndOf="@id/downvote_button_item_post_card_2_gallery_type" />
+
+        <ImageView
+            android:id="@+id/save_button_item_post_card_2_gallery_type"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:padding="12dp"
+            android:background="?actionBarItemBackground"
+            android:clickable="true"
+            android:focusable="true"
+            app:layout_constraintHorizontal_bias="1"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toEndOf="@id/comments_count_text_view_item_post_card_2_gallery_type"
+            app:layout_constraintEnd_toStartOf="@id/share_button_item_post_card_2_gallery_type" />
+
+        <ImageView
+            android:id="@+id/share_button_item_post_card_2_gallery_type"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:padding="12dp"
+            android:src="@drawable/ic_share_grey_24dp"
+            android:background="?actionBarItemBackground"
+            android:clickable="true"
+            android:focusable="true"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <View
+        android:id="@+id/divider_item_post_card_2_gallery_type"
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:paddingBottom="8dp" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/item_post_gallery_type.xml
+++ b/app/src/main/res/layout/item_post_gallery_type.xml
@@ -196,11 +196,31 @@
 
         </com.nex3z.flowlayout.FlowLayout>
 
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/gallery_recycler_view_item_post_gallery_type"
-            android:layout_width="match_parent"
+        <FrameLayout
+            android:id="@+id/gallery_frame_layout_item_post_gallery_type"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:orientation="horizontal" />
+            android:visibility="gone">
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/gallery_recycler_view_item_post_gallery_type"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal" />
+
+            <com.libRG.CustomTextView
+                android:id="@+id/image_index_text_view_item_post_gallery_type"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_margin="16dp"
+                android:textSize="?attr/font_12"
+                android:fontFamily="?attr/font_family"
+                android:padding="4dp"
+                app:lib_setRadius="6dp"
+                app:lib_setRoundedView="true"
+                app:lib_setShape="rectangle" />
+
+        </FrameLayout>
 
         <ImageView
             android:id="@+id/no_preview_image_view_item_post_gallery_type"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,12 +25,12 @@
     <string name="edit_multi_reddit_activity_label">Edit Multireddit</string>
     <string name="selected_subeddits_activity_label">Selected Subreddits</string>
     <string name="report_activity_label">Report</string>
-    <string name="view_imgur_media_activity_image_label">Image %1$,d/%2$d</string>
-    <string name="view_imgur_media_activity_video_label">Video %1$,d/%2$d</string>
+    <string name="view_imgur_media_activity_image_label">Image %1$d/%2$d</string>
+    <string name="view_imgur_media_activity_video_label">Video %1$d/%2$d</string>
     <string name="send_private_message_activity_label">Send PM</string>
-    <string name="view_reddit_gallery_activity_image_label">Image %1$,d/%2$d</string>
-    <string name="view_reddit_gallery_activity_gif_label">Gif %1$,d/%2$d</string>
-    <string name="view_reddit_gallery_activity_video_label">Video %1$,d/%2$d</string>
+    <string name="view_reddit_gallery_activity_image_label">Image %1$d/%2$d</string>
+    <string name="view_reddit_gallery_activity_gif_label">Gif %1$d/%2$d</string>
+    <string name="view_reddit_gallery_activity_video_label">Video %1$d/%2$d</string>
     <string name="submit_crosspost_activity_label">Crosspost</string>
     <string name="give_award_activity_label">Give Award</string>
     <string name="subreddit_filter_popular_and_all_activity_label">r/all and r/popular</string>
@@ -201,7 +201,7 @@
     <string name="title_required">The post needs a good title</string>
     <string name="link_required">Hey where is the link?</string>
     <string name="select_an_image">Please select an image first</string>
-    <string name="voting_length">Voting length: %1$,d days</string>
+    <string name="voting_length">Voting length: %1$d days</string>
     <string name="posting">Posting</string>
     <string name="post_failed">Could not post it</string>
     <string name="error_processing_image">Error processing image</string>
@@ -358,7 +358,7 @@
     <string name="notification_summary_message">New Message</string>
     <string name="notification_summary_subreddit">Subreddit</string>
     <string name="notification_summary_award">Award</string>
-    <string name="notification_new_messages">%1$,d New Messages</string>
+    <string name="notification_new_messages">%1$d New Messages</string>
 
     <string name="label_account">Account</string>
     <string name="label_reddit">Reddit</string>
@@ -382,9 +382,9 @@
     <string name="settings_mute_autoplaying_videos_title">Mute Autoplaying Videos</string>
     <string name="settings_autoplay_nsfw_videos_title">Autoplay NSFW Videos</string>
     <string name="settings_start_autoplay_visible_area_offset_portrait_title">Autoplay Videos Visible Area Offset (Portrait)</string>
-    <string name="settings_start_autoplay_visible_area_offset_portrait_summary">Start autoplaying videos when %1$,d%% of them are visible</string>
+    <string name="settings_start_autoplay_visible_area_offset_portrait_summary">Start autoplaying videos when %1$d%% of them are visible</string>
     <string name="settings_start_autoplay_visible_area_offset_landscape_title">Autoplay Videos Visible Area Offset (Landscape)</string>
-    <string name="settings_start_autoplay_visible_area_offset_landscape_summary">Start autoplaying videos when %1$,d%% of them are visible</string>
+    <string name="settings_start_autoplay_visible_area_offset_landscape_summary">Start autoplaying videos when %1$d%% of them are visible</string>
     <string name="settings_immersive_interface_title">Immersive Interface</string>
     <string name="settings_immersive_interface_summary">Does Not Apply to All Pages</string>
     <string name="settings_immersive_interface_ignore_nav_bar_title">Ignore Navigation Bar in Immersive Interface</string>
@@ -636,7 +636,7 @@
     <string name="settings_hide_text_post_content">Hide Text Post Content</string>
     <string name="settings_hide_comment_awards_title">Hide Comment Awards</string>
     <string name="settings_show_fewer_toolbar_options_threshold_title">Show Fewer Toolbar Options Starting From</string>
-    <string name="settings_show_fewer_toolbar_options_threshold_summary">Level %1$,d</string>
+    <string name="settings_show_fewer_toolbar_options_threshold_summary">Level %1$d</string>
     <string name="settings_show_author_avatar_title">Show Author Avatar</string>
     <string name="settings_reddit_user_agreement_title">Reddit User Agreement</string>
     <string name="settings_always_show_child_comment_count_title">Always Show the Number of Child Comments</string>
@@ -688,15 +688,15 @@
 
     <string name="elapsed_time_just_now">Just Now</string>
     <string name="elapsed_time_a_minute_ago">1 Minute</string>
-    <string name="elapsed_time_minutes_ago">%1$,d Minutes</string>
+    <string name="elapsed_time_minutes_ago">%1$d Minutes</string>
     <string name="elapsed_time_an_hour_ago">1 Hour</string>
-    <string name="elapsed_time_hours_ago">%1$,d Hours</string>
+    <string name="elapsed_time_hours_ago">%1$d Hours</string>
     <string name="elapsed_time_yesterday">Yesterday</string>
-    <string name="elapsed_time_days_ago">%1$,d Days</string>
+    <string name="elapsed_time_days_ago">%1$d Days</string>
     <string name="elapsed_time_a_month_ago">1 Month</string>
-    <string name="elapsed_time_months_ago">%1$,d Months</string>
+    <string name="elapsed_time_months_ago">%1$d Months</string>
     <string name="elapsed_time_a_year_ago">1 Year</string>
-    <string name="elapsed_time_years_ago">%1$,d Years</string>
+    <string name="elapsed_time_years_ago">%1$d Years</string>
 
     <string name="error_getting_multi_reddit_data">Error getting multireddit data</string>
     <string name="error_loading_multi_reddit_list">Cannot sync multireddits</string>
@@ -1077,7 +1077,7 @@
 
     <string name="give_award_dialog_title">Give Award?</string>
     <string name="anonymous">Anonymous</string>
-    <string name="give_award_error_message">Code: %1$,d/\n Message: %2$s</string>
+    <string name="give_award_error_message">Code: %1$d/\n Message: %2$s</string>
     <string name="give_award_success">Award given</string>
     <string name="give_award_failed">Failed</string>
 
@@ -1314,5 +1314,7 @@
 
     <string name="load_more_posts_failed">Failed to load more posts.\nTap to retry.</string>
     <string name="no_more_posts">No more posts</string>
+
+    <string name="image_index_in_gallery">%1$d/%2$d</string>
 
 </resources>


### PR DESCRIPTION
Fixes #1221. Caught this one early

- [Remove commentData argument that is always an empty ArrayList](https://github.com/Docile-Alligator/Infinity-For-Reddit/commit/d82d7e51aaeb4be743fc453b332fa447bfbf0bb3)
- [Return top level comments in addition to expanded comments after parsing](https://github.com/Docile-Alligator/Infinity-For-Reddit/commit/ba0c1739df7d2d7c8103d9942984952077c76120)

  Since #1186  loading more comments loads not only first level replies, but also deeper comments. Because of this `expandedComments` can contain those deep replies if `expandChildren` is true. Adding `expandedComments` to parent causes a bug because parent's children are supposed to be only next level replies. Because of previously mentioned changes that is not true.

  Now expanding parent comment results in duplicate comments: one of them correctly comes from the parent of duplicated comment. The other one is shown because it is incorrectly stored in the parent of "load more comments" button.

  This comment separates top level comments (fist level replies) and expanded comments. `expandedComments` are still used for display, but only first level replies are added to the parent
- [Add debug assertion for children depth](https://github.com/Docile-Alligator/Infinity-For-Reddit/commit/1d4f0a688a91566e74cb953f4354192055abf233)