### PR TITLE
Fix deleted comment lookup errors

### DIFF
--- a/app/src/main/java/ml/docilealligator/infinityforreddit/comment/FetchRemovedComment.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/comment/FetchRemovedComment.java
@@ -54,8 +54,8 @@ public class FetchRemovedComment {
             try {
                 Response<String> response = retrofit.create(PushshiftAPI.class).searchComments(
                         comment.getLinkId(),
-                        3000,
-                        "asc",
+                        1000,
+                        "id",
                         "id,author,body,is_submitter",
                         after,
                         after + 43200, // 12 Hours later

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/comment/FetchRemovedCommentReveddit.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/comment/FetchRemovedCommentReveddit.java
@@ -55,13 +55,15 @@ public class FetchRemovedCommentReveddit {
         String id = result.getString(JSONUtils.ID_KEY);
         String author = result.getString(JSONUtils.AUTHOR_KEY);
         String body = Utils.modifyMarkdown(Utils.trimTrailingWhitespace(result.optString(JSONUtils.BODY_KEY)));
-        boolean isSubmitter = result.getBoolean(JSONUtils.IS_SUBMITTER_KEY);
 
         if (id.equals(comment.getId()) && (!author.equals(comment.getAuthor()) || !body.equals(comment.getCommentRawText()))) {
             comment.setAuthor(author);
             comment.setCommentMarkdown(body);
             comment.setCommentRawText(body);
-            comment.setSubmittedByAuthor(isSubmitter);
+            if (result.has(JSONUtils.IS_SUBMITTER_KEY)) {
+                // This doesn't seem to be present for the Reveddit API anymore...
+                comment.setSubmittedByAuthor(result.getBoolean(JSONUtils.IS_SUBMITTER_KEY));
+            }
             return comment;
         } else {
             return null;

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/fragments/ViewPostDetailFragment.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/fragments/ViewPostDetailFragment.java
@@ -1811,7 +1811,7 @@ public class ViewPostDetailFragment extends Fragment implements FragmentCommunic
 
     public void showRemovedComment(Comment comment, int position) {
         Toast.makeText(activity, R.string.fetching_removed_comment, Toast.LENGTH_SHORT).show();
-        FetchRemovedComment.searchRemovedComment(
+        FetchRemovedComment.fetchRemovedComment(
                 mExecutor, new Handler(), pushshiftRetrofit, comment,
                 new FetchRemovedComment.FetchRemovedCommentListener() {
                     @Override


### PR DESCRIPTION
Fix `is_submitter` property not being present on responses from the reveddit API. I don't know where the docs are for the reveddit API are, so I can't say whether the API occasionally responds with `is_submitter`...

Tried to fix some issues with the pushshift API when searching for deleted comments. It seems like searching by comment ids (might?) work again, so this PR switched back to directly searching by comment id. Though this will need a lot of testing to be sure.

Fixes #1334 and other reports.