### PR TITLE
hide keyboard when choosing account from bottom sheet

### DIFF
--- a/app/src/main/java/ml/docilealligator/infinityforreddit/bottomsheetfragments/AccountChooserBottomSheetFragment.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/bottomsheetfragments/AccountChooserBottomSheetFragment.java
@@ -34,6 +34,7 @@ import ml.docilealligator.infinityforreddit.adapters.AccountChooserRecyclerViewA
 import ml.docilealligator.infinityforreddit.customtheme.CustomThemeWrapper;
 import ml.docilealligator.infinityforreddit.customviews.LandscapeExpandedBottomSheetDialogFragment;
 import ml.docilealligator.infinityforreddit.utils.SharedPreferencesUtils;
+import ml.docilealligator.infinityforreddit.utils.Utils;
 
 public class AccountChooserBottomSheetFragment extends LandscapeExpandedBottomSheetDialogFragment {
 
@@ -60,6 +61,8 @@ public class AccountChooserBottomSheetFragment extends LandscapeExpandedBottomSh
         View rootView = inflater.inflate(R.layout.fragment_account_chooser_bottom_sheet, container, false);
 
         ((Infinity) activity.getApplication()).getAppComponent().inject(this);
+
+        Utils.hideKeyboard(activity);
 
         recyclerView = rootView.findViewById(R.id.recycler_view_account_chooser_bottom_sheet_fragment);
         adapter = new AccountChooserRecyclerViewAdapter(activity, customThemeWrapper, Glide.with(this),


### PR DESCRIPTION
When selecting an account from the bottom sheet, currently the keyboard can get in the way. This adds a call to hide the keyboard whenever the bottom sheet is opened.

Closes #998 and #932.