### PR TITLE
Anonymous to see Post History Settings

### DIFF
--- a/app/src/main/java/ml/docilealligator/infinityforreddit/settings/PostHistoryFragment.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/settings/PostHistoryFragment.java
@@ -83,14 +83,6 @@ public class PostHistoryFragment extends Fragment {
         }
 
         String accountName = getArguments().getString(EXTRA_ACCOUNT_NAME);
-        if (accountName == null) {
-            infoTextView.setText(R.string.only_for_logged_in_user);
-            markPostsAsReadLinearLayout.setVisibility(View.GONE);
-            markPostsAsReadAfterVotingLinearLayout.setVisibility(View.GONE);
-            markPostsAsReadOnScrollLinearLayout.setVisibility(View.GONE);
-            hideReadPostsAutomaticallyLinearLayout.setVisibility(View.GONE);
-            return rootView;
-        }
 
         markPostsAsReadSwitch.setChecked(postHistorySharedPreferences.getBoolean(
                 accountName + SharedPreferencesUtils.MARK_POSTS_AS_READ_BASE, false));


### PR DESCRIPTION
Allows users who are anonymous or logged out to be able to customize their Post History settings.
In response to the issue https://github.com/Docile-Alligator/Infinity-For-Reddit/issues/1169
