### PR TITLE
Remove unused download events

### DIFF
--- a/app/src/main/java/ml/docilealligator/infinityforreddit/events/DownloadMediaEvent.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/events/DownloadMediaEvent.java
@@ -1,9 +1,0 @@
-package ml.docilealligator.infinityforreddit.events;
-
-public class DownloadMediaEvent {
-    public boolean isSuccessful;
-
-    public DownloadMediaEvent(boolean isSuccessful) {
-        this.isSuccessful = isSuccessful;
-    }
-}

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/events/DownloadRedditVideoEvent.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/events/DownloadRedditVideoEvent.java
@@ -1,9 +1,0 @@
-package ml.docilealligator.infinityforreddit.events;
-
-public class DownloadRedditVideoEvent {
-    public boolean isSuccessful;
-
-    public DownloadRedditVideoEvent(boolean isSuccessful) {
-        this.isSuccessful = isSuccessful;
-    }
-}

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/services/DownloadMediaService.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/services/DownloadMediaService.java
@@ -27,8 +27,6 @@ import androidx.core.app.NotificationCompat;
 import androidx.core.app.NotificationManagerCompat;
 import androidx.documentfile.provider.DocumentFile;
 
-import org.greenrobot.eventbus.EventBus;
-
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -45,7 +43,6 @@ import ml.docilealligator.infinityforreddit.R;
 import ml.docilealligator.infinityforreddit.apis.DownloadFile;
 import ml.docilealligator.infinityforreddit.broadcastreceivers.DownloadedMediaDeleteActionBroadcastReceiver;
 import ml.docilealligator.infinityforreddit.customtheme.CustomThemeWrapper;
-import ml.docilealligator.infinityforreddit.events.DownloadMediaEvent;
 import ml.docilealligator.infinityforreddit.utils.APIUtils;
 import ml.docilealligator.infinityforreddit.utils.NotificationUtils;
 import ml.docilealligator.infinityforreddit.utils.SharedPreferencesUtils;
@@ -337,14 +334,12 @@ public class DownloadMediaService extends Service {
                                 -1, randomNotificationIdOffset, null, null);
                         break;
                 }
-                EventBus.getDefault().post(new DownloadMediaEvent(false));
             } else {
                 MediaScannerConnection.scanFile(
                         DownloadMediaService.this, new String[]{destinationFileUri.toString()}, null,
                         (path, uri) -> {
                             updateNotification(mediaType, R.string.downloading_media_finished, -1,
                                     randomNotificationIdOffset, destinationFileUri, mimeType);
-                            EventBus.getDefault().post(new DownloadMediaEvent(true));
                         }
                 );
             }

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/services/DownloadRedditVideoService.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/services/DownloadRedditVideoService.java
@@ -25,14 +25,11 @@ import android.os.Looper;
 import android.os.Message;
 import android.os.Process;
 import android.provider.MediaStore;
-import android.util.Log;
 
 import androidx.core.app.NotificationChannelCompat;
 import androidx.core.app.NotificationCompat;
 import androidx.core.app.NotificationManagerCompat;
 import androidx.documentfile.provider.DocumentFile;
-
-import org.greenrobot.eventbus.EventBus;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -52,7 +49,6 @@ import ml.docilealligator.infinityforreddit.R;
 import ml.docilealligator.infinityforreddit.apis.DownloadFile;
 import ml.docilealligator.infinityforreddit.broadcastreceivers.DownloadedMediaDeleteActionBroadcastReceiver;
 import ml.docilealligator.infinityforreddit.customtheme.CustomThemeWrapper;
-import ml.docilealligator.infinityforreddit.events.DownloadRedditVideoEvent;
 import ml.docilealligator.infinityforreddit.utils.NotificationUtils;
 import ml.docilealligator.infinityforreddit.utils.SharedPreferencesUtils;
 import okhttp3.OkHttpClient;
@@ -594,13 +590,11 @@ public class DownloadRedditVideoService extends Service {
                             randomNotificationIdOffset, null);
                     break;
             }
-            EventBus.getDefault().post(new DownloadRedditVideoEvent(false));
         } else {
             MediaScannerConnection.scanFile(
                     this, new String[]{destinationFileUri.toString()}, null,
                     (path, uri) -> {
                         updateNotification(R.string.downloading_reddit_video_finished, -1, randomNotificationIdOffset, destinationFileUri);
-                        EventBus.getDefault().post(new DownloadRedditVideoEvent(true));
                     }
             );
         }


### PR DESCRIPTION
I haven't actually checked if they should be used anywhere, so this might point to a bug