### PR TITLE
Show collapsed comment count when toolbar closed.

### DIFF
--- a/app/src/main/res/layout/item_comment.xml
+++ b/app/src/main/res/layout/item_comment.xml
@@ -76,6 +76,19 @@
                 android:fontFamily="?attr/font_family"
                 android:gravity="end"
                 android:textSize="?attr/font_default"
+                app:autoSizeTextType="uniform"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toStartOf="@id/top_child_comment_count_text_view_item_post_comment"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+                android:id="@+id/top_child_comment_count_text_view_item_post_comment"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="8dp"
+                android:fontFamily="?attr/font_family"
+                android:gravity="end"
+                android:textSize="?attr/font_default"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toStartOf="@id/comment_time_text_view_item_post_comment"
                 app:layout_constraintTop_toTopOf="parent" />


### PR DESCRIPTION
For users that leave comment toolbars collapsed by default for space reasons, the need to see the child comment count (or that a comment has children) is still present.

This PR shows the child comment count similarly to the vote count that shows up when a comment toolbar is collapsed.

There's been some suggestions around for it, eg https://github.com/Docile-Alligator/Infinity-For-Reddit/discussions/869 and https://www.reddit.com/r/Infinity_For_Reddit/comments/106e3cs/cant_see_number_of_child_comments_unless_comment/

I'm not sure what the feeling would be for something like this. It might need a different preference. However, a different preference would be confusing with the 'Always Show the Number of Child Comments' preference, so perhaps it should behind that existing preference?

Glad to hear thoughts, thanks.
