### PR TITLE
Disable aspect ratio logic when it is negative

### DIFF
--- a/app/src/main/java/ml/docilealligator/infinityforreddit/customviews/AspectRatioGifImageView.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/customviews/AspectRatioGifImageView.java
@@ -44,16 +44,18 @@ public class AspectRatioGifImageView extends GifImageView {
     @Override
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
         super.onMeasure(widthMeasureSpec, heightMeasureSpec);
-        int width = this.getMeasuredWidth();
-        int height = this.getMeasuredHeight();
-        if (width != 0 || height != 0) {
-            if (width > 0) {
-                height = (int) ((float) width * this.ratio);
-            } else {
-                width = (int) ((float) height / this.ratio);
-            }
+        if (this.ratio > 0) {
+            int width = this.getMeasuredWidth();
+            int height = this.getMeasuredHeight();
+            if (width != 0 || height != 0) {
+                if (width > 0) {
+                    height = (int) ((float) width * this.ratio);
+                } else {
+                    width = (int) ((float) height / this.ratio);
+                }
 
-            this.setMeasuredDimension(width, height);
+                this.setMeasuredDimension(width, height);
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #1295 

Gallery can set aspect ratio to -1 which would result in negative measured height. It seem that Android treats dimensions as unsigned numbers, so negative numbers actually become huge positive numbers resulting in "infinite" height.

It should be noted that this change allows to disable aspect ratio logic even when some dimension is set to `wrap_content`.