### PR TITLE
Sort type converters - part 2

### DIFF
--- a/app/src/main/java/ml/docilealligator/infinityforreddit/activities/ViewPostDetailActivity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/activities/ViewPostDetailActivity.java
@@ -164,9 +164,9 @@ public class ViewPostDetailActivity extends BaseActivity implements SortTypeSele
     @State
     PostFilter postFilter;
     @State
-    String sortType;
+    SortType.Type sortType;
     @State
-    String sortTime;
+    SortType.Time sortTime;
     @State
     ArrayList<String> readPostList;
     @State
@@ -535,111 +535,55 @@ public class ViewPostDetailActivity extends BaseActivity implements SortTypeSele
                 switch (postType) {
                     case PostPagingSource.TYPE_SUBREDDIT:
                         if (mAccessToken == null) {
-                            if (sortTime != null) {
-                                call = api.getSubredditBestPosts(subredditName, sortType, sortTime, afterKey);
-                            } else {
-                                call = api.getSubredditBestPosts(subredditName, sortType, afterKey);
-                            }
+                            call = api.getSubredditBestPosts(subredditName, sortType, sortTime, afterKey);
                         } else {
-                            if (sortTime != null) {
-                                call = api.getSubredditBestPostsOauth(subredditName, sortType,
-                                        sortTime, afterKey, APIUtils.getOAuthHeader(mAccessToken));
-                            } else {
-                                call = api.getSubredditBestPostsOauth(subredditName, sortType,
-                                        afterKey, APIUtils.getOAuthHeader(mAccessToken));
-                            }
+                            call = api.getSubredditBestPostsOauth(subredditName, sortType,
+                                   sortTime, afterKey, APIUtils.getOAuthHeader(mAccessToken));
                         }
                         break;
                     case PostPagingSource.TYPE_USER:
                         if (mAccessToken == null) {
-                            if (sortTime != null) {
-                                call = api.getUserPosts(username, afterKey, sortType,
-                                        sortTime);
-                            } else {
-                                call = api.getUserPosts(username, afterKey, sortType);
-                            }
+                            call = api.getUserPosts(username, afterKey, sortType, sortTime);
                         } else {
-                            if (sortTime != null) {
-                                call = api.getUserPostsOauth(username, userWhere, afterKey, sortType,
-                                        sortTime, APIUtils.getOAuthHeader(mAccessToken));
-                            } else {
-                                call = api.getUserPostsOauth(username, userWhere, afterKey, sortType,
-                                        APIUtils.getOAuthHeader(mAccessToken));
-                            }
+                            call = api.getUserPostsOauth(username, userWhere, afterKey, sortType,
+                                    sortTime, APIUtils.getOAuthHeader(mAccessToken));
                         }
                         break;
                     case PostPagingSource.TYPE_SEARCH:
                         if (subredditName == null) {
                             if (mAccessToken == null) {
-                                if (sortTime != null) {
-                                    call = api.searchPosts(query, afterKey, sortType, sortTime,
-                                            trendingSource);
-                                } else {
-                                    call = api.searchPosts(query, afterKey, sortType, trendingSource);
-                                }
+                                call = api.searchPosts(query, afterKey, sortType, sortTime,
+                                        trendingSource);
                             } else {
-                                if (sortTime != null) {
-                                    call = api.searchPostsOauth(query, afterKey, sortType,
-                                            sortTime, trendingSource, APIUtils.getOAuthHeader(mAccessToken));
-                                } else {
-                                    call = api.searchPostsOauth(query, afterKey, sortType, trendingSource,
-                                            APIUtils.getOAuthHeader(mAccessToken));
-                                }
+                                call = api.searchPostsOauth(query, afterKey, sortType,
+                                        sortTime, trendingSource, APIUtils.getOAuthHeader(mAccessToken));
                             }
                         } else {
                             if (mAccessToken == null) {
-                                if (sortTime != null) {
-                                    call = api.searchPostsInSpecificSubreddit(subredditName, query,
-                                            sortType, sortTime, afterKey);
-                                } else {
-                                    call = api.searchPostsInSpecificSubreddit(subredditName, query,
-                                            sortType, afterKey);
-                                }
+                                call = api.searchPostsInSpecificSubreddit(subredditName, query,
+                                        sortType, sortTime, afterKey);
                             } else {
-                                if (sortTime != null) {
-                                    call = api.searchPostsInSpecificSubredditOauth(subredditName, query,
-                                            sortType, sortTime, afterKey,
-                                            APIUtils.getOAuthHeader(mAccessToken));
-                                } else {
-                                    call = api.searchPostsInSpecificSubredditOauth(subredditName, query,
-                                            sortType, afterKey,
-                                            APIUtils.getOAuthHeader(mAccessToken));
-                                }
+                                call = api.searchPostsInSpecificSubredditOauth(subredditName, query,
+                                        sortType, sortTime, afterKey,
+                                        APIUtils.getOAuthHeader(mAccessToken));
                             }
                         }
                         break;
                     case PostPagingSource.TYPE_MULTI_REDDIT:
                         if (mAccessToken == null) {
-                            if (sortTime != null) {
-                                call = api.getMultiRedditPosts(multiPath, afterKey, sortTime);
-                            } else {
-                                call = api.getMultiRedditPosts(multiPath, afterKey);
-                            }
+                            call = api.getMultiRedditPosts(multiPath, afterKey, sortTime);
                         } else {
-                            if (sortTime != null) {
-                                call = api.getMultiRedditPostsOauth(multiPath, afterKey,
-                                        sortTime, APIUtils.getOAuthHeader(mAccessToken));
-                            } else {
-                                call = api.getMultiRedditPostsOauth(multiPath, afterKey,
-                                        APIUtils.getOAuthHeader(mAccessToken));
-                            }
+                            call = api.getMultiRedditPostsOauth(multiPath, afterKey,
+                                    sortTime, APIUtils.getOAuthHeader(mAccessToken));
                         }
                         break;
                     case PostPagingSource.TYPE_ANONYMOUS_FRONT_PAGE:
                         //case PostPagingSource.TYPE_ANONYMOUS_MULTIREDDIT
-                        if (sortTime != null) {
-                            call = api.getSubredditBestPosts(subredditName, sortType, sortTime, afterKey);
-                        } else {
-                            call = api.getSubredditBestPosts(subredditName, sortType, afterKey);
-                        }
+                        call = api.getSubredditBestPosts(subredditName, sortType, sortTime, afterKey);
                         break;
                     default:
-                        if (sortTime != null) {
-                            call = api.getBestPosts(sortType, sortTime, afterKey,
-                                    APIUtils.getOAuthHeader(mAccessToken));
-                        } else {
-                            call = api.getBestPosts(sortType, afterKey, APIUtils.getOAuthHeader(mAccessToken));
-                        }
+                        call = api.getBestPosts(sortType, sortTime, afterKey,
+                                APIUtils.getOAuthHeader(mAccessToken));
                 }
 
                 try {
@@ -806,8 +750,8 @@ public class ViewPostDetailActivity extends BaseActivity implements SortTypeSele
             this.query = event.query;
             this.trendingSource = event.trendingSource;
             this.postFilter = event.postFilter;
-            this.sortType = event.sortType.getType().value;
-            this.sortTime = event.sortType.getTime() == null ? null : event.sortType.getTime().value;
+            this.sortType = event.sortType.getType();
+            this.sortTime = event.sortType.getTime();
             this.readPostList = event.readPostList;
 
             if (sectionsPagerAdapter != null) {

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/CommentsRecyclerViewAdapter.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/CommentsRecyclerViewAdapter.java
@@ -48,6 +48,7 @@ import jp.wasabeef.glide.transformations.RoundedCornersTransformation;
 import me.saket.bettermovementmethod.BetterLinkMovementMethod;
 import ml.docilealligator.infinityforreddit.R;
 import ml.docilealligator.infinityforreddit.SaveThing;
+import ml.docilealligator.infinityforreddit.SortType;
 import ml.docilealligator.infinityforreddit.VoteThing;
 import ml.docilealligator.infinityforreddit.activities.BaseActivity;
 import ml.docilealligator.infinityforreddit.activities.CommentActivity;
@@ -626,7 +627,7 @@ public class CommentsRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerVi
                         ((LoadMoreChildCommentsViewHolder) holder).placeholderTextView.setText(R.string.loading);
 
                         Retrofit retrofit = mAccessToken == null ? mRetrofit : mOauthRetrofit;
-                        String sortType = mCommentRecyclerViewAdapterCallback.getSortType();
+                        SortType.Type sortType = mCommentRecyclerViewAdapterCallback.getSortType();
                         FetchComment.fetchMoreComment(mExecutor, new Handler(), retrofit, mAccessToken,
                                 parentComment.getMoreChildrenIds(),
                                 mExpandChildren, mPost.getFullName(), sortType, new FetchComment.FetchMoreCommentListener() {
@@ -1178,7 +1179,7 @@ public class CommentsRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerVi
 
         void retryFetchingMoreComments();
 
-        String getSortType();
+        SortType.Type getSortType();
     }
 
     public class CommentViewHolder extends RecyclerView.ViewHolder {

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/apis/RedditAPI.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/apis/RedditAPI.java
@@ -130,19 +130,19 @@ public interface RedditAPI {
 
     @GET("/comments/{id}/placeholder/{singleCommentId}.json?raw_json=1")
     Call<String> getPostAndCommentsSingleThreadByIdOauth(@Path("id") String id, @Path("singleCommentId") String singleCommentId,
-                                                         @Query("sort") String sortType, @Query("context") String contextNumber,
+                                                         @Query("sort") SortType.Type sortType, @Query("context") String contextNumber,
                                                          @HeaderMap Map<String, String> headers);
 
     @GET("/comments/{id}.json?raw_json=1")
-    Call<String> getPostAndCommentsByIdOauth(@Path("id") String id, @Query("sort") String sortType,
+    Call<String> getPostAndCommentsByIdOauth(@Path("id") String id, @Query("sort") SortType.Type sortType,
                                              @HeaderMap Map<String, String> headers);
 
     @GET("/comments/{id}/placeholder/{singleCommentId}.json?raw_json=1")
     Call<String> getPostAndCommentsSingleThreadById(@Path("id") String id, @Path("singleCommentId") String singleCommentId,
-                                                    @Query("sort") String sortType, @Query("context") String contextNumber);
+                                                    @Query("sort") SortType.Type sortType, @Query("context") String contextNumber);
 
     @GET("/comments/{id}.json?raw_json=1")
-    Call<String> getPostAndCommentsById(@Path("id") String id, @Query("sort") String sortType);
+    Call<String> getPostAndCommentsById(@Path("id") String id, @Query("sort") SortType.Type sortType);
 
     @Multipart
     @POST(".")
@@ -458,9 +458,9 @@ public interface RedditAPI {
 
     @FormUrlEncoded
     @POST("/api/morechildren.json?raw_json=1&api_type=json")
-    Call<String> moreChildren(@Field("link_id") String linkId, @Field("children") String children, @Field("sort") String sort);
+    Call<String> moreChildren(@Field("link_id") String linkId, @Field("children") String children, @Field("sort") SortType.Type sort);
 
     @FormUrlEncoded
     @POST("/api/morechildren.json?raw_json=1&api_type=json")
-    Call<String> moreChildrenOauth(@Field("link_id") String linkId, @Field("children") String children, @Field("sort") String sort, @HeaderMap Map<String, String> headers);
+    Call<String> moreChildrenOauth(@Field("link_id") String linkId, @Field("children") String children, @Field("sort") SortType.Type sort, @HeaderMap Map<String, String> headers);
 }

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/apis/RedditAPI.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/apis/RedditAPI.java
@@ -336,105 +336,57 @@ public interface RedditAPI {
                                           @HeaderMap Map<String, String> headers);
 
     @GET("{sortType}?raw_json=1")
-    Call<String> getBestPosts(@Path("sortType") String sortType, @Query("after") String lastItem, @HeaderMap Map<String, String> headers);
-
-    @GET("{sortType}?raw_json=1")
-    Call<String> getBestPosts(@Path("sortType") String sortType, @Query("t") String sortTime,
+    Call<String> getBestPosts(@Path("sortType") SortType.Type sortType, @Query("t") SortType.Time sortTime,
                                                                     @Query("after") String lastItem, @HeaderMap Map<String, String> headers);
 
     @GET("r/{subredditName}/{sortType}.json?raw_json=1&limit=25&always_show_media=1")
-    Call<String> getSubredditBestPostsOauth(@Path("subredditName") String subredditName, @Path("sortType") String sortType,
-                                                                                  @Query("after") String lastItem, @HeaderMap Map<String, String> headers);
-
-    @GET("r/{subredditName}/{sortType}.json?raw_json=1&limit=25&always_show_media=1")
-    Call<String> getSubredditBestPostsOauth(@Path("subredditName") String subredditName, @Path("sortType") String sortType,
-                                                                                  @Query("t") String sortTime, @Query("after") String lastItem,
+    Call<String> getSubredditBestPostsOauth(@Path("subredditName") String subredditName, @Path("sortType") SortType.Type sortType,
+                                                                                  @Query("t") SortType.Time sortTime, @Query("after") String lastItem,
                                                                                   @HeaderMap Map<String, String> headers);
 
     @GET("r/{subredditName}/{sortType}.json?raw_json=1&limit=25&always_show_media=1")
-    Call<String> getSubredditBestPosts(@Path("subredditName") String subredditName, @Path("sortType") String sortType,
-                                                                             @Query("after") String lastItem);
-
-    @GET("r/{subredditName}/{sortType}.json?raw_json=1&limit=25&always_show_media=1")
-    Call<String> getSubredditBestPosts(@Path("subredditName") String subredditName, @Path("sortType") String sortType,
-                                                                             @Query("t") String sortTime, @Query("after") String lastItem);
+    Call<String> getSubredditBestPosts(@Path("subredditName") String subredditName, @Path("sortType") SortType.Type sortType,
+                                                                             @Query("t") SortType.Time sortTime, @Query("after") String lastItem);
 
     @GET("user/{username}/{where}.json?&type=links&raw_json=1&limit=25")
     Call<String> getUserPostsOauth(@Path("username") String username, @Path("where") String where,
-                                                                         @Query("after") String lastItem, @Query("sort") String sortType, @HeaderMap Map<String, String> headers);
-
-    @GET("user/{username}/{where}.json?&type=links&raw_json=1&limit=25")
-    Call<String> getUserPostsOauth(@Path("username") String username, @Path("where") String where,
-                                                                         @Query("after") String lastItem, @Query("sort") String sortType,
-                                                                         @Query("t") String sortTime, @HeaderMap Map<String, String> headers);
+                                                                         @Query("after") String lastItem, @Query("sort") SortType.Type sortType,
+                                                                         @Query("t") SortType.Time sortTime, @HeaderMap Map<String, String> headers);
 
     @GET("user/{username}/submitted.json?raw_json=1&limit=25")
     Call<String> getUserPosts(@Path("username") String username, @Query("after") String lastItem,
-                                                                    @Query("sort") String sortType);
-
-    @GET("user/{username}/submitted.json?raw_json=1&limit=25")
-    Call<String> getUserPosts(@Path("username") String username, @Query("after") String lastItem,
-                                                                    @Query("sort") String sortType, @Query("t") String sortTime);
+                                                                    @Query("sort") SortType.Type sortType, @Query("t") SortType.Time sortTime);
 
     @GET("search.json?include_over_18=1&raw_json=1&type=link")
     Call<String> searchPostsOauth(@Query("q") String query, @Query("after") String after,
-                                                                        @Query("sort") String sort, @Query("source") String source,
-                                                                        @HeaderMap Map<String, String> headers);
-
-    @GET("search.json?include_over_18=1&raw_json=1&type=link")
-    Call<String> searchPostsOauth(@Query("q") String query, @Query("after") String after,
-                                                                        @Query("sort") String sort, @Query("t") String sortTime,
+                                                                        @Query("sort") SortType.Type sort, @Query("t") SortType.Time sortTime,
                                                                         @Query("source") String source,
                                                                         @HeaderMap Map<String, String> headers);
 
     @GET("search.json?include_over_18=1&raw_json=1&type=link")
     Call<String> searchPosts(@Query("q") String query, @Query("after") String after,
-                                                                   @Query("sort") String sort, @Query("source") String source);
-
-    @GET("search.json?include_over_18=1&raw_json=1&type=link")
-    Call<String> searchPosts(@Query("q") String query, @Query("after") String after,
-                                                                   @Query("sort") String sort, @Query("t") String sortTime,
+                                                                   @Query("sort") SortType.Type sort, @Query("t") SortType.Time sortTime,
                                                                    @Query("source") String source);
 
     @GET("r/{subredditName}/search.json?include_over_18=1&raw_json=1&type=link&restrict_sr=true")
     Call<String> searchPostsInSpecificSubredditOauth(@Path("subredditName") String subredditName,
-                                                                                           @Query("q") String query, @Query("sort") String sort,
-                                                                                           @Query("after") String after,
+                                                                                           @Query("q") String query, @Query("sort") SortType.Type sort,
+                                                                                           @Query("t") SortType.Time sortTime, @Query("after") String after,
                                                                                            @HeaderMap Map<String, String> headers);
 
     @GET("r/{subredditName}/search.json?include_over_18=1&raw_json=1&type=link&restrict_sr=true")
-    Call<String> searchPostsInSpecificSubredditOauth(@Path("subredditName") String subredditName,
-                                                                                           @Query("q") String query, @Query("sort") String sort,
-                                                                                           @Query("t") String sortTime, @Query("after") String after,
-                                                                                           @HeaderMap Map<String, String> headers);
-
-    @GET("r/{subredditName}/search.json?include_over_18=1&raw_json=1&type=link&restrict_sr=true")
-
     Call<String> searchPostsInSpecificSubreddit(@Path("subredditName") String subredditName,
-                                                                                      @Query("q") String query, @Query("sort") String sort,
-                                                                                      @Query("after") String after);
-
-    @GET("r/{subredditName}/search.json?include_over_18=1&raw_json=1&type=link&restrict_sr=true")
-    Call<String> searchPostsInSpecificSubreddit(@Path("subredditName") String subredditName,
-                                                                                      @Query("q") String query, @Query("sort") String sort,
-                                                                                      @Query("t") String sortTime, @Query("after") String after);
+                                                                                      @Query("q") String query, @Query("sort") SortType.Type sort,
+                                                                                      @Query("t") SortType.Time sortTime, @Query("after") String after);
 
     @GET("{multipath}?raw_json=1")
     Call<String> getMultiRedditPosts(@Path(value = "multipath", encoded = true) String multiPath,
-                                                                           @Query("after") String after);
-
-    @GET("{multipath}?raw_json=1")
-    Call<String> getMultiRedditPosts(@Path(value = "multipath", encoded = true) String multiPath,
-                                                                           @Query("after") String after, @Query("t") String sortTime);
+                                                                           @Query("after") String after, @Query("t") SortType.Time sortTime);
 
     @GET("{multipath}.json?raw_json=1")
     Call<String> getMultiRedditPostsOauth(@Path(value = "multipath", encoded = true) String multiPath,
-                                                                                @Query("after") String after, @Query("t") String sortTime,
+                                                                                @Query("after") String after, @Query("t") SortType.Time sortTime,
                                                                                 @HeaderMap Map<String, String> headers);
-
-    @GET("{multipath}.json?raw_json=1")
-    Call<String> getMultiRedditPostsOauth(@Path(value = "multipath", encoded = true) String multiPath,
-                                                                                @Query("after") String after, @HeaderMap Map<String, String> headers);
 
     @POST("r/{subredditName}/api/delete_sr_icon")
     Call<String> deleteSrIcon(@HeaderMap Map<String, String> headers, @Path("subredditName") String subredditName);

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/apis/RedditAPI.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/apis/RedditAPI.java
@@ -59,25 +59,12 @@ public interface RedditAPI {
 
     @GET("user/{username}/comments.json?raw_json=1")
     Call<String> getUserComments(@Path("username") String username, @Query("after") String after,
-                                 @Query("sort") SortType.Type sortType);
-
-    @GET("user/{username}/comments.json?raw_json=1")
-    Call<String> getUserComments(@Path("username") String username, @Query("after") String after,
                                  @Query("sort") SortType.Type sortType, @Query("t") SortType.Time sortTime);
-
-    @GET("user/{username}/comments.json?raw_json=1")
-    Call<String> getUserCommentsOauth(@HeaderMap Map<String, String> headers, @Path("username") String username,
-                                      @Query("after") String after, @Query("sort") SortType.Type sortType);
 
     @GET("user/{username}/comments.json?raw_json=1")
     Call<String> getUserCommentsOauth(@HeaderMap Map<String, String> headers, @Path("username") String username,
                                       @Query("after") String after, @Query("sort") SortType.Type sortType,
                                       @Query("t") SortType.Time sortTime);
-
-    @GET("user/{username}/{where}.json?&type=comments&raw_json=1&limit=25")
-    Call<String> getUserSavedCommentsOauth(@Path("username") String username, @Path("where") String where,
-                                           @Query("after") String lastItem, @Query("sort") SortType.Type sortType,
-                                           @HeaderMap Map<String, String> headers);
 
     @GET("user/{username}/{where}.json?&type=comments&raw_json=1&limit=25")
     Call<String> getUserSavedCommentsOauth(@Path("username") String username, @Path("where") String where,

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/apis/RedditAPI.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/apis/RedditAPI.java
@@ -96,12 +96,12 @@ public interface RedditAPI {
 
     @GET("subreddits/search.json?raw_json=1")
     Call<String> searchSubreddits(@Query("q") String subredditName, @Query("after") String after,
-                                  @Query("sort") String sort, @Query("include_over_18") int nsfw,
+                                  @Query("sort") SortType.Type sort, @Query("include_over_18") int nsfw,
                                   @HeaderMap Map<String, String> headers);
 
     @GET("search.json?raw_json=1&type=user")
     Call<String> searchUsers(@Query("q") String profileName, @Query("after") String after,
-                             @Query("sort") String sort, @Query("include_over_18") int nsfw);
+                             @Query("sort") SortType.Type sort, @Query("include_over_18") int nsfw);
 
     @FormUrlEncoded
     @POST("api/comment")

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/bottomsheetfragments/PostCommentSortTypeBottomSheetFragment.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/bottomsheetfragments/PostCommentSortTypeBottomSheetFragment.java
@@ -52,10 +52,10 @@ public class PostCommentSortTypeBottomSheetFragment extends LandscapeExpandedRou
         // Required empty public constructor
     }
 
-    public static PostCommentSortTypeBottomSheetFragment getNewInstance(String currentSortTypeValue) {
+    public static PostCommentSortTypeBottomSheetFragment getNewInstance(SortType.Type currentSortType) {
         PostCommentSortTypeBottomSheetFragment fragment = new PostCommentSortTypeBottomSheetFragment();
         Bundle bundle = new Bundle();
-        bundle.putString(EXTRA_CURRENT_SORT_TYPE, currentSortTypeValue);
+        bundle.putSerializable(EXTRA_CURRENT_SORT_TYPE, currentSortType);
         fragment.setArguments(bundle);
         return fragment;
     }
@@ -68,22 +68,22 @@ public class PostCommentSortTypeBottomSheetFragment extends LandscapeExpandedRou
         View rootView = inflater.inflate(R.layout.fragment_post_comment_sort_type_bottom_sheet, container, false);
         ButterKnife.bind(this, rootView);
 
-        String currentSortType = getArguments().getString(EXTRA_CURRENT_SORT_TYPE);
-        if (currentSortType.equals(SortType.Type.BEST.value) || currentSortType.equals(SortType.Type.CONFIDENCE.value)) {
+        SortType.Type currentSortType = (SortType.Type) getArguments().getSerializable(EXTRA_CURRENT_SORT_TYPE);
+        if (currentSortType.equals(SortType.Type.BEST) || currentSortType.equals(SortType.Type.CONFIDENCE)) {
             confidenceTypeTextView.setCompoundDrawablesRelativeWithIntrinsicBounds(confidenceTypeTextView.getCompoundDrawablesRelative()[0], null, AppCompatResources.getDrawable(activity, R.drawable.ic_round_check_circle_day_night_24dp), null);
-        } else if (currentSortType.equals(SortType.Type.TOP.value)) {
+        } else if (currentSortType.equals(SortType.Type.TOP)) {
             topTypeTextView.setCompoundDrawablesRelativeWithIntrinsicBounds(topTypeTextView.getCompoundDrawablesRelative()[0], null, AppCompatResources.getDrawable(activity, R.drawable.ic_round_check_circle_day_night_24dp), null);
-        } else if (currentSortType.equals(SortType.Type.NEW.value)) {
+        } else if (currentSortType.equals(SortType.Type.NEW)) {
             newTypeTextView.setCompoundDrawablesRelativeWithIntrinsicBounds(newTypeTextView.getCompoundDrawablesRelative()[0], null, AppCompatResources.getDrawable(activity, R.drawable.ic_round_check_circle_day_night_24dp), null);
-        } else if (currentSortType.equals(SortType.Type.CONTROVERSIAL.value)) {
+        } else if (currentSortType.equals(SortType.Type.CONTROVERSIAL)) {
             controversialTypeTextView.setCompoundDrawablesRelativeWithIntrinsicBounds(controversialTypeTextView.getCompoundDrawablesRelative()[0], null, AppCompatResources.getDrawable(activity, R.drawable.ic_round_check_circle_day_night_24dp), null);
-        } else if (currentSortType.equals(SortType.Type.OLD.value)) {
+        } else if (currentSortType.equals(SortType.Type.OLD)) {
             oldTypeTextView.setCompoundDrawablesRelativeWithIntrinsicBounds(oldTypeTextView.getCompoundDrawablesRelative()[0], null, AppCompatResources.getDrawable(activity, R.drawable.ic_round_check_circle_day_night_24dp), null);
-        } else if (currentSortType.equals(SortType.Type.RANDOM.value)) {
+        } else if (currentSortType.equals(SortType.Type.RANDOM)) {
             randomTypeTextView.setCompoundDrawablesRelativeWithIntrinsicBounds(randomTypeTextView.getCompoundDrawablesRelative()[0], null, AppCompatResources.getDrawable(activity, R.drawable.ic_round_check_circle_day_night_24dp), null);
-        } else if (currentSortType.equals(SortType.Type.QA.value)) {
+        } else if (currentSortType.equals(SortType.Type.QA)) {
             qaTypeTextView.setCompoundDrawablesRelativeWithIntrinsicBounds(qaTypeTextView.getCompoundDrawablesRelative()[0], null, AppCompatResources.getDrawable(activity, R.drawable.ic_round_check_circle_day_night_24dp), null);
-        } else if (currentSortType.equals(SortType.Type.LIVE.value)) {
+        } else if (currentSortType.equals(SortType.Type.LIVE)) {
             liveTypeTextView.setCompoundDrawablesRelativeWithIntrinsicBounds(liveTypeTextView.getCompoundDrawablesRelative()[0], null, AppCompatResources.getDrawable(activity, R.drawable.ic_round_check_circle_day_night_24dp), null);
         }
 

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/comment/FetchComment.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/comment/FetchComment.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.Locale;
 import java.util.concurrent.Executor;
 
+import ml.docilealligator.infinityforreddit.SortType;
 import ml.docilealligator.infinityforreddit.apis.RedditAPI;
 import ml.docilealligator.infinityforreddit.utils.APIUtils;
 import retrofit2.Call;
@@ -19,7 +20,7 @@ import retrofit2.Retrofit;
 public class FetchComment {
     public static void fetchComments(Executor executor, Handler handler, Retrofit retrofit,
                                      @Nullable String accessToken, String article,
-                                     String commentId, String sortType, String contextNumber, boolean expandChildren,
+                                     String commentId, SortType.Type sortType, String contextNumber, boolean expandChildren,
                                      Locale locale, FetchCommentListener fetchCommentListener) {
         RedditAPI api = retrofit.create(RedditAPI.class);
         Call<String> comments;
@@ -72,7 +73,7 @@ public class FetchComment {
                                         @Nullable String accessToken,
                                         ArrayList<String> allChildren,
                                         boolean expandChildren, String postFullName,
-                                        String sortType,
+                                        SortType.Type sortType,
                                         FetchMoreCommentListener fetchMoreCommentListener) {
         if (allChildren == null) {
             return;

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/fragments/ViewPostDetailFragment.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/fragments/ViewPostDetailFragment.java
@@ -210,7 +210,7 @@ public class ViewPostDetailFragment extends Fragment implements FragmentCommunic
     @State
     String mMessageFullname;
     @State
-    String sortType;
+    SortType.Type sortType;
     @State
     boolean mRespectSubredditRecommendedSortType;
     @State
@@ -553,13 +553,12 @@ public class ViewPostDetailFragment extends Fragment implements FragmentCommunic
             mMessageFullname = getArguments().getString(EXTRA_MESSAGE_FULLNAME);
 
             if (!mRespectSubredditRecommendedSortType || isSingleCommentThreadMode) {
-                SortType.Type sortTypeType = loadSortType();
-                activity.setTitle(sortTypeType.fullName);
-                sortType = sortTypeType.value;
+                sortType = loadSortType();
+                activity.setTitle(sortType.fullName);
             }
         } else {
             if (sortType != null) {
-                activity.setTitle(SortType.Type.valueOf(sortType.toUpperCase()).fullName);
+                activity.setTitle(sortType.fullName);
             }
         }
 
@@ -621,7 +620,7 @@ public class ViewPostDetailFragment extends Fragment implements FragmentCommunic
                         }
 
                         @Override
-                        public String getSortType() {
+                        public SortType.Type getSortType() {
                             return sortType;
                         }
                     });
@@ -816,12 +815,12 @@ public class ViewPostDetailFragment extends Fragment implements FragmentCommunic
         if (children != null) {
             children.clear();
         }
-        this.sortType = sortType.getType().value;
+        this.sortType = sortType.getType();
         if (!mSharedPreferences.getBoolean(SharedPreferencesUtils.RESPECT_SUBREDDIT_RECOMMENDED_COMMENT_SORT_TYPE, false)
                 && mSharedPreferences.getBoolean(SharedPreferencesUtils.SAVE_SORT_TYPE, true)) {
             mSortTypeSharedPreferences.edit().putString(SharedPreferencesUtils.SORT_TYPE_POST_COMMENT, sortType.getType().name()).apply();
         }
-        fetchCommentsRespectRecommendedSort(false, false, sortType.getType().value);
+        fetchCommentsRespectRecommendedSort(false, false, sortType.getType());
     }
 
     @NonNull
@@ -1331,7 +1330,7 @@ public class ViewPostDetailFragment extends Fragment implements FragmentCommunic
                                         }
 
                                         @Override
-                                        public String getSortType() {
+                                        public SortType.Type getSortType() {
                                             return sortType;
                                         }
                                     });
@@ -1429,7 +1428,7 @@ public class ViewPostDetailFragment extends Fragment implements FragmentCommunic
         });
     }
 
-    private void fetchCommentsRespectRecommendedSort(boolean changeRefreshState, boolean checkSortState, String sortType) {
+    private void fetchCommentsRespectRecommendedSort(boolean changeRefreshState, boolean checkSortState, SortType.Type sortType) {
         if (mRespectSubredditRecommendedSortType && mPost != null) {
             FetchSubredditData.fetchSubredditData(mOauthRetrofit, mRetrofit, mPost.getSubredditName(), mAccessToken,
                     new FetchSubredditData.FetchSubredditDataListener() {
@@ -1444,7 +1443,7 @@ public class ViewPostDetailFragment extends Fragment implements FragmentCommunic
                                 sortTypeType = SortType.Type.valueOf(suggestedCommentSort.toUpperCase(Locale.US));
                             }
                             activity.setTitle(sortTypeType.fullName);
-                            ViewPostDetailFragment.this.sortType = sortTypeType.value;
+                            ViewPostDetailFragment.this.sortType = sortTypeType;
                             fetchComments(changeRefreshState, checkSortState, ViewPostDetailFragment.this.sortType);
                         }
 
@@ -1453,7 +1452,7 @@ public class ViewPostDetailFragment extends Fragment implements FragmentCommunic
                             mRespectSubredditRecommendedSortType = false;
                             SortType.Type sortTypeType = loadSortType();
                             activity.setTitle(sortTypeType.fullName);
-                            ViewPostDetailFragment.this.sortType = sortTypeType.value;
+                            ViewPostDetailFragment.this.sortType = sortTypeType;
                         }
                     });
         } else {
@@ -1461,7 +1460,7 @@ public class ViewPostDetailFragment extends Fragment implements FragmentCommunic
         }
     }
 
