### PR TITLE
Fix bug where auth network objects weren't getting authenticators and converterAdapter

### DIFF
--- a/app/src/main/java/ml/docilealligator/infinityforreddit/NetworkModule.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/NetworkModule.java
@@ -11,6 +11,7 @@ import dagger.Module;
 import dagger.Provides;
 import ml.docilealligator.infinityforreddit.network.SortTypeConverterFactory;
 import ml.docilealligator.infinityforreddit.utils.APIUtils;
+import okhttp3.Authenticator;
 import okhttp3.ConnectionPool;
 import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
@@ -21,81 +22,95 @@ import retrofit2.converter.scalars.ScalarsConverterFactory;
 @Module(includes = AppModule.class)
 abstract class NetworkModule {
 
-    @Provides
-    @Singleton
-    static OkHttpClient providesBaseOkhttp() {
-        return new OkHttpClient.Builder()
-                .connectTimeout(30, TimeUnit.SECONDS)
-                .readTimeout(30, TimeUnit.SECONDS)
-                .writeTimeout(30, TimeUnit.SECONDS)
-                .build();
-    }
+    private static final String NAMED_BASE_OKHTTP = "base_okhttp_client";
+    private static final String NAMED_BASE_RETROFIT = "base_retrofit_client";
+    private static final String NAMED_DEFAULT_OKHTTP = "default_okhttp_client";
 
     @Provides
-    @Singleton
-    static Retrofit providesBaseRetrofit(OkHttpClient okHttpClient) {
-        return new Retrofit.Builder()
-                .baseUrl(APIUtils.API_BASE_URI)
-                .client(okHttpClient)
-                .addConverterFactory(ScalarsConverterFactory.create())
-                .addConverterFactory(SortTypeConverterFactory.create())
-                .addCallAdapterFactory(GuavaCallAdapterFactory.create())
-                .build();
-    }
-
-    @Provides
-    static ConnectionPool providesConnectionPool() {
+    static ConnectionPool provideConnectionPool() {
         return new ConnectionPool(0, 1, TimeUnit.NANOSECONDS);
     }
 
     @Provides
-    @Named("no_oauth")
-    static Retrofit provideRetrofit(Retrofit retrofit) {
-        return retrofit;
-    }
-
-    @Provides
-    @Named("oauth")
-    static Retrofit providesOAuthRetrofit(Retrofit retrofit, @Named("default") OkHttpClient okHttpClient) {
-        return retrofit.newBuilder()
-                .baseUrl(APIUtils.OAUTH_API_BASE_URI)
-                .client(okHttpClient)
-                .build();
-    }
-
-    @Provides
-    @Named("default")
     @Singleton
-    static OkHttpClient provideOkHttpClient(OkHttpClient httpClient,
-                                            Retrofit retrofit,
-                                            RedditDataRoomDatabase accountRoomDatabase,
-                                            @Named("current_account") SharedPreferences currentAccountSharedPreferences,
-                                            ConnectionPool connectionPool) {
-        return httpClient.newBuilder()
-                .authenticator(new AccessTokenAuthenticator(retrofit, accountRoomDatabase, currentAccountSharedPreferences))
+    @Named(NAMED_BASE_OKHTTP)
+    static OkHttpClient provideBaseOkhttp(ConnectionPool connectionPool) {
+        return new OkHttpClient.Builder()
+                .connectTimeout(30, TimeUnit.SECONDS)
+                .readTimeout(30, TimeUnit.SECONDS)
+                .writeTimeout(30, TimeUnit.SECONDS)
                 .connectionPool(connectionPool)
                 .build();
     }
 
     @Provides
-    @Named("rpan")
-    static OkHttpClient provideRPANOkHttpClient(OkHttpClient httpClient) {
-        return httpClient;
+    @Singleton
+    @Named(NAMED_BASE_RETROFIT)
+    static Retrofit provideBaseRetrofit(@Named(NAMED_BASE_OKHTTP) OkHttpClient okHttpClient) {
+        return new Retrofit.Builder()
+                .baseUrl(APIUtils.API_BASE_URI)
+                .client(okHttpClient)
+                .addConverterFactory(SortTypeConverterFactory.create())
+                .addConverterFactory(ScalarsConverterFactory.create())
+                .addCallAdapterFactory(GuavaCallAdapterFactory.create())
+                .build();
+    }
+
+    @Provides
+    @Named("access_token_authenticator")
+    static Authenticator provideAccessTokenAuthenticator(@Named(NAMED_BASE_RETROFIT) Retrofit retrofit,
+                                                         RedditDataRoomDatabase accountRoomDatabase,
+                                                         @Named("current_account") SharedPreferences currentAccountSharedPreferences) {
+        return new AccessTokenAuthenticator(retrofit, accountRoomDatabase, currentAccountSharedPreferences);
+    }
+
+    @Provides
+    @Named(NAMED_DEFAULT_OKHTTP)
+    @Singleton
+    static OkHttpClient provideOkHttpClient(@Named(NAMED_BASE_OKHTTP) OkHttpClient httpClient,
+                                            @Named("access_token_authenticator") Authenticator authenticator) {
+        return httpClient.newBuilder()
+                .authenticator(authenticator)
+                .build();
     }
 
     @Provides
     @Named("oauth_without_authenticator")
     @Singleton
-    static Retrofit provideOauthWithoutAuthenticatorRetrofit(Retrofit retrofit) {
+    static Retrofit provideOauthWithoutAuthenticatorRetrofit(@Named(NAMED_BASE_RETROFIT) Retrofit retrofit) {
         return retrofit.newBuilder()
                 .baseUrl(APIUtils.OAUTH_API_BASE_URI)
                 .build();
     }
 
     @Provides
+    @Named("no_oauth")
+    static Retrofit provideRetrofit(@Named(NAMED_BASE_RETROFIT) Retrofit retrofit) {
+        return retrofit.newBuilder()
+                .baseUrl(APIUtils.OAUTH_API_BASE_URI)
+                .build();
+    }
+
+    @Provides
+    @Named("oauth")
+    static Retrofit provideOAuthRetrofit(@Named(NAMED_DEFAULT_OKHTTP) OkHttpClient okHttpClient,
+                                         @Named(NAMED_BASE_RETROFIT) Retrofit retrofit) {
+        return retrofit.newBuilder()
+                .client(okHttpClient)
+                .build();
+    }
+
+    @Provides
+    @Singleton
+    @Named("rpan")
+    static OkHttpClient provideRPANOkHttpClient(@Named(NAMED_BASE_OKHTTP) OkHttpClient httpClient) {
+        return httpClient;
+    }
+
+    @Provides
     @Named("upload_media")
     @Singleton
-    static Retrofit provideUploadMediaRetrofit(Retrofit retrofit) {
+    static Retrofit provideUploadMediaRetrofit(@Named(NAMED_BASE_RETROFIT) Retrofit retrofit) {
         return retrofit.newBuilder()
                 .baseUrl(APIUtils.API_UPLOAD_MEDIA_URI)
                 .build();
@@ -104,7 +119,7 @@ abstract class NetworkModule {
     @Provides
     @Named("upload_video")
     @Singleton
-    static Retrofit provideUploadVideoRetrofit(Retrofit retrofit) {
+    static Retrofit provideUploadVideoRetrofit(@Named(NAMED_BASE_RETROFIT) Retrofit retrofit) {
         return retrofit.newBuilder()
                 .baseUrl(APIUtils.API_UPLOAD_VIDEO_URI)
                 .build();
@@ -113,7 +128,7 @@ abstract class NetworkModule {
     @Provides
     @Named("download_media")
     @Singleton
-    static Retrofit provideDownloadRedditVideoRetrofit(Retrofit retrofit) {
+    static Retrofit provideDownloadRedditVideoRetrofit(@Named(NAMED_BASE_RETROFIT) Retrofit retrofit) {
         return retrofit.newBuilder()
                 .baseUrl("http://localhost/")
                 .build();
@@ -122,7 +137,7 @@ abstract class NetworkModule {
     @Provides
     @Named("gfycat")
     @Singleton
-    static Retrofit provideGfycatRetrofit(Retrofit retrofit) {
+    static Retrofit provideGfycatRetrofit(@Named(NAMED_BASE_RETROFIT) Retrofit retrofit) {
         return retrofit.newBuilder()
                 .baseUrl(APIUtils.GFYCAT_API_BASE_URI)
                 .build();
@@ -130,16 +145,17 @@ abstract class NetworkModule {
 
     @Provides
     @Named("RedgifsAccessTokenAuthenticator")
-    static Interceptor redgifsAccessTokenAuthenticator(@Named("current_account") SharedPreferences currentAccountSharedPreferences) {
+    static Interceptor redgifsAccessTokenAuthenticator(
+            @Named("current_account") SharedPreferences currentAccountSharedPreferences) {
         return new RedgifsAccessTokenAuthenticator(currentAccountSharedPreferences);
     }
 
     @Provides
     @Named("redgifs")
     @Singleton
-    static Retrofit provideRedgifsRetrofit(@Named("RedgifsAccessTokenAuthenticator") Interceptor accessTokenAuthenticator,
-                                           OkHttpClient httpClient,
-                                           Retrofit retrofit,
+    static Retrofit provideRedgifsRetrofit(@Named("RedgifsAccessTokenAuthenticator") Interceptor accessTokenAuthenticatorInterceptor,
+                                           @Named(NAMED_BASE_OKHTTP) OkHttpClient httpClient,
+                                           @Named(NAMED_BASE_RETROFIT) Retrofit retrofit,
                                            ConnectionPool connectionPool) {
         OkHttpClient.Builder okHttpClientBuilder = httpClient.newBuilder()
                 .addInterceptor(chain -> chain.proceed(
@@ -148,7 +164,7 @@ abstract class NetworkModule {
                                 .header("User-Agent", APIUtils.USER_AGENT)
                                 .build()
                 ))
-                .addInterceptor(accessTokenAuthenticator)
+                .addInterceptor(accessTokenAuthenticatorInterceptor)
                 .connectionPool(connectionPool);
 
         return retrofit.newBuilder()
@@ -160,7 +176,7 @@ abstract class NetworkModule {
     @Provides
     @Named("imgur")
     @Singleton
-    static Retrofit provideImgurRetrofit(Retrofit retrofit) {
+    static Retrofit provideImgurRetrofit(@Named(NAMED_BASE_RETROFIT) Retrofit retrofit) {
         return retrofit.newBuilder()
                 .baseUrl(APIUtils.IMGUR_API_BASE_URI)
                 .build();
@@ -169,7 +185,7 @@ abstract class NetworkModule {
     @Provides
     @Named("pushshift")
     @Singleton
-    static Retrofit providePushshiftRetrofit(Retrofit retrofit) {
+    static Retrofit providePushshiftRetrofit(@Named(NAMED_BASE_RETROFIT) Retrofit retrofit) {
         return retrofit.newBuilder()
                 .baseUrl(APIUtils.PUSHSHIFT_API_BASE_URI)
                 .build();
@@ -178,7 +194,7 @@ abstract class NetworkModule {
     @Provides
     @Named("reveddit")
     @Singleton
-    static Retrofit provideRevedditRetrofit(Retrofit retrofit) {
+    static Retrofit provideRevedditRetrofit(@Named(NAMED_BASE_RETROFIT) Retrofit retrofit) {
         return retrofit.newBuilder()
                 .baseUrl(APIUtils.REVEDDIT_API_BASE_URI)
                 .build();
@@ -187,16 +203,27 @@ abstract class NetworkModule {
     @Provides
     @Named("vReddIt")
     @Singleton
-    static Retrofit provideVReddItRetrofit(Retrofit retrofit) {
+    static Retrofit provideVReddItRetrofit(@Named(NAMED_BASE_RETROFIT) Retrofit retrofit) {
         return retrofit.newBuilder()
                 .baseUrl("http://localhost/")
                 .build();
     }
 
     @Provides
+    @Named("strapi")
+    @Singleton
+    static Retrofit provideStrapiRetrofit(@Named(NAMED_DEFAULT_OKHTTP) OkHttpClient okHttpClient,
+                                          @Named(NAMED_BASE_RETROFIT) Retrofit retrofit) {
+        return retrofit.newBuilder()
+                .baseUrl(APIUtils.STRAPI_BASE_URI)
+                .client(okHttpClient)
+                .build();
+    }
+
+    @Provides
     @Named("streamable")
     @Singleton
-    static Retrofit provideStreamableRetrofit(Retrofit retrofit) {
+    static Retrofit provideStreamableRetrofit(@Named(NAMED_BASE_RETROFIT) Retrofit retrofit) {
         return retrofit.newBuilder()
                 .baseUrl(APIUtils.STREAMABLE_API_BASE_URI)
                 .build();

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/NetworkModule.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/NetworkModule.java
@@ -86,16 +86,16 @@ abstract class NetworkModule {
     @Provides
     @Named("no_oauth")
     static Retrofit provideRetrofit(@Named(NAMED_BASE_RETROFIT) Retrofit retrofit) {
-        return retrofit.newBuilder()
-                .baseUrl(APIUtils.OAUTH_API_BASE_URI)
-                .build();
+        return retrofit;
     }
 
     @Provides
+    @Singleton
     @Named("oauth")
     static Retrofit provideOAuthRetrofit(@Named(NAMED_DEFAULT_OKHTTP) OkHttpClient okHttpClient,
                                          @Named(NAMED_BASE_RETROFIT) Retrofit retrofit) {
         return retrofit.newBuilder()
+                .baseUrl(APIUtils.OAUTH_API_BASE_URI)
                 .client(okHttpClient)
                 .build();
     }


### PR DESCRIPTION
This bug emerged from the refactor #1125 - This should add the missing authenticator and converter adapter to the common okhttp and retrofit objects respectively

Thank you for the feedback @RSBat 