### PR TITLE
Ignore NotifyDataSetChanged lint warnings for Markwon adapters

### DIFF
--- a/app/src/main/java/ml/docilealligator/infinityforreddit/activities/CommentActivity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/activities/CommentActivity.java
@@ -213,6 +213,7 @@ public class CommentActivity extends BaseActivity implements UploadImageEnabledA
             binding.commentContentMarkdownView.setLayoutManager(new LinearLayoutManagerBugFixed(this));
             binding.commentContentMarkdownView.setAdapter(markwonAdapter);
             markwonAdapter.setMarkdown(postBodyMarkwon, parentBodyMarkdown);
+            // noinspection NotifyDataSetChanged
             markwonAdapter.notifyDataSetChanged();
         }
         parentFullname = intent.getStringExtra(EXTRA_PARENT_FULLNAME_KEY);

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/activities/FullMarkdownActivity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/activities/FullMarkdownActivity.java
@@ -162,6 +162,7 @@ public class FullMarkdownActivity extends BaseActivity {
         markdownRecyclerView.setLayoutManager(linearLayoutManager);
         markdownRecyclerView.setAdapter(markwonAdapter);
         markwonAdapter.setMarkdown(markwon, commentMarkdown);
+        // noinspection NotifyDataSetChanged
         markwonAdapter.notifyDataSetChanged();
     }
 

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/activities/WikiActivity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/activities/WikiActivity.java
@@ -204,6 +204,7 @@ public class WikiActivity extends BaseActivity {
             loadWiki();
         } else {
             markwonAdapter.setMarkdown(markwon, wikiMarkdown);
+            // noinspection NotifyDataSetChanged
             markwonAdapter.notifyDataSetChanged();
         }
     }
@@ -227,6 +228,7 @@ public class WikiActivity extends BaseActivity {
                         String markdown = new JSONObject(response.body())
                                 .getJSONObject(JSONUtils.DATA_KEY).getString(JSONUtils.CONTENT_MD_KEY);
                         markwonAdapter.setMarkdown(markwon, Utils.modifyMarkdown(markdown));
+                        // noinspection NotifyDataSetChanged
                         markwonAdapter.notifyDataSetChanged();
                     } catch (JSONException e) {
                         e.printStackTrace();

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/CommentsListingRecyclerViewAdapter.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/CommentsListingRecyclerViewAdapter.java
@@ -216,6 +216,7 @@ public class CommentsListingRecyclerViewAdapter extends PagedListAdapter<Comment
                 }
 
                 ((CommentViewHolder) holder).markwonAdapter.setMarkdown(mMarkwon, comment.getCommentMarkdown());
+                // noinspection NotifyDataSetChanged
                 ((CommentViewHolder) holder).markwonAdapter.notifyDataSetChanged();
 
                 String commentText = "";

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/CommentsRecyclerViewAdapter.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/CommentsRecyclerViewAdapter.java
@@ -441,6 +441,7 @@ public class CommentsRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerVi
                 }
 
                 ((CommentViewHolder) holder).mMarkwonAdapter.setMarkdown(mCommentMarkwon, comment.getCommentMarkdown());
+                // noinspection NotifyDataSetChanged
                 ((CommentViewHolder) holder).mMarkwonAdapter.notifyDataSetChanged();
 
                 if (!mHideTheNumberOfVotes) {

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/CustomizeThemeRecyclerViewAdapter.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/CustomizeThemeRecyclerViewAdapter.java
@@ -129,7 +129,6 @@ public class CustomizeThemeRecyclerViewAdapter extends RecyclerView.Adapter<Recy
 
     public void setCustomThemeSettingsItem(ArrayList<CustomThemeSettingsItem> customThemeSettingsItems) {
         this.customThemeSettingsItems.clear();
-        notifyDataSetChanged();
         this.customThemeSettingsItems.addAll(customThemeSettingsItems);
         notifyDataSetChanged();
     }

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/PostDetailRecyclerViewAdapter.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/PostDetailRecyclerViewAdapter.java
@@ -632,6 +632,7 @@ public class PostDetailRecyclerViewAdapter extends RecyclerView.Adapter<Recycler
                 ((PostDetailBaseViewHolder) holder).mContentMarkdownView.setVisibility(View.VISIBLE);
                 ((PostDetailBaseViewHolder) holder).mContentMarkdownView.setAdapter(mMarkwonAdapter);
                 mMarkwonAdapter.setMarkdown(mPostDetailMarkwon, mPost.getSelfText());
+                // noinspection NotifyDataSetChanged
                 mMarkwonAdapter.notifyDataSetChanged();
             }
 

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/fragments/SidebarFragment.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/fragments/SidebarFragment.java
@@ -169,6 +169,7 @@ public class SidebarFragment extends Fragment {
                 sidebarDescription = subredditData.getSidebarDescription();
                 if (sidebarDescription != null && !sidebarDescription.equals("")) {
                     markwonAdapter.setMarkdown(markwon, sidebarDescription);
+                    // noinspection NotifyDataSetChanged
                     markwonAdapter.notifyDataSetChanged();
                 }
             } else {


### PR DESCRIPTION
There is no "more efficient" way to update it