-    private void fetchComments(boolean changeRefreshState, boolean checkSortState, String sortType) {
+    private void fetchComments(boolean changeRefreshState, boolean checkSortState, SortType.Type sortType) {
         isFetchingComments = true;
         mCommentsAdapter.setSingleComment(mSingleCommentId, isSingleCommentThreadMode);
         mCommentsAdapter.initiallyLoading();

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/subreddit/FetchSubredditData.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/subreddit/FetchSubredditData.java
@@ -9,6 +9,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import ml.docilealligator.infinityforreddit.SortType;
 import ml.docilealligator.infinityforreddit.apis.RedditAPI;
 import ml.docilealligator.infinityforreddit.utils.APIUtils;
 import retrofit2.Call;
@@ -54,7 +55,7 @@ public class FetchSubredditData {
         });
     }
 
-    static void fetchSubredditListingData(Retrofit retrofit, String query, String after, String sortType, String accessToken,
+    static void fetchSubredditListingData(Retrofit retrofit, String query, String after, SortType.Type sortType, String accessToken,
                                           boolean nsfw, final FetchSubredditListingDataListener fetchSubredditListingDataListener) {
         RedditAPI api = retrofit.create(RedditAPI.class);
 

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/subreddit/SubredditListingDataSource.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/subreddit/SubredditListingDataSource.java
@@ -52,7 +52,7 @@ public class SubredditListingDataSource extends PageKeyedDataSource<String, Subr
     public void loadInitial(@NonNull LoadInitialParams<String> params, @NonNull LoadInitialCallback<String, SubredditData> callback) {
         initialLoadStateLiveData.postValue(NetworkState.LOADING);
 
-        FetchSubredditData.fetchSubredditListingData(retrofit, query, null, sortType.getType().value, accessToken, nsfw,
+        FetchSubredditData.fetchSubredditListingData(retrofit, query, null, sortType.getType(), accessToken, nsfw,
                 new FetchSubredditData.FetchSubredditListingDataListener() {
                     @Override
                     public void onFetchSubredditListingDataSuccess(ArrayList<SubredditData> subredditData, String after) {
@@ -87,7 +87,7 @@ public class SubredditListingDataSource extends PageKeyedDataSource<String, Subr
             return;
         }
 
-        FetchSubredditData.fetchSubredditListingData(retrofit, query, params.key, sortType.getType().value, accessToken, nsfw,
+        FetchSubredditData.fetchSubredditListingData(retrofit, query, params.key, sortType.getType(), accessToken, nsfw,
                 new FetchSubredditData.FetchSubredditListingDataListener() {
                     @Override
                     public void onFetchSubredditListingDataSuccess(ArrayList<SubredditData> subredditData, String after) {

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/user/FetchUserData.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/user/FetchUserData.java
@@ -5,6 +5,7 @@ import androidx.annotation.NonNull;
 import java.util.ArrayList;
 
 import ml.docilealligator.infinityforreddit.RedditDataRoomDatabase;
+import ml.docilealligator.infinityforreddit.SortType;
 import ml.docilealligator.infinityforreddit.apis.RedditAPI;
 import ml.docilealligator.infinityforreddit.utils.APIUtils;
 import retrofit2.Call;
@@ -53,7 +54,7 @@ public class FetchUserData {
         });
     }
 
-    public static void fetchUserListingData(Retrofit retrofit, String query, String after, String sortType, boolean nsfw,
+    public static void fetchUserListingData(Retrofit retrofit, String query, String after, SortType.Type sortType, boolean nsfw,
                                             FetchUserListingDataListener fetchUserListingDataListener) {
         RedditAPI api = retrofit.create(RedditAPI.class);
 

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/user/UserListingDataSource.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/user/UserListingDataSource.java
@@ -50,7 +50,7 @@ public class UserListingDataSource extends PageKeyedDataSource<String, UserData>
     public void loadInitial(@NonNull PageKeyedDataSource.LoadInitialParams<String> params, @NonNull PageKeyedDataSource.LoadInitialCallback<String, UserData> callback) {
         initialLoadStateLiveData.postValue(NetworkState.LOADING);
 
-        FetchUserData.fetchUserListingData(retrofit, query, null, sortType.getType().value, nsfw,
+        FetchUserData.fetchUserListingData(retrofit, query, null, sortType.getType(), nsfw,
                 new FetchUserData.FetchUserListingDataListener() {
                     @Override
                     public void onFetchUserListingDataSuccess(ArrayList<UserData> UserData, String after) {
@@ -81,7 +81,7 @@ public class UserListingDataSource extends PageKeyedDataSource<String, UserData>
             return;
         }
 
-        FetchUserData.fetchUserListingData(retrofit, query, params.key, sortType.getType().value, nsfw,
+        FetchUserData.fetchUserListingData(retrofit, query, params.key, sortType.getType(), nsfw,
                 new FetchUserData.FetchUserListingDataListener() {
                     @Override
                     public void onFetchUserListingDataSuccess(ArrayList<UserData> UserData, String after) {


### PR DESCRIPTION
This is continuation of #1211 and should replace all usages of strings with enums. Fortunately all enums are `Serializable` so storing/restoring them requires no additional changes.