### PR TITLE
Sensible download name

### DIFF
--- a/app/src/main/java/ml/docilealligator/infinityforreddit/activities/ViewImageOrGifActivity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/activities/ViewImageOrGifActivity.java
@@ -84,6 +84,7 @@ public class ViewImageOrGifActivity extends AppCompatActivity implements SetAsWa
     public static final String EXTRA_IMAGE_URL_KEY = "EIUK";
     public static final String EXTRA_GIF_URL_KEY = "EGUK";
     public static final String EXTRA_FILE_NAME_KEY = "EFNK";
+    public static final String EXTRA_SENSIBLE_FILE_NAME_KEY = "ESFNK";
     public static final String EXTRA_SUBREDDIT_OR_USERNAME_KEY = "ESOUK";
     public static final String EXTRA_POST_TITLE_KEY = "EPTK";
     public static final String EXTRA_IS_NSFW = "EIN";
@@ -114,6 +115,7 @@ public class ViewImageOrGifActivity extends AppCompatActivity implements SetAsWa
     private RequestManager glide;
     private String mImageUrl;
     private String mImageFileName;
+    private String mImageSensibleFileName;
     private String mSubredditName;
     private boolean isGif = true;
     private boolean isNsfw;
@@ -172,6 +174,8 @@ public class ViewImageOrGifActivity extends AppCompatActivity implements SetAsWa
             mImageUrl = intent.getStringExtra(EXTRA_IMAGE_URL_KEY);
         }
         mImageFileName = intent.getStringExtra(EXTRA_FILE_NAME_KEY);
+        mImageSensibleFileName = intent.getStringExtra(EXTRA_SENSIBLE_FILE_NAME_KEY);
+
         String postTitle = intent.getStringExtra(EXTRA_POST_TITLE_KEY);
         mSubredditName = intent.getStringExtra(EXTRA_SUBREDDIT_OR_USERNAME_KEY);
         isNsfw = intent.getBooleanExtra(EXTRA_IS_NSFW, false);
@@ -377,10 +381,12 @@ public class ViewImageOrGifActivity extends AppCompatActivity implements SetAsWa
     private void download() {
         isDownloading = false;
 
+        boolean isSensibleFileName = mSharedPreferences.getBoolean(SharedPreferencesUtils.DOWNLOAD_WITH_SENSIBLE_FILE_NAME, false);
+
         Intent intent = new Intent(this, DownloadMediaService.class);
         intent.putExtra(DownloadMediaService.EXTRA_URL, mImageUrl);
         intent.putExtra(DownloadMediaService.EXTRA_MEDIA_TYPE, isGif ? DownloadMediaService.EXTRA_MEDIA_TYPE_GIF : DownloadMediaService.EXTRA_MEDIA_TYPE_IMAGE);
-        intent.putExtra(DownloadMediaService.EXTRA_FILE_NAME, mImageFileName);
+        intent.putExtra(DownloadMediaService.EXTRA_FILE_NAME, isSensibleFileName ? mImageSensibleFileName : mImageFileName);
         intent.putExtra(DownloadMediaService.EXTRA_SUBREDDIT_NAME, mSubredditName);
         intent.putExtra(DownloadMediaService.EXTRA_IS_NSFW, isNsfw);
         ContextCompat.startForegroundService(this, intent);

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/HistoryPostRecyclerViewAdapter.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/HistoryPostRecyclerViewAdapter.java
@@ -2020,6 +2020,8 @@ public class HistoryPostRecyclerViewAdapter extends PagingDataAdapter<Post, Recy
                 intent.putExtra(ViewImageOrGifActivity.EXTRA_IMAGE_URL_KEY, post.getUrl());
                 intent.putExtra(ViewImageOrGifActivity.EXTRA_FILE_NAME_KEY, post.getSubredditName()
                         + "-" + post.getId() + ".jpg");
+                intent.putExtra(ViewImageOrGifActivity.EXTRA_SENSIBLE_FILE_NAME_KEY, post.getSubredditName()
+                        + "-" + post.getTitle() + ".jpg");
                 intent.putExtra(ViewImageOrGifActivity.EXTRA_POST_TITLE_KEY, post.getTitle());
                 intent.putExtra(ViewImageOrGifActivity.EXTRA_SUBREDDIT_OR_USERNAME_KEY, post.getSubredditName());
                 intent.putExtra(ViewImageOrGifActivity.EXTRA_IS_NSFW, post.isNSFW());

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/PostDetailRecyclerViewAdapter.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/PostDetailRecyclerViewAdapter.java
@@ -1979,6 +1979,8 @@ public class PostDetailRecyclerViewAdapter extends RecyclerView.Adapter<Recycler
                         intent.putExtra(ViewImageOrGifActivity.EXTRA_IMAGE_URL_KEY, mPost.getUrl());
                         intent.putExtra(ViewImageOrGifActivity.EXTRA_FILE_NAME_KEY, mPost.getSubredditNamePrefixed().substring(2)
                                 + "-" + mPost.getId().substring(3) + ".jpg");
+                        intent.putExtra(ViewImageOrGifActivity.EXTRA_SENSIBLE_FILE_NAME_KEY, mPost.getSubredditName()
+                                + "-" + mPost.getTitle() + ".jpg");
                         intent.putExtra(ViewImageOrGifActivity.EXTRA_POST_TITLE_KEY, mPost.getTitle());
                         intent.putExtra(ViewImageOrGifActivity.EXTRA_SUBREDDIT_OR_USERNAME_KEY, mPost.getSubredditName());
                         mActivity.startActivity(intent);

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/PostRecyclerViewAdapter.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/PostRecyclerViewAdapter.java
@@ -2120,6 +2120,8 @@ public class PostRecyclerViewAdapter extends PagingDataAdapter<Post, RecyclerVie
                 intent.putExtra(ViewImageOrGifActivity.EXTRA_IMAGE_URL_KEY, post.getUrl());
                 intent.putExtra(ViewImageOrGifActivity.EXTRA_FILE_NAME_KEY, post.getSubredditName()
                         + "-" + post.getId() + ".jpg");
+                intent.putExtra(ViewImageOrGifActivity.EXTRA_SENSIBLE_FILE_NAME_KEY, post.getSubredditName()
+                        + "-" + post.getTitle() + ".jpg");
                 intent.putExtra(ViewImageOrGifActivity.EXTRA_POST_TITLE_KEY, post.getTitle());
                 intent.putExtra(ViewImageOrGifActivity.EXTRA_SUBREDDIT_OR_USERNAME_KEY, post.getSubredditName());
                 intent.putExtra(ViewImageOrGifActivity.EXTRA_IS_NSFW, post.isNSFW());

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/utils/SharedPreferencesUtils.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/utils/SharedPreferencesUtils.java
@@ -137,6 +137,7 @@ public class SharedPreferencesUtils {
     public static final String GIF_DOWNLOAD_LOCATION = "gif_download_location";
     public static final String VIDEO_DOWNLOAD_LOCATION = "video_download_location";
     public static final String SEPARATE_FOLDER_FOR_EACH_SUBREDDIT = "separate_folder_for_each_subreddit";
+    public static final String DOWNLOAD_WITH_SENSIBLE_FILE_NAME = "download_with_sensible_file_name";
     public static final String SAVE_NSFW_MEDIA_IN_DIFFERENT_FOLDER = "save_nsfw_media_in_different_folder";
     public static final String NSFW_DOWNLOAD_LOCATION = "nsfw_download_location";
     public static final String VIBRATE_WHEN_ACTION_TRIGGERED = "vibrate_when_action_triggered";

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -525,6 +525,7 @@
     <string name="settings_gif_download_location_title">Gif Download Location</string>
     <string name="settings_video_download_location_title">Video Download Location</string>
     <string name="settings_separate_folder_for_each_subreddit">Separate Folder for Each Subreddit</string>
+    <string name="settings_download_with_sensible_file_name">Download with Sensible File Name</string>
     <string name="settings_save_nsfw_media_in_different_folder_title">Save NSFW Media in Different Location</string>
     <string name="settings_nsfw_download_location_title">NSFW Download Location</string>
     <string name="settings_swipe_action_title">Swipe Action</string>

--- a/app/src/main/res/xml/download_location_preferences.xml
+++ b/app/src/main/res/xml/download_location_preferences.xml
@@ -16,6 +16,11 @@
         app:key="separate_folder_for_each_subreddit"
         app:title="@string/settings_separate_folder_for_each_subreddit" />
 
+    <ml.docilealligator.infinityforreddit.customviews.CustomFontSwitchPreference
+        app:defaultValue="false"
+        app:key="download_with_sensible_file_name"
+        app:title="@string/settings_download_with_sensible_file_name" />
+
     <ml.docilealligator.infinityforreddit.customviews.CustomFontPreferenceCategory
         app:title="@string/nsfw" />
 


### PR DESCRIPTION
This PR is meant for review purpose only as it's not complete yet

## Feature Description
Allow user to toggle the setting to download the file with `sensible` file name.

### What's the problem
`NOTE: I'm taking the image as example for downloadable media for now`

Previously the downloaded files where stored with the format `subredditname + id`, which in some cases (mentioned down below), didn't make much sense (visible in below image)

![photo_2022-11-29_11-36-24](https://user-images.githubusercontent.com/58421041/204453323-e0088642-d88b-4636-96da-faf956a52378.jpg)

### What's the fix

Provide user with toggle to enable this feature

![photo_2022-11-29_11-36-48](https://user-images.githubusercontent.com/58421041/204453044-2185841d-0984-4b0e-9103-1eefe2be7347.jpg)

Now, the downloaded files are provided with the post title too

![photo_2022-11-29_11-36-43](https://user-images.githubusercontent.com/58421041/204453548-0ed6d678-58f5-49a0-96d5-3546bfeaddac.jpg)

### Why is the feature necessary

* You want to search some downloaded media in your heap of already downloaded media in your storage. It will be easy if user can find the files by just typing some letter/words in filter of their file explorer/gallery
* Can write some scripts/tools to re-organize the downloaded media on the basis of the names by applying different sort of grouping techniques (helpful when gallery type images are downloaded, so user can group them with post names)

NOTE: I was not able to downloaded images from gallery post (multiple images post). Is it not implemented ?