### PR TITLE
Locally saved posts

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -43,6 +43,12 @@
             android:parentActivityName=".activities.MainActivity"
             android:theme="@style/AppTheme.Slidable" />
         <activity
+            android:name=".activities.LocalPostsActivity"
+            android:exported="false"
+            android:label="@string/local_post_activity_label"
+            android:parentActivityName=".activities.MainActivity"
+            android:theme="@style/AppTheme.Slidable" />
+        <activity
             android:name=".activities.PostPollActivity"
             android:label="@string/post_poll_activity_label"
             android:parentActivityName=".activities.MainActivity"

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/AppComponent.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/AppComponent.java
@@ -25,6 +25,7 @@ import ml.docilealligator.infinityforreddit.activities.GiveAwardActivity;
 import ml.docilealligator.infinityforreddit.activities.HistoryActivity;
 import ml.docilealligator.infinityforreddit.activities.InboxActivity;
 import ml.docilealligator.infinityforreddit.activities.LinkResolverActivity;
+import ml.docilealligator.infinityforreddit.activities.LocalPostsActivity;
 import ml.docilealligator.infinityforreddit.activities.LockScreenActivity;
 import ml.docilealligator.infinityforreddit.activities.LoginActivity;
 import ml.docilealligator.infinityforreddit.activities.MainActivity;
@@ -70,6 +71,7 @@ import ml.docilealligator.infinityforreddit.fragments.CommentsListingFragment;
 import ml.docilealligator.infinityforreddit.fragments.FollowedUsersListingFragment;
 import ml.docilealligator.infinityforreddit.fragments.HistoryPostFragment;
 import ml.docilealligator.infinityforreddit.fragments.InboxFragment;
+import ml.docilealligator.infinityforreddit.fragments.LocalPostFragment;
 import ml.docilealligator.infinityforreddit.fragments.MorePostsInfoFragment;
 import ml.docilealligator.infinityforreddit.fragments.MultiRedditListingFragment;
 import ml.docilealligator.infinityforreddit.fragments.PostFragment;
@@ -99,6 +101,7 @@ import ml.docilealligator.infinityforreddit.settings.MiscellaneousPreferenceFrag
 import ml.docilealligator.infinityforreddit.settings.NotificationPreferenceFragment;
 import ml.docilealligator.infinityforreddit.settings.NsfwAndSpoilerFragment;
 import ml.docilealligator.infinityforreddit.settings.PostHistoryFragment;
+import ml.docilealligator.infinityforreddit.settings.PostLocalFragment;
 import ml.docilealligator.infinityforreddit.settings.SecurityPreferenceFragment;
 import ml.docilealligator.infinityforreddit.settings.ThemePreferenceFragment;
 import ml.docilealligator.infinityforreddit.settings.TranslationFragment;
@@ -306,6 +309,10 @@ public interface AppComponent {
     void inject(HistoryActivity historyActivity);
 
     void inject(MorePostsInfoFragment morePostsInfoFragment);
+
+    void inject(LocalPostsActivity localPostsActivity);
+    void inject(LocalPostFragment localPostFragment);
+    void inject(PostLocalFragment postLocalFragment);
 
     @Component.Factory
     interface Factory {

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/AppModule.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/AppModule.java
@@ -112,6 +112,12 @@ abstract class AppModule {
     }
 
     @Provides
+    @Named("post_local")
+    static SharedPreferences providePostLocalSharedPreferences(Application application) {
+        return application.getSharedPreferences(SharedPreferencesUtils.POST_LOCAL_POSTS_SHARED_PREFERENCES_FILE, Context.MODE_PRIVATE);
+    }
+
+    @Provides
     @Named("current_account")
     static SharedPreferences provideCurrentAccountSharedPreferences(Application application) {
         return application.getSharedPreferences(SharedPreferencesUtils.CURRENT_ACCOUNT_SHARED_PREFERENCES_FILE, Context.MODE_PRIVATE);

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/LocalSave.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/LocalSave.java
@@ -264,11 +264,7 @@ public class LocalSave
         int i = 0;
         for(SavedPost post : savedPosts.values())
         {
-            i++;
-            if(i == 900)
-            {
-                useFilter = true;
-            }
+            useFilter = true;
 
             if(post.GetFilters(filters))
             {

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/LocalSave.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/LocalSave.java
@@ -1,5 +1,6 @@
 package ml.docilealligator.infinityforreddit;
 
+import android.content.ComponentCallbacks;
 import android.content.Context;
 import android.net.Uri;
 import android.os.ParcelFileDescriptor;
@@ -31,10 +32,7 @@ import ml.docilealligator.infinityforreddit.post.Post;
 
 public class LocalSave
 {
-    public static final int CREATE_BACKUP = 1;
-    public static final int LOAD_BACKUP = 2;
-
-    public static class SavedPost implements Serializable
+    public static class SavedPost implements Serializable, Comparable<SavedPost>
     {
         String id;
         String title;
@@ -59,10 +57,7 @@ public class LocalSave
             return id;
         }
 
-        public long getTime()
-        {
-            return time;
-        }
+        public long getTime() { return time; }
 
         public String getTags() { return tags; }
         public void setTags(String newTags) { tags = newTags; }
@@ -92,13 +87,20 @@ public class LocalSave
 
             return false;
         }
+
+        @Override
+        public int compareTo(SavedPost o) {
+            return Long.compare(time, o.getTime());
+        }
     }
 
-    public static final int SORT_NEWEST = 0;
-    public static final int SORT_OLDEST = 1;
-    public static final int SORT_RANDOM = 2;
-    public static final CharSequence[] SortTypes = new CharSequence[] { "Newest", "Oldest", "Random" };
-    public static int sortType = SORT_NEWEST;
+    public static final int SORT_RANDOM = 0;
+    public static final int SORT_NEWEST_ADDED = 1;
+    public static final int SORT_OLDEST_ADDED = 2;
+    public static final int SORT_NEWEST_UPLOAD= 3;
+    public static final int SORT_OLDEST_UPLOAD= 4;
+    public static final CharSequence[] SortTypes = new CharSequence[] { "Random", "Newest Added", "Oldest Added", "Newest Upload", "Oldest Upload" };
+    public static int sortType = SORT_NEWEST_ADDED;
 
     public static Context globalCtx;
 
@@ -138,12 +140,20 @@ public class LocalSave
         switch(sortType)
         {
             default:
+            case SORT_OLDEST_ADDED:
                 break;
-            case SORT_NEWEST:
+            case SORT_NEWEST_ADDED:
                 Collections.reverse(posts);
                 break;
             case SORT_RANDOM:
                 Collections.shuffle(posts, new SecureRandom());
+                break;
+            case SORT_OLDEST_UPLOAD:
+                Collections.sort(posts);
+                break;
+            case SORT_NEWEST_UPLOAD:
+                Collections.sort(posts);
+                Collections.reverse(posts);
                 break;
         }
 

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/LocalSave.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/LocalSave.java
@@ -116,7 +116,13 @@ public class LocalSave
     public static boolean cacheHistory = false;
     public static boolean cacheSaved = true;
 
-    public static void AddPosts(LinkedHashSet<Post> posts)
+
+    public static int GetCachedPostsCount()
+    {
+        return cachedPosts.size();
+    }
+
+    public static void CachePosts(LinkedHashSet<Post> posts)
     {
         for(Post post : posts)
         {
@@ -133,7 +139,7 @@ public class LocalSave
         {
             default:
                 break;
-            case SORT_OLDEST:
+            case SORT_NEWEST:
                 Collections.reverse(posts);
                 break;
             case SORT_RANDOM:
@@ -157,7 +163,7 @@ public class LocalSave
         ObjectInputStream input = null;
         try
         {
-            File directory = new File(globalCtx.getFilesDir()+java.io.File.separator +"localPosts.txt");
+            File directory = new File(globalCtx.getFilesDir(), "localPosts.txt");
             if(!directory.exists()) { return; }
 
             input = new ObjectInputStream(new FileInputStream(directory));
@@ -174,7 +180,7 @@ public class LocalSave
     public static void SaveLocalPosts()
     {
         ObjectOutputStream output = null;
-        File f = new File(globalCtx.getFilesDir(), "localPost.txt");
+        File f = new File(globalCtx.getFilesDir(), "localPosts.txt");
         try {
             f.createNewFile();
         } catch (IOException e) {
@@ -229,7 +235,6 @@ public class LocalSave
     public static void ClearSavedPosts()
     {
         savedPosts.clear();
-        cachedPosts.clear();
 
         Toast.makeText(globalCtx, "Removed All Local Posts", Toast.LENGTH_SHORT).show();
     }

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/LocalSave.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/LocalSave.java
@@ -1,0 +1,309 @@
+package ml.docilealligator.infinityforreddit;
+
+import android.content.Context;
+import android.net.Uri;
+import android.os.ParcelFileDescriptor;
+import android.widget.Toast;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.security.SecureRandom;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+
+import ml.docilealligator.infinityforreddit.post.Post;
+
+public class LocalSave
+{
+    public static final int CREATE_BACKUP = 1;
+    public static final int LOAD_BACKUP = 2;
+
+    public static class SavedPost implements Serializable
+    {
+        String id;
+        String title;
+        String subreddit;
+        String flair;
+        long time;
+
+        String tags;
+
+        public SavedPost(String _id, String _title, String _subreddit, String _flair, long _time)
+        {
+            id = _id;
+            title = _title;
+            subreddit = _subreddit;
+            flair = _flair;
+            time = _time;
+            tags = "";
+        }
+
+        public String getId()
+        {
+            return id;
+        }
+
+        public long getTime()
+        {
+            return time;
+        }
+
+        public String getTags() { return tags; }
+        public void setTags(String newTags) { tags = newTags; }
+
+        private boolean Filter(String filter)
+        {
+            filter = filter.toLowerCase();
+            if(title.toLowerCase().contains(filter)) { return true; }
+            if(subreddit.toLowerCase().contains(filter)) { return true; }
+            if(flair.toLowerCase().contains(filter)) { return true; }
+
+            if(tags.toLowerCase().contains(filter)) { return true; }
+
+            return false;
+        }
+
+        public boolean GetFilters(String[] filters)
+        {
+            for(String filter : filters)
+            {
+                filter = filter.replace("_", " ");
+                if(Filter(filter))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+
+    public static final int SORT_NEWEST = 0;
+    public static final int SORT_OLDEST = 1;
+    public static final int SORT_RANDOM = 2;
+    public static final CharSequence[] SortTypes = new CharSequence[] { "Newest", "Oldest", "Random" };
+    public static int sortType = SORT_NEWEST;
+
+    public static Context globalCtx;
+
+    private static boolean useFilter;
+    private static LinkedHashMap<String, SavedPost> savedPosts = new LinkedHashMap<String, SavedPost>();
+    private static ArrayList<SavedPost> filteredPosts = new ArrayList<SavedPost>();
+
+    private static LinkedHashMap<String, Post> cachedPosts = new LinkedHashMap<String, Post>();
+
+    public static SavedPost GetPost(String postId)
+    {
+        return savedPosts.get(postId);
+    }
+
+    public static boolean cacheHistory = false;
+    public static boolean cacheSaved = true;
+
+    public static void AddPosts(LinkedHashSet<Post> posts)
+    {
+        for(Post post : posts)
+        {
+            cachedPosts.put(post.getId(), post);
+        }
+    }
+
+    public static List<SavedPost> GetPosts()
+    {
+        ArrayList<SavedPost> posts;
+        posts = useFilter ? filteredPosts : new ArrayList<SavedPost>(savedPosts.values());
+
+        switch(sortType)
+        {
+            default:
+                break;
+            case SORT_OLDEST:
+                Collections.reverse(posts);
+                break;
+            case SORT_RANDOM:
+                Collections.shuffle(posts, new SecureRandom());
+                break;
+        }
+
+        //return posts.stream().limit(100).collect(Collectors.toList());    // This requires API level 24 at least
+        if(posts.size() <= 100)
+        {
+            return posts;
+        }
+        else
+        {
+            return posts.subList(0, 100);
+        }
+    }
+
+    public static void LoadLocalPosts()
+    {
+        ObjectInputStream input = null;
+        try
+        {
+            File directory = new File(globalCtx.getFilesDir()+java.io.File.separator +"localPosts.txt");
+            if(!directory.exists()) { return; }
+
+            input = new ObjectInputStream(new FileInputStream(directory));
+            savedPosts = (LinkedHashMap<String, SavedPost>) input.readObject();
+            input.close();
+
+            Toast.makeText(globalCtx, "Loaded Local Posts", Toast.LENGTH_SHORT).show();
+        }
+        catch (Exception e)
+        {
+            e.printStackTrace();
+        }
+    }
+    public static void SaveLocalPosts()
+    {
+        ObjectOutputStream output = null;
+        File f = new File(globalCtx.getFilesDir(), "localPost.txt");
+        try {
+            f.createNewFile();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        try
+        {
+            FileOutputStream fo = new FileOutputStream(f, false);
+            output = new ObjectOutputStream(fo);
+            output.writeObject(savedPosts);
+            output.close();
+            fo.close();
+
+            Toast.makeText(globalCtx, "Saved Local Posts", Toast.LENGTH_SHORT).show();
+        }
+        catch (IOException e)
+        {
+            e.printStackTrace();
+        }
+    }
+
+    public static void AddPost(String id, String title, String subreddit, String flair, long time)
+    {
+        savedPosts.put(id, new SavedPost(id, title, subreddit, flair, time));
+
+        Toast.makeText(globalCtx, "Saved Local Post", Toast.LENGTH_SHORT).show();
+    }
+
+    public static void RemovePost(String id)
+    {
+        savedPosts.remove(id);
+        Toast.makeText(globalCtx, "Removed Local Post", Toast.LENGTH_SHORT).show();
+    }
+
+    public static void GetAllSaved()
+    {
+        for(Post post : cachedPosts.values())
+        {
+            savedPosts.put(post.getId(), new SavedPost(post.getId(), post.getTitle(), post.getSubredditName(), post.getFlair(), post.getPostTimeMillis()));
+        }
+        Toast.makeText(globalCtx, "Saved Cached Posts Locally", Toast.LENGTH_SHORT).show();
+    }
+
+    public static void ClearCachedPosts()
+    {
+        cachedPosts.clear();
+
+        Toast.makeText(globalCtx, "Cached Posts Cleard", Toast.LENGTH_SHORT).show();
+    }
+
+    public static void ClearSavedPosts()
+    {
+        savedPosts.clear();
+        cachedPosts.clear();
+
+        Toast.makeText(globalCtx, "Removed All Local Posts", Toast.LENGTH_SHORT).show();
+    }
+
+    public static void Filter(String text)
+    {
+        if(text.isBlank())
+        {
+            useFilter = false;
+            return;
+        }
+
+        useFilter = true;
+        filteredPosts.clear();
+
+        String[] filters = text.split(" ");
+        int i = 0;
+        for(SavedPost post : savedPosts.values())
+        {
+            i++;
+            if(i == 900)
+            {
+                useFilter = true;
+            }
+
+            if(post.GetFilters(filters))
+            {
+                filteredPosts.add(post);
+            }
+        }
+    }
+
+    public static void LoadBackup(Uri uri)
+    {
+        StringBuilder stringBuilder = new StringBuilder();
+        try (InputStream inputStream = globalCtx.getContentResolver().openInputStream(uri);
+             BufferedReader reader = new BufferedReader(
+                     new InputStreamReader(Objects.requireNonNull(inputStream)))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                stringBuilder.append(line);
+            }
+        } catch (FileNotFoundException e) {
+            throw new RuntimeException(e);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        //TODO: Maybe make this a bit cleaner. Save HashMap directly instead of recreating it from an array?
+        Gson gson = new Gson();
+        SavedPost[] posts = gson.fromJson(stringBuilder.toString(), SavedPost[].class);
+        savedPosts.clear();
+        for(SavedPost post : posts)
+        {
+            savedPosts.put(post.getId(), post);
+        }
+    }
+    public static void SaveBackup(Uri uri)
+    {
+        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+        String json = gson.toJson(savedPosts.values());
+
+        try {
+            ParcelFileDescriptor pfd = globalCtx.getContentResolver().
+                    openFileDescriptor(uri, "w");
+            FileOutputStream fileOutputStream =
+                    new FileOutputStream(pfd.getFileDescriptor());
+            fileOutputStream.write(json.getBytes());
+            fileOutputStream.close();
+            pfd.close();
+        } catch (FileNotFoundException e) {
+            e.printStackTrace();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/activities/LocalPostsActivity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/activities/LocalPostsActivity.java
@@ -4,7 +4,6 @@ import android.app.Activity;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
-import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.view.KeyEvent;
@@ -88,6 +87,9 @@ public class LocalPostsActivity extends BaseActivity implements ActivityToolbarI
     private String mAccessToken;
     private String mAccountName;
 
+    public static final int CREATE_BACKUP = 1;
+    public static final int LOAD_BACKUP = 2;
+
     private void ChangeSort()
     {
         MaterialAlertDialogBuilder alert = new MaterialAlertDialogBuilder(this, R.style.MaterialAlertDialogTheme).setTitle("Sort");
@@ -138,7 +140,6 @@ public class LocalPostsActivity extends BaseActivity implements ActivityToolbarI
         saveCachedBtn.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                //Save Cache
                 LocalSave.GetAllSaved();
                 sectionsPagerAdapter.refresh();
             }
@@ -158,8 +159,13 @@ public class LocalPostsActivity extends BaseActivity implements ActivityToolbarI
                 new MaterialAlertDialogBuilder(v.getContext(), R.style.MaterialAlertDialogTheme)
                         .setTitle("Clear?")
                         .setMessage("Clear Saved Posts")
-                        .setPositiveButton(R.string.yes, (dialogInterface, i)
-                                -> LocalSave.ClearSavedPosts())
+                        .setPositiveButton(R.string.yes, new DialogInterface.OnClickListener() {
+                            @Override
+                            public void onClick(DialogInterface dialog, int which) {
+                                LocalSave.ClearSavedPosts();
+                                sectionsPagerAdapter.refresh();
+                            }
+                        })
                         .setNegativeButton(R.string.no, null)
                         .show();
             }
@@ -193,8 +199,6 @@ public class LocalPostsActivity extends BaseActivity implements ActivityToolbarI
         if (mSharedPreferences.getBoolean(SharedPreferencesUtils.SWIPE_RIGHT_TO_GO_BACK, true)) {
             mSliderPanel = Slidr.attach(this);
         }
-
-        //mViewPager2 = viewPager2;
 
         searchView.clearFocus();
         searchView.setOnQueryTextListener(new SearchView.OnQueryTextListener() {
@@ -278,15 +282,7 @@ public class LocalPostsActivity extends BaseActivity implements ActivityToolbarI
         tabLayout.setVisibility(View.GONE);
         viewPager2.setAdapter(sectionsPagerAdapter);
         viewPager2.setOffscreenPageLimit(2);
-        //viewPager2.setUserInputEnabled(!mSharedPreferences.getBoolean(SharedPreferencesUtils.DISABLE_SWIPING_BETWEEN_TABS, false));
         viewPager2.setUserInputEnabled(false);
-        /*new TabLayoutMediator(tabLayout, viewPager2, (tab, position) -> {
-            switch (position) {
-                case 0:
-                    Utils.setTitleWithCustomFontToTab(typeface, tab, getString(R.string.posts));
-                    break;
-            }
-        }).attach();*/
 
         viewPager2.registerOnPageChangeCallback(new ViewPager2.OnPageChangeCallback() {
             @Override
@@ -338,7 +334,7 @@ public class LocalPostsActivity extends BaseActivity implements ActivityToolbarI
             intent.setType("text/plain");
             intent.putExtra(Intent.EXTRA_TITLE, "backup.txt");
 
-            startActivityForResult(intent, LocalSave.CREATE_BACKUP);
+            startActivityForResult(intent, CREATE_BACKUP);
 
             return true;
         } else if (itemId == R.id.backup_load) {
@@ -347,7 +343,7 @@ public class LocalPostsActivity extends BaseActivity implements ActivityToolbarI
             intent.addCategory(Intent.CATEGORY_OPENABLE);
             intent.setType("text/plain");
 
-            startActivityForResult(intent, LocalSave.LOAD_BACKUP);
+            startActivityForResult(intent, LOAD_BACKUP);
 
             return true;
         }
@@ -362,13 +358,11 @@ public class LocalPostsActivity extends BaseActivity implements ActivityToolbarI
             return;
         }
 
-        if (requestCode == LocalSave.CREATE_BACKUP) {
-            Uri uri = null;
+        if (requestCode == CREATE_BACKUP) {
             if (resultData != null) {
                 LocalSave.SaveBackup(resultData.getData());
             }
-        } else if(requestCode == LocalSave.LOAD_BACKUP) {
-            Uri uri = null;
+        } else if(requestCode == LOAD_BACKUP) {
             if (resultData != null) {
                 LocalSave.LoadBackup(resultData.getData());
                 sectionsPagerAdapter.refresh();

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/activities/LocalPostsActivity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/activities/LocalPostsActivity.java
@@ -97,6 +97,7 @@ public class LocalPostsActivity extends BaseActivity implements ActivityToolbarI
             public void onClick(DialogInterface dialog, int sortType) {
                 LocalSave.sortType = sortType;
                 sectionsPagerAdapter.refresh();
+                mPostLayoutSharedPreferences.edit().putInt(SharedPreferencesUtils.LOCAL_POST_SORTING, sortType).apply();
                 dialog.dismiss();
             }
         });
@@ -120,6 +121,7 @@ public class LocalPostsActivity extends BaseActivity implements ActivityToolbarI
             @Override
             public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
                 LocalSave.cacheSaved = isChecked;
+                mPostLayoutSharedPreferences.edit().putBoolean(SharedPreferencesUtils.LOCAL_POST_CACHE_SAVED, isChecked).apply();
             }
         });
 
@@ -128,15 +130,17 @@ public class LocalPostsActivity extends BaseActivity implements ActivityToolbarI
             @Override
             public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
                 LocalSave.cacheHistory = isChecked;
+                mPostLayoutSharedPreferences.edit().putBoolean(SharedPreferencesUtils.LOCAL_POST_CACHE_HISTORY, isChecked).apply();
             }
         });
 
-
+        saveCachedBtn.setText(String.format("Save Cached Posts (%s)", LocalSave.GetCachedPostsCount()));
         saveCachedBtn.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
                 //Save Cache
                 LocalSave.GetAllSaved();
+                sectionsPagerAdapter.refresh();
             }
         });
 
@@ -144,6 +148,7 @@ public class LocalPostsActivity extends BaseActivity implements ActivityToolbarI
             @Override
             public void onClick(View v) {
                 LocalSave.ClearCachedPosts();
+                saveCachedBtn.setText(String.format("Save Cached Posts (%s)", LocalSave.GetCachedPostsCount()));
             }
         });
 
@@ -161,6 +166,12 @@ public class LocalPostsActivity extends BaseActivity implements ActivityToolbarI
         });
 
         alert.setView(view);
+
+        alert.setPositiveButton("Done", new DialogInterface.OnClickListener() {
+            public void onClick(DialogInterface dialog, int which) {
+                dialog.dismiss();
+            }
+        });
 
         alert.show();
     }
@@ -360,6 +371,7 @@ public class LocalPostsActivity extends BaseActivity implements ActivityToolbarI
             Uri uri = null;
             if (resultData != null) {
                 LocalSave.LoadBackup(resultData.getData());
+                sectionsPagerAdapter.refresh();
             }
         }
     }

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/activities/LocalPostsActivity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/activities/LocalPostsActivity.java
@@ -1,0 +1,488 @@
+package ml.docilealligator.infinityforreddit.activities;
+
+import android.app.Activity;
+import android.content.DialogInterface;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.net.Uri;
+import android.os.Build;
+import android.os.Bundle;
+import android.view.KeyEvent;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.Window;
+import android.view.WindowManager;
+import android.widget.Button;
+import android.widget.CheckBox;
+import android.widget.CompoundButton;
+import android.widget.SearchView;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.widget.Toolbar;
+import androidx.coordinatorlayout.widget.CoordinatorLayout;
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentActivity;
+import androidx.fragment.app.FragmentManager;
+import androidx.viewpager2.adapter.FragmentStateAdapter;
+import androidx.viewpager2.widget.ViewPager2;
+
+import com.google.android.material.appbar.AppBarLayout;
+import com.google.android.material.appbar.CollapsingToolbarLayout;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+import com.google.android.material.tabs.TabLayout;
+
+import org.greenrobot.eventbus.EventBus;
+import org.greenrobot.eventbus.Subscribe;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import butterknife.BindView;
+import butterknife.ButterKnife;
+import ml.docilealligator.infinityforreddit.ActivityToolbarInterface;
+import ml.docilealligator.infinityforreddit.Infinity;
+import ml.docilealligator.infinityforreddit.LocalSave;
+import ml.docilealligator.infinityforreddit.R;
+import ml.docilealligator.infinityforreddit.bottomsheetfragments.PostLayoutBottomSheetFragment;
+import ml.docilealligator.infinityforreddit.customtheme.CustomThemeWrapper;
+import ml.docilealligator.infinityforreddit.customviews.slidr.Slidr;
+import ml.docilealligator.infinityforreddit.events.ChangeNSFWEvent;
+import ml.docilealligator.infinityforreddit.events.SwitchAccountEvent;
+import ml.docilealligator.infinityforreddit.fragments.LocalPostFragment;
+import ml.docilealligator.infinityforreddit.fragments.PostFragment;
+import ml.docilealligator.infinityforreddit.utils.SharedPreferencesUtils;
+
+public class LocalPostsActivity extends BaseActivity implements ActivityToolbarInterface,
+        PostLayoutBottomSheetFragment.PostLayoutSelectionCallback {
+
+    @BindView(R.id.coordinator_layout_local_posts_activity)
+    CoordinatorLayout coordinatorLayout;
+    @BindView(R.id.appbar_layout_local_posts_activity)
+    AppBarLayout appBarLayout;
+    @BindView(R.id.collapsing_toolbar_layout_local_posts_activity)
+    CollapsingToolbarLayout collapsingToolbarLayout;
+    @BindView(R.id.toolbar_local_posts_activity)
+    Toolbar toolbar;
+    @BindView(R.id.tab_layout_tab_layout_local_posts_activity_activity)
+    TabLayout tabLayout;
+    @BindView(R.id.view_pager_local_posts_activity)
+    ViewPager2 viewPager2;
+
+    @BindView(R.id.local_posts_searchbar)
+    SearchView searchView;
+    @Inject
+    @Named("default")
+    SharedPreferences mSharedPreferences;
+    @Inject
+    @Named("post_layout")
+    SharedPreferences mPostLayoutSharedPreferences;
+    @Inject
+    @Named("current_account")
+    SharedPreferences mCurrentAccountSharedPreferences;
+    @Inject
+    CustomThemeWrapper mCustomThemeWrapper;
+    private FragmentManager fragmentManager;
+    private SectionsPagerAdapter sectionsPagerAdapter;
+    private String mAccessToken;
+    private String mAccountName;
+
+    private void ChangeSort()
+    {
+        MaterialAlertDialogBuilder alert = new MaterialAlertDialogBuilder(this, R.style.MaterialAlertDialogTheme).setTitle("Sort");
+
+        alert.setSingleChoiceItems(LocalSave.SortTypes, LocalSave.sortType, new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int sortType) {
+                LocalSave.sortType = sortType;
+                sectionsPagerAdapter.refresh();
+                dialog.dismiss();
+            }
+        });
+
+        alert.show();
+    }
+
+    private void ShowLocalSaveSettings()
+    {
+        MaterialAlertDialogBuilder alert = new MaterialAlertDialogBuilder(this, R.style.MaterialAlertDialogTheme).setTitle("Settings");
+
+        View view = getLayoutInflater().inflate(R.layout.local_posts_settings, null);
+        CheckBox cacheSavedCheck = view.findViewById(R.id.cache_saved_checkbox);
+        CheckBox cacheHistoryCheck = view.findViewById(R.id.cache_history_checkbox);
+        Button saveCachedBtn = view.findViewById(R.id.save_cached_btn);
+        Button clearCachedBtn = view.findViewById(R.id.clear_cached_btn);
+        Button removeAllSavedBtn = view.findViewById(R.id.remove_all_saved_btn);
+
+        cacheSavedCheck.setChecked(LocalSave.cacheSaved);
+        cacheSavedCheck.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+            @Override
+            public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+                LocalSave.cacheSaved = isChecked;
+            }
+        });
+
+        cacheHistoryCheck.setChecked(LocalSave.cacheHistory);
+        cacheHistoryCheck.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+            @Override
+            public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+                LocalSave.cacheHistory = isChecked;
+            }
+        });
+
+
+        saveCachedBtn.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                //Save Cache
+                LocalSave.GetAllSaved();
+            }
+        });
+
+        clearCachedBtn.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                LocalSave.ClearCachedPosts();
+            }
+        });
+
+        removeAllSavedBtn.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                new MaterialAlertDialogBuilder(v.getContext(), R.style.MaterialAlertDialogTheme)
+                        .setTitle("Clear?")
+                        .setMessage("Clear Saved Posts")
+                        .setPositiveButton(R.string.yes, (dialogInterface, i)
+                                -> LocalSave.ClearSavedPosts())
+                        .setNegativeButton(R.string.no, null)
+                        .show();
+            }
+        });
+
+        alert.setView(view);
+
+        alert.show();
+    }
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        ((Infinity) getApplication()).getAppComponent().inject(this);
+
+        super.onCreate(savedInstanceState);
+
+        setContentView(R.layout.activity_local_posts);
+
+        ButterKnife.bind(this);
+
+        EventBus.getDefault().register(this);
+
+        applyCustomTheme();
+
+        if (mSharedPreferences.getBoolean(SharedPreferencesUtils.SWIPE_RIGHT_TO_GO_BACK, true)) {
+            mSliderPanel = Slidr.attach(this);
+        }
+
+        //mViewPager2 = viewPager2;
+
+        searchView.clearFocus();
+        searchView.setOnQueryTextListener(new SearchView.OnQueryTextListener() {
+            @Override
+            public boolean onQueryTextSubmit(String query)
+            {
+                LocalSave.Filter(query);
+                sectionsPagerAdapter.refresh();
+                searchView.clearFocus();
+                return true;
+            }
+
+            @Override
+            public boolean onQueryTextChange(String newText)
+            {
+                if(newText.isBlank())
+                {
+                    onQueryTextSubmit("");
+                }
+                return true;
+            }
+        });
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            Window window = getWindow();
+
+            if (isChangeStatusBarIconColor()) {
+                addOnOffsetChangedListener(appBarLayout);
+            }
+
+            if (isImmersiveInterface()) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                    window.setDecorFitsSystemWindows(false);
+                } else {
+                    window.setFlags(WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS, WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS);
+                }
+                adjustToolbar(toolbar);
+            }
+        }
+
+        setSupportActionBar(toolbar);
+        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+        setToolbarGoToTop(toolbar);
+
+        fragmentManager = getSupportFragmentManager();
+
+        mAccessToken = mCurrentAccountSharedPreferences.getString(SharedPreferencesUtils.ACCESS_TOKEN, null);
+        mAccountName = mCurrentAccountSharedPreferences.getString(SharedPreferencesUtils.ACCOUNT_NAME, null);
+
+        initializeViewPager();
+    }
+
+    @Override
+    public boolean onKeyDown(int keyCode, KeyEvent event) {
+        if (sectionsPagerAdapter != null) {
+            return sectionsPagerAdapter.handleKeyDown(keyCode) || super.onKeyDown(keyCode, event);
+        }
+
+        return super.onKeyDown(keyCode, event);
+    }
+
+    @Override
+    public SharedPreferences getDefaultSharedPreferences() {
+        return mSharedPreferences;
+    }
+
+    @Override
+    protected CustomThemeWrapper getCustomThemeWrapper() {
+        return mCustomThemeWrapper;
+    }
+
+    @Override
+    protected void applyCustomTheme() {
+        coordinatorLayout.setBackgroundColor(mCustomThemeWrapper.getBackgroundColor());
+        applyAppBarLayoutAndCollapsingToolbarLayoutAndToolbarTheme(appBarLayout, collapsingToolbarLayout, toolbar);
+        applyTabLayoutTheme(tabLayout);
+    }
+
+    private void initializeViewPager() {
+        sectionsPagerAdapter = new SectionsPagerAdapter(this);
+        tabLayout.setVisibility(View.GONE);
+        viewPager2.setAdapter(sectionsPagerAdapter);
+        viewPager2.setOffscreenPageLimit(2);
+        //viewPager2.setUserInputEnabled(!mSharedPreferences.getBoolean(SharedPreferencesUtils.DISABLE_SWIPING_BETWEEN_TABS, false));
+        viewPager2.setUserInputEnabled(false);
+        /*new TabLayoutMediator(tabLayout, viewPager2, (tab, position) -> {
+            switch (position) {
+                case 0:
+                    Utils.setTitleWithCustomFontToTab(typeface, tab, getString(R.string.posts));
+                    break;
+            }
+        }).attach();*/
+
+        viewPager2.registerOnPageChangeCallback(new ViewPager2.OnPageChangeCallback() {
+            @Override
+            public void onPageSelected(int position) {
+                if (position == 0) {
+                    unlockSwipeRightToGoBack();
+                } else {
+                    lockSwipeRightToGoBack();
+                }
+            }
+        });
+
+        fixViewPager2Sensitivity(viewPager2);
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        getMenuInflater().inflate(R.menu.local_posts_activity, menu);
+        applyMenuItemTheme(menu);
+        return true;
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
+        int itemId = item.getItemId();
+        if (itemId == android.R.id.home) {
+            finish();
+            return true;
+        } else if (itemId == R.id.action_refresh_local_posts_activity) {
+            sectionsPagerAdapter.refresh();
+            return true;
+        } else if (itemId == R.id.action_change_post_layout_local_posts_activity) {
+            PostLayoutBottomSheetFragment postLayoutBottomSheetFragment = new PostLayoutBottomSheetFragment();
+            postLayoutBottomSheetFragment.show(getSupportFragmentManager(), postLayoutBottomSheetFragment.getTag());
+            return true;
+        }  else if (itemId == R.id.change_sort_type) {
+            ChangeSort();
+            return true;
+        } else if (itemId == R.id.manual_save) {
+            LocalSave.SaveLocalPosts();
+            return true;
+        } else if (itemId == R.id.local_settings) {
+            ShowLocalSaveSettings();
+            return true;
+        } else if (itemId == R.id.backup_save) {
+
+            Intent intent = new Intent(Intent.ACTION_CREATE_DOCUMENT);
+            intent.addCategory(Intent.CATEGORY_OPENABLE);
+            intent.setType("text/plain");
+            intent.putExtra(Intent.EXTRA_TITLE, "backup.txt");
+
+            startActivityForResult(intent, LocalSave.CREATE_BACKUP);
+
+            return true;
+        } else if (itemId == R.id.backup_load) {
+
+            Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
+            intent.addCategory(Intent.CATEGORY_OPENABLE);
+            intent.setType("text/plain");
+
+            startActivityForResult(intent, LocalSave.LOAD_BACKUP);
+
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent resultData) {
+        super.onActivityResult(requestCode, resultCode, resultData);
+        if(resultCode != Activity.RESULT_OK)
+        {
+            return;
+        }
+
+        if (requestCode == LocalSave.CREATE_BACKUP) {
+            Uri uri = null;
+            if (resultData != null) {
+                LocalSave.SaveBackup(resultData.getData());
+            }
+        } else if(requestCode == LocalSave.LOAD_BACKUP) {
+            Uri uri = null;
+            if (resultData != null) {
+                LocalSave.LoadBackup(resultData.getData());
+            }
+        }
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        EventBus.getDefault().unregister(this);
+    }
+
+    @Subscribe
+    public void onAccountSwitchEvent(SwitchAccountEvent event) {
+        finish();
+    }
+
+    @Subscribe
+    public void onChangeNSFWEvent(ChangeNSFWEvent changeNSFWEvent) {
+        sectionsPagerAdapter.changeNSFW(changeNSFWEvent.nsfw);
+    }
+
+    @Override
+    public void onLongPress() {
+        if (sectionsPagerAdapter != null) {
+            sectionsPagerAdapter.goBackToTop();
+        }
+    }
+
+    @Override
+    public void lockSwipeRightToGoBack() {
+        if (mSliderPanel != null) {
+            mSliderPanel.lock();
+        }
+    }
+
+    @Override
+    public void unlockSwipeRightToGoBack() {
+        if (mSliderPanel != null) {
+            mSliderPanel.unlock();
+        }
+    }
+
+    @Override
+    public void postLayoutSelected(int postLayout) {
+        if (sectionsPagerAdapter != null) {
+            mPostLayoutSharedPreferences.edit().putInt(SharedPreferencesUtils.LOCAL_POST_LAYOUT, postLayout).apply();
+            sectionsPagerAdapter.changePostLayout(postLayout);
+        }
+    }
+
+    private class SectionsPagerAdapter extends FragmentStateAdapter {
+
+        SectionsPagerAdapter(FragmentActivity fa) {
+            super(fa);
+        }
+
+        @NonNull
+        @Override
+        public Fragment createFragment(int position) {
+            if (position == 0) {
+                LocalPostFragment fragment = new LocalPostFragment();
+                Bundle bundle = new Bundle();
+                bundle.putInt(LocalPostFragment.EXTRA_LOCALPOST_TYPE, LocalPostFragment.LOCALPOST_TYPE_READ_POSTS);
+                bundle.putString(LocalPostFragment.EXTRA_ACCESS_TOKEN, mAccessToken);
+                bundle.putString(LocalPostFragment.EXTRA_ACCOUNT_NAME, mAccountName);
+                fragment.setArguments(bundle);
+                return fragment;
+            } else {
+                LocalPostFragment fragment = new LocalPostFragment();
+                Bundle bundle = new Bundle();
+                bundle.putInt(LocalPostFragment.EXTRA_LOCALPOST_TYPE, LocalPostFragment.LOCALPOST_TYPE_READ_POSTS);
+                bundle.putString(LocalPostFragment.EXTRA_ACCESS_TOKEN, mAccessToken);
+                bundle.putString(LocalPostFragment.EXTRA_ACCOUNT_NAME, mAccountName);
+                fragment.setArguments(bundle);
+                return fragment;
+            }
+        }
+
+        @Nullable
+        private Fragment getCurrentFragment() {
+            if (viewPager2 == null || fragmentManager == null) {
+                return null;
+            }
+            return fragmentManager.findFragmentByTag("f" + viewPager2.getCurrentItem());
+        }
+
+        public boolean handleKeyDown(int keyCode) {
+            if (viewPager2.getCurrentItem() == 0) {
+                Fragment fragment = getCurrentFragment();
+                if (fragment instanceof PostFragment) {
+                    return ((PostFragment) fragment).handleKeyDown(keyCode);
+                }
+            }
+            return false;
+        }
+
+        public void refresh() {
+            Fragment fragment = getCurrentFragment();
+            ((LocalPostFragment)fragment).refresh();
+        }
+
+        public void changeNSFW(boolean nsfw) {
+            Fragment fragment = getCurrentFragment();
+            if (fragment instanceof PostFragment) {
+                ((PostFragment) fragment).changeNSFW(nsfw);
+            }
+        }
+
+        public void changePostLayout(int postLayout) {
+            Fragment fragment = getCurrentFragment();
+            if (fragment instanceof LocalPostFragment) {
+                ((LocalPostFragment) fragment).changePostLayout(postLayout);
+            }
+        }
+
+
+        public void goBackToTop() {
+            Fragment fragment = getCurrentFragment();
+            ((LocalPostFragment)fragment).goBackToTop();
+        }
+
+        @Override
+        public int getItemCount() {
+            return 1;
+        }
+    }
+}

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/activities/MainActivity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/activities/MainActivity.java
@@ -77,6 +77,7 @@ import butterknife.ButterKnife;
 import ml.docilealligator.infinityforreddit.ActivityToolbarInterface;
 import ml.docilealligator.infinityforreddit.FetchSubscribedThing;
 import ml.docilealligator.infinityforreddit.Infinity;
+import ml.docilealligator.infinityforreddit.LocalSave;
 import ml.docilealligator.infinityforreddit.MarkPostAsReadInterface;
 import ml.docilealligator.infinityforreddit.PullNotificationWorker;
 import ml.docilealligator.infinityforreddit.R;
@@ -327,6 +328,8 @@ public class MainActivity extends BaseActivity implements SortTypeSelectionCallb
         mAccessToken = mCurrentAccountSharedPreferences.getString(SharedPreferencesUtils.ACCESS_TOKEN, null);
         mAccountName = mCurrentAccountSharedPreferences.getString(SharedPreferencesUtils.ACCOUNT_NAME, null);
 
+        LocalSave.globalCtx = getApplication().getApplicationContext();
+
         if (savedInstanceState != null) {
             mFetchUserInfoSuccess = savedInstanceState.getBoolean(FETCH_USER_INFO_STATE);
             mFetchSubscriptionsSuccess = savedInstanceState.getBoolean(FETCH_SUBSCRIPTIONS_STATE);
@@ -337,6 +340,8 @@ public class MainActivity extends BaseActivity implements SortTypeSelectionCallb
         } else {
             mMessageFullname = getIntent().getStringExtra(EXTRA_MESSSAGE_FULLNAME);
             mNewAccountName = getIntent().getStringExtra(EXTRA_NEW_ACCOUNT_NAME);
+
+            LocalSave.LoadLocalPosts();
         }
         initializeNotificationAndBindView();
     }
@@ -789,6 +794,8 @@ public class MainActivity extends BaseActivity implements SortTypeSelectionCallb
                             intent.putExtra(SubscribedThingListingActivity.EXTRA_SHOW_MULTIREDDITS, true);
                         } else if (stringId == R.string.history) {
                             intent = new Intent(MainActivity.this, HistoryActivity.class);
+                        } else if (stringId == R.string.local_posts) {
+                            intent = new Intent(MainActivity.this, LocalPostsActivity.class);
                         } else if (stringId == R.string.trending) {
                             intent = new Intent(MainActivity.this, TrendingActivity.class);
                         } else if (stringId == R.string.upvoted) {

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/LocalPostRecyclerViewAdapter.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/LocalPostRecyclerViewAdapter.java
@@ -1656,6 +1656,7 @@ public class LocalPostRecyclerViewAdapter extends PagingDataAdapter<Post, Recycl
         bundle.putString(ShareLinkBottomSheetFragment.EXTRA_POST_TITLE, post.getTitle());
         bundle.putString(ShareLinkBottomSheetFragment.EXTRA_POST_SUBREDDIT, post.getSubredditName());
         bundle.putString(ShareLinkBottomSheetFragment.EXTRA_POST_FLAIR, post.getFlair());
+        bundle.putLong(ShareLinkBottomSheetFragment.EXTRA_POST_TIME, post.getPostTimeMillis());
         if (post.getPostType() != Post.TEXT_TYPE) {
             bundle.putInt(ShareLinkBottomSheetFragment.EXTRA_MEDIA_TYPE, post.getPostType());
             switch (post.getPostType()) {

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/LocalPostRecyclerViewAdapter.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/LocalPostRecyclerViewAdapter.java
@@ -1,0 +1,4985 @@
+package ml.docilealligator.infinityforreddit.adapters;
+
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.content.res.ColorStateList;
+import android.content.res.Configuration;
+import android.content.res.Resources;
+import android.graphics.ColorFilter;
+import android.graphics.PorterDuff;
+import android.graphics.drawable.Drawable;
+import android.net.Uri;
+import android.os.Bundle;
+import android.os.Handler;
+import android.view.LayoutInflater;
+import android.view.MotionEvent;
+import android.view.View;
+import android.view.ViewConfiguration;
+import android.view.ViewGroup;
+import android.widget.FrameLayout;
+import android.widget.ImageView;
+import android.widget.LinearLayout;
+import android.widget.ProgressBar;
+import android.widget.RelativeLayout;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.content.res.AppCompatResources;
+import androidx.constraintlayout.widget.Barrier;
+import androidx.constraintlayout.widget.ConstraintLayout;
+import androidx.constraintlayout.widget.ConstraintSet;
+import androidx.core.content.ContextCompat;
+import androidx.paging.PagingDataAdapter;
+import androidx.recyclerview.widget.DiffUtil;
+import androidx.recyclerview.widget.ItemTouchHelper;
+import androidx.recyclerview.widget.PagerSnapHelper;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.bumptech.glide.Glide;
+import com.bumptech.glide.RequestBuilder;
+import com.bumptech.glide.RequestManager;
+import com.bumptech.glide.load.DataSource;
+import com.bumptech.glide.load.engine.GlideException;
+import com.bumptech.glide.request.RequestListener;
+import com.bumptech.glide.request.RequestOptions;
+import com.bumptech.glide.request.target.Target;
+import com.google.android.exoplayer2.Tracks;
+import com.google.android.exoplayer2.ui.AspectRatioFrameLayout;
+import com.google.android.exoplayer2.ui.DefaultTimeBar;
+import com.google.android.exoplayer2.ui.PlayerView;
+import com.google.android.exoplayer2.ui.TimeBar;
+import com.google.common.collect.ImmutableList;
+import com.libRG.CustomTextView;
+
+import org.greenrobot.eventbus.EventBus;
+
+import java.util.ArrayList;
+import java.util.Locale;
+import java.util.concurrent.Executor;
+
+import javax.inject.Provider;
+
+import butterknife.BindView;
+import butterknife.ButterKnife;
+import jp.wasabeef.glide.transformations.BlurTransformation;
+import jp.wasabeef.glide.transformations.RoundedCornersTransformation;
+import ml.docilealligator.infinityforreddit.FetchGfycatOrRedgifsVideoLinks;
+import ml.docilealligator.infinityforreddit.FetchStreamableVideo;
+import ml.docilealligator.infinityforreddit.LocalSave;
+import ml.docilealligator.infinityforreddit.R;
+import ml.docilealligator.infinityforreddit.SaveMemoryCenterInisdeDownsampleStrategy;
+import ml.docilealligator.infinityforreddit.SaveThing;
+import ml.docilealligator.infinityforreddit.StreamableVideo;
+import ml.docilealligator.infinityforreddit.VoteThing;
+import ml.docilealligator.infinityforreddit.activities.BaseActivity;
+import ml.docilealligator.infinityforreddit.activities.FilteredPostsActivity;
+import ml.docilealligator.infinityforreddit.activities.LinkResolverActivity;
+import ml.docilealligator.infinityforreddit.activities.ViewImageOrGifActivity;
+import ml.docilealligator.infinityforreddit.activities.ViewPostDetailActivity;
+import ml.docilealligator.infinityforreddit.activities.ViewRedditGalleryActivity;
+import ml.docilealligator.infinityforreddit.activities.ViewSubredditDetailActivity;
+import ml.docilealligator.infinityforreddit.activities.ViewUserDetailActivity;
+import ml.docilealligator.infinityforreddit.activities.ViewVideoActivity;
+import ml.docilealligator.infinityforreddit.apis.GfycatAPI;
+import ml.docilealligator.infinityforreddit.apis.RedgifsAPI;
+import ml.docilealligator.infinityforreddit.apis.StreamableAPI;
+import ml.docilealligator.infinityforreddit.bottomsheetfragments.ShareLinkBottomSheetFragment;
+import ml.docilealligator.infinityforreddit.customtheme.CustomThemeWrapper;
+import ml.docilealligator.infinityforreddit.customviews.AspectRatioGifImageView;
+import ml.docilealligator.infinityforreddit.customviews.LinearLayoutManagerBugFixed;
+import ml.docilealligator.infinityforreddit.databinding.ItemPostCard2GalleryTypeBinding;
+import ml.docilealligator.infinityforreddit.databinding.ItemPostGalleryGalleryTypeBinding;
+import ml.docilealligator.infinityforreddit.databinding.ItemPostGalleryTypeBinding;
+import ml.docilealligator.infinityforreddit.events.PostUpdateEventToPostDetailFragment;
+import ml.docilealligator.infinityforreddit.fragments.LocalPostFragment;
+import ml.docilealligator.infinityforreddit.post.Post;
+import ml.docilealligator.infinityforreddit.post.PostPagingSource;
+import ml.docilealligator.infinityforreddit.utils.APIUtils;
+import ml.docilealligator.infinityforreddit.utils.SharedPreferencesUtils;
+import ml.docilealligator.infinityforreddit.utils.Utils;
+import ml.docilealligator.infinityforreddit.videoautoplay.CacheManager;
+import ml.docilealligator.infinityforreddit.videoautoplay.ExoCreator;
+import ml.docilealligator.infinityforreddit.videoautoplay.ExoPlayerViewHelper;
+import ml.docilealligator.infinityforreddit.videoautoplay.Playable;
+import ml.docilealligator.infinityforreddit.videoautoplay.ToroPlayer;
+import ml.docilealligator.infinityforreddit.videoautoplay.ToroUtil;
+import ml.docilealligator.infinityforreddit.videoautoplay.media.PlaybackInfo;
+import ml.docilealligator.infinityforreddit.videoautoplay.widget.Container;
+import pl.droidsonroids.gif.GifImageView;
+import retrofit2.Call;
+import retrofit2.Retrofit;
+
+public class LocalPostRecyclerViewAdapter extends PagingDataAdapter<Post, RecyclerView.ViewHolder> implements CacheManager {
+    private static final int VIEW_TYPE_POST_CARD_VIDEO_AUTOPLAY_TYPE = 1;
+    private static final int VIEW_TYPE_POST_CARD_WITH_PREVIEW_TYPE = 2;
+    private static final int VIEW_TYPE_POST_CARD_GALLERY_TYPE = 3;
+    private static final int VIEW_TYPE_POST_CARD_TEXT_TYPE = 4;
+    private static final int VIEW_TYPE_POST_COMPACT = 5;
+    private static final int VIEW_TYPE_POST_GALLERY = 6;
+    private static final int VIEW_TYPE_POST_GALLERY_GALLERY_TYPE = 7;
+    private static final int VIEW_TYPE_POST_CARD_2_VIDEO_AUTOPLAY_TYPE = 8;
+    private static final int VIEW_TYPE_POST_CARD_2_WITH_PREVIEW_TYPE = 9;
+    private static final int VIEW_TYPE_POST_CARD_2_GALLERY_TYPE = 10;
+    private static final int VIEW_TYPE_POST_CARD_2_TEXT_TYPE = 11;
+
+    private static final DiffUtil.ItemCallback<Post> DIFF_CALLBACK = new DiffUtil.ItemCallback<Post>() {
+        @Override
+        public boolean areItemsTheSame(@NonNull Post post, @NonNull Post t1) {
+            return post.getId().equals(t1.getId());
+        }
+
+        @Override
+        public boolean areContentsTheSame(@NonNull Post post, @NonNull Post t1) {
+            return false;
+        }
+    };
+
+    private BaseActivity mActivity;
+    private LocalPostFragment mFragment;
+    private SharedPreferences mSharedPreferences;
+    private SharedPreferences mCurrentAccountSharedPreferences;
+    private Executor mExecutor;
+    private Retrofit mOauthRetrofit;
+    private Retrofit mGfycatRetrofit;
+    private Retrofit mRedgifsRetrofit;
+    private Provider<StreamableAPI> mStreamableApiProvider;
+    private String mAccessToken;
+    private RequestManager mGlide;
+    private int mMaxResolution;
+    private SaveMemoryCenterInisdeDownsampleStrategy mSaveMemoryCenterInsideDownsampleStrategy;
+    private Locale mLocale;
+    private boolean canStartActivity = true;
+    private int mPostType;
+    private int mPostLayout;
+    private int mDefaultLinkPostLayout;
+    private int mColorAccent;
+    private int mCardViewBackgroundColor;
+    private int mPrimaryTextColor;
+    private int mSecondaryTextColor;
+    private int mPostTitleColor;
+    private int mPostContentColor;
+    private int mStickiedPostIconTint;
+    private int mPostTypeBackgroundColor;
+    private int mPostTypeTextColor;
+    private int mSubredditColor;
+    private int mUsernameColor;
+    private int mModeratorColor;
+    private int mSpoilerBackgroundColor;
+    private int mSpoilerTextColor;
+    private int mFlairBackgroundColor;
+    private int mFlairTextColor;
+    private int mAwardsBackgroundColor;
+    private int mAwardsTextColor;
+    private int mNSFWBackgroundColor;
+    private int mNSFWTextColor;
+    private int mArchivedIconTint;
+    private int mLockedIconTint;
+    private int mCrosspostIconTint;
+    private int mMediaIndicatorIconTint;
+    private int mMediaIndicatorBackgroundColor;
+    private int mNoPreviewPostTypeBackgroundColor;
+    private int mNoPreviewPostTypeIconTint;
+    private int mUpvotedColor;
+    private int mDownvotedColor;
+    private int mVoteAndReplyUnavailableVoteButtonColor;
+    private int mPostIconAndInfoColor;
+    private int mDividerColor;
+    private float mScale;
+    private boolean mDisplaySubredditName;
+    private boolean mVoteButtonsOnTheRight;
+    private boolean mNeedBlurNsfw;
+    private boolean mNeedBlurSpoiler;
+    private boolean mShowElapsedTime;
+    private String mTimeFormatPattern;
+    private boolean mShowDividerInCompactLayout;
+    private boolean mShowAbsoluteNumberOfVotes;
+    private boolean mAutoplay = false;
+    private boolean mAutoplayNsfwVideos;
+    private boolean mMuteAutoplayingVideos;
+    private boolean mShowThumbnailOnTheRightInCompactLayout;
+    private double mStartAutoplayVisibleAreaOffset;
+    private boolean mMuteNSFWVideo;
+    private boolean mAutomaticallyTryRedgifs;
+    private boolean mLongPressToHideToolbarInCompactLayout;
+    private boolean mCompactLayoutToolbarHiddenByDefault;
+    private boolean mDataSavingMode = false;
+    private boolean mDisableImagePreview;
+    private boolean mOnlyDisablePreviewInVideoAndGifPosts;
+    private boolean mHidePostType;
+    private boolean mHidePostFlair;
+    private boolean mHideTheNumberOfAwards;
+    private boolean mHideSubredditAndUserPrefix;
+    private boolean mHideTheNumberOfVotes;
+    private boolean mHideTheNumberOfComments;
+    private boolean mLegacyAutoplayVideoControllerUI;
+    private boolean mFixedHeightPreviewInCard;
+    private boolean mHideTextPostContent;
+    private boolean mEasierToWatchInFullScreen;
+    private Drawable mCommentIcon;
+    private ExoCreator mExoCreator;
+    private Callback mCallback;
+    private boolean canPlayVideo = true;
+    private RecyclerView.RecycledViewPool mGalleryRecycledViewPool;
+
+    public LocalPostRecyclerViewAdapter(BaseActivity activity, LocalPostFragment fragment, Executor executor, Retrofit oauthRetrofit,
+                                        Retrofit gfycatRetrofit, Retrofit redgifsRetrofit, Provider<StreamableAPI> streambleApiProvider,
+                                        CustomThemeWrapper customThemeWrapper, Locale locale,
+                                        String accessToken, String accountName, int postType, int postLayout, boolean displaySubredditName,
+                                        SharedPreferences sharedPreferences, SharedPreferences currentAccountSharedPreferences,
+                                        SharedPreferences nsfwAndSpoilerSharedPreferences,
+                                        ExoCreator exoCreator, Callback callback) {
+        super(DIFF_CALLBACK);
+        if (activity != null) {
+            mActivity = activity;
+            mFragment = fragment;
+            mSharedPreferences = sharedPreferences;
+            mCurrentAccountSharedPreferences = currentAccountSharedPreferences;
+            mExecutor = executor;
+            mOauthRetrofit = oauthRetrofit;
+            mGfycatRetrofit = gfycatRetrofit;
+            mRedgifsRetrofit = redgifsRetrofit;
+            mStreamableApiProvider = streambleApiProvider;
+            mAccessToken = accessToken;
+            mPostType = postType;
+            mDisplaySubredditName = displaySubredditName;
+            mNeedBlurNsfw = nsfwAndSpoilerSharedPreferences.getBoolean((accountName == null ? "" : accountName) + SharedPreferencesUtils.BLUR_NSFW_BASE, true);
+            mNeedBlurSpoiler = nsfwAndSpoilerSharedPreferences.getBoolean((accountName == null ? "" : accountName) + SharedPreferencesUtils.BLUR_SPOILER_BASE, false);
+            mVoteButtonsOnTheRight = sharedPreferences.getBoolean(SharedPreferencesUtils.VOTE_BUTTONS_ON_THE_RIGHT_KEY, false);
+            mShowElapsedTime = sharedPreferences.getBoolean(SharedPreferencesUtils.SHOW_ELAPSED_TIME_KEY, false);
+            mTimeFormatPattern = sharedPreferences.getString(SharedPreferencesUtils.TIME_FORMAT_KEY, SharedPreferencesUtils.TIME_FORMAT_DEFAULT_VALUE);
+            mShowDividerInCompactLayout = sharedPreferences.getBoolean(SharedPreferencesUtils.SHOW_DIVIDER_IN_COMPACT_LAYOUT, true);
+            mShowAbsoluteNumberOfVotes = sharedPreferences.getBoolean(SharedPreferencesUtils.SHOW_ABSOLUTE_NUMBER_OF_VOTES, true);
+            String autoplayString = sharedPreferences.getString(SharedPreferencesUtils.VIDEO_AUTOPLAY, SharedPreferencesUtils.VIDEO_AUTOPLAY_VALUE_NEVER);
+            int networkType = Utils.getConnectedNetwork(activity);
+            if (autoplayString.equals(SharedPreferencesUtils.VIDEO_AUTOPLAY_VALUE_ALWAYS_ON)) {
+                mAutoplay = true;
+            } else if (autoplayString.equals(SharedPreferencesUtils.VIDEO_AUTOPLAY_VALUE_ON_WIFI)) {
+                mAutoplay = networkType == Utils.NETWORK_TYPE_WIFI;
+            }
+            mAutoplayNsfwVideos = sharedPreferences.getBoolean(SharedPreferencesUtils.AUTOPLAY_NSFW_VIDEOS, true);
+            mMuteAutoplayingVideos = sharedPreferences.getBoolean(SharedPreferencesUtils.MUTE_AUTOPLAYING_VIDEOS, true);
+            mShowThumbnailOnTheRightInCompactLayout = sharedPreferences.getBoolean(
+                    SharedPreferencesUtils.SHOW_THUMBNAIL_ON_THE_LEFT_IN_COMPACT_LAYOUT, false);
+
+            Resources resources = activity.getResources();
+            mStartAutoplayVisibleAreaOffset = resources.getConfiguration().orientation == Configuration.ORIENTATION_PORTRAIT ?
+                    sharedPreferences.getInt(SharedPreferencesUtils.START_AUTOPLAY_VISIBLE_AREA_OFFSET_PORTRAIT, 75) / 100.0 :
+                    sharedPreferences.getInt(SharedPreferencesUtils.START_AUTOPLAY_VISIBLE_AREA_OFFSET_LANDSCAPE, 50) / 100.0;
+
+            mMuteNSFWVideo = sharedPreferences.getBoolean(SharedPreferencesUtils.MUTE_NSFW_VIDEO, false);
+            mAutomaticallyTryRedgifs = sharedPreferences.getBoolean(SharedPreferencesUtils.AUTOMATICALLY_TRY_REDGIFS, true);
+
+            mLongPressToHideToolbarInCompactLayout = sharedPreferences.getBoolean(SharedPreferencesUtils.LONG_PRESS_TO_HIDE_TOOLBAR_IN_COMPACT_LAYOUT, false);
+            mCompactLayoutToolbarHiddenByDefault = sharedPreferences.getBoolean(SharedPreferencesUtils.POST_COMPACT_LAYOUT_TOOLBAR_HIDDEN_BY_DEFAULT, false);
+
+            String dataSavingModeString = sharedPreferences.getString(SharedPreferencesUtils.DATA_SAVING_MODE, SharedPreferencesUtils.DATA_SAVING_MODE_OFF);
+            if (dataSavingModeString.equals(SharedPreferencesUtils.DATA_SAVING_MODE_ALWAYS)) {
+                mDataSavingMode = true;
+            } else if (dataSavingModeString.equals(SharedPreferencesUtils.DATA_SAVING_MODE_ONLY_ON_CELLULAR_DATA)) {
+                mDataSavingMode = networkType == Utils.NETWORK_TYPE_CELLULAR;
+            }
+            mDisableImagePreview = sharedPreferences.getBoolean(SharedPreferencesUtils.DISABLE_IMAGE_PREVIEW, false);
+            mOnlyDisablePreviewInVideoAndGifPosts = sharedPreferences.getBoolean(SharedPreferencesUtils.ONLY_DISABLE_PREVIEW_IN_VIDEO_AND_GIF_POSTS, false);
+
+            mHidePostType = sharedPreferences.getBoolean(SharedPreferencesUtils.HIDE_POST_TYPE, false);
+            mHidePostFlair = sharedPreferences.getBoolean(SharedPreferencesUtils.HIDE_POST_FLAIR, false);
+            mHideTheNumberOfAwards = sharedPreferences.getBoolean(SharedPreferencesUtils.HIDE_THE_NUMBER_OF_AWARDS, false);
+            mHideSubredditAndUserPrefix = sharedPreferences.getBoolean(SharedPreferencesUtils.HIDE_SUBREDDIT_AND_USER_PREFIX, false);
+            mHideTheNumberOfVotes = sharedPreferences.getBoolean(SharedPreferencesUtils.HIDE_THE_NUMBER_OF_VOTES, false);
+            mHideTheNumberOfComments = sharedPreferences.getBoolean(SharedPreferencesUtils.HIDE_THE_NUMBER_OF_COMMENTS, false);
+            mLegacyAutoplayVideoControllerUI = sharedPreferences.getBoolean(SharedPreferencesUtils.LEGACY_AUTOPLAY_VIDEO_CONTROLLER_UI, false);
+            mFixedHeightPreviewInCard = sharedPreferences.getBoolean(SharedPreferencesUtils.FIXED_HEIGHT_PREVIEW_IN_CARD, false);
+            mHideTextPostContent = sharedPreferences.getBoolean(SharedPreferencesUtils.HIDE_TEXT_POST_CONTENT, false);
+            mEasierToWatchInFullScreen = sharedPreferences.getBoolean(SharedPreferencesUtils.EASIER_TO_WATCH_IN_FULL_SCREEN, false);
+
+            mPostLayout = postLayout;
+            mDefaultLinkPostLayout = Integer.parseInt(sharedPreferences.getString(SharedPreferencesUtils.DEFAULT_LINK_POST_LAYOUT_KEY, "-1"));
+
+            mColorAccent = customThemeWrapper.getColorAccent();
+            mCardViewBackgroundColor = customThemeWrapper.getCardViewBackgroundColor();
+            mPrimaryTextColor = customThemeWrapper.getPrimaryTextColor();
+            mSecondaryTextColor = customThemeWrapper.getSecondaryTextColor();
+            mPostTitleColor = customThemeWrapper.getPostTitleColor();
+            mPostContentColor = customThemeWrapper.getPostContentColor();
+            mStickiedPostIconTint = customThemeWrapper.getStickiedPostIconTint();
+            mPostTypeBackgroundColor = customThemeWrapper.getPostTypeBackgroundColor();
+            mPostTypeTextColor = customThemeWrapper.getPostTypeTextColor();
+            mSubredditColor = customThemeWrapper.getSubreddit();
+            mUsernameColor = customThemeWrapper.getUsername();
+            mModeratorColor = customThemeWrapper.getModerator();
+            mSpoilerBackgroundColor = customThemeWrapper.getSpoilerBackgroundColor();
+            mSpoilerTextColor = customThemeWrapper.getSpoilerTextColor();
+            mFlairBackgroundColor = customThemeWrapper.getFlairBackgroundColor();
+            mFlairTextColor = customThemeWrapper.getFlairTextColor();
+            mAwardsBackgroundColor = customThemeWrapper.getAwardsBackgroundColor();
+            mAwardsTextColor = customThemeWrapper.getAwardsTextColor();
+            mNSFWBackgroundColor = customThemeWrapper.getNsfwBackgroundColor();
+            mNSFWTextColor = customThemeWrapper.getNsfwTextColor();
+            mArchivedIconTint = customThemeWrapper.getArchivedIconTint();
+            mLockedIconTint = customThemeWrapper.getLockedIconTint();
+            mCrosspostIconTint = customThemeWrapper.getCrosspostIconTint();
+            mMediaIndicatorIconTint = customThemeWrapper.getMediaIndicatorIconColor();
+            mMediaIndicatorBackgroundColor = customThemeWrapper.getMediaIndicatorBackgroundColor();
+            mNoPreviewPostTypeBackgroundColor = customThemeWrapper.getNoPreviewPostTypeBackgroundColor();
+            mNoPreviewPostTypeIconTint = customThemeWrapper.getNoPreviewPostTypeIconTint();
+            mUpvotedColor = customThemeWrapper.getUpvoted();
+            mDownvotedColor = customThemeWrapper.getDownvoted();
+            mVoteAndReplyUnavailableVoteButtonColor = customThemeWrapper.getVoteAndReplyUnavailableButtonColor();
+            mPostIconAndInfoColor = customThemeWrapper.getPostIconAndInfoColor();
+            mDividerColor = customThemeWrapper.getDividerColor();
+
+            mCommentIcon = AppCompatResources.getDrawable(activity, R.drawable.ic_comment_grey_24dp);
+            if (mCommentIcon != null) {
+                mCommentIcon.setTint(mPostIconAndInfoColor);
+            }
+
+            mScale = resources.getDisplayMetrics().density;
+            mGlide = Glide.with(mActivity);
+            mMaxResolution = Integer.parseInt(mSharedPreferences.getString(SharedPreferencesUtils.POST_FEED_MAX_RESOLUTION, "5000000"));
+            mSaveMemoryCenterInsideDownsampleStrategy = new SaveMemoryCenterInisdeDownsampleStrategy(mMaxResolution);
+            mLocale = locale;
+            mExoCreator = exoCreator;
+            mCallback = callback;
+            mGalleryRecycledViewPool = new RecyclerView.RecycledViewPool();
+        }
+    }
+
+    public void setCanStartActivity(boolean canStartActivity) {
+        this.canStartActivity = canStartActivity;
+    }
+
+    @Override
+    public int getItemViewType(int position) {
+        if (mPostLayout == SharedPreferencesUtils.POST_LAYOUT_CARD) {
+            Post post = getItem(position);
+            if (post != null) {
+                switch (post.getPostType()) {
+                    case Post.VIDEO_TYPE:
+                        if (mAutoplay) {
+                            if ((!mAutoplayNsfwVideos && post.isNSFW()) || post.isSpoiler()) {
+                                return VIEW_TYPE_POST_CARD_WITH_PREVIEW_TYPE;
+                            }
+                            return VIEW_TYPE_POST_CARD_VIDEO_AUTOPLAY_TYPE;
+                        }
+                        return VIEW_TYPE_POST_CARD_WITH_PREVIEW_TYPE;
+                    case Post.GIF_TYPE:
+                    case Post.IMAGE_TYPE:
+                        return VIEW_TYPE_POST_CARD_WITH_PREVIEW_TYPE;
+                    case Post.GALLERY_TYPE:
+                        return VIEW_TYPE_POST_CARD_GALLERY_TYPE;
+                    case Post.LINK_TYPE:
+                    case Post.NO_PREVIEW_LINK_TYPE:
+                        switch (mDefaultLinkPostLayout) {
+                            case SharedPreferencesUtils.POST_LAYOUT_CARD_2:
+                                return VIEW_TYPE_POST_CARD_2_WITH_PREVIEW_TYPE;
+                            case SharedPreferencesUtils.POST_LAYOUT_GALLERY:
+                                return VIEW_TYPE_POST_GALLERY;
+                            case SharedPreferencesUtils.POST_LAYOUT_COMPACT:
+                                return VIEW_TYPE_POST_COMPACT;
+                        }
+                        return VIEW_TYPE_POST_CARD_WITH_PREVIEW_TYPE;
+                    default:
+                        return VIEW_TYPE_POST_CARD_TEXT_TYPE;
+                }
+            }
+            return VIEW_TYPE_POST_CARD_TEXT_TYPE;
+        } else if (mPostLayout == SharedPreferencesUtils.POST_LAYOUT_COMPACT) {
+            Post post = getItem(position);
+            if (post != null) {
+                if (post.getPostType() == Post.LINK_TYPE || post.getPostType() == Post.NO_PREVIEW_LINK_TYPE) {
+                    switch (mDefaultLinkPostLayout) {
+                        case SharedPreferencesUtils.POST_LAYOUT_CARD:
+                            return VIEW_TYPE_POST_CARD_WITH_PREVIEW_TYPE;
+                        case SharedPreferencesUtils.POST_LAYOUT_GALLERY:
+                            return VIEW_TYPE_POST_GALLERY;
+                        case SharedPreferencesUtils.POST_LAYOUT_CARD_2:
+                            return VIEW_TYPE_POST_CARD_2_WITH_PREVIEW_TYPE;
+                    }
+                }
+            }
+            return VIEW_TYPE_POST_COMPACT;
+        } else if (mPostLayout == SharedPreferencesUtils.POST_LAYOUT_GALLERY) {
+            Post post = getItem(position);
+            if (post != null) {
+                if (post.getPostType() == Post.GALLERY_TYPE) {
+                    return VIEW_TYPE_POST_GALLERY_GALLERY_TYPE;
+                } else {
+                    return VIEW_TYPE_POST_GALLERY;
+                }
+            } else {
+                return VIEW_TYPE_POST_GALLERY;
+            }
+        } else {
+            Post post = getItem(position);
+            if (post != null) {
+                switch (post.getPostType()) {
+                    case Post.VIDEO_TYPE:
+                        if (mAutoplay) {
+                            if ((!mAutoplayNsfwVideos && post.isNSFW()) || post.isSpoiler()) {
+                                return VIEW_TYPE_POST_CARD_2_WITH_PREVIEW_TYPE;
+                            }
+                            return VIEW_TYPE_POST_CARD_2_VIDEO_AUTOPLAY_TYPE;
+                        }
+                        return VIEW_TYPE_POST_CARD_2_WITH_PREVIEW_TYPE;
+                    case Post.GIF_TYPE:
+                    case Post.IMAGE_TYPE:
+                        return VIEW_TYPE_POST_CARD_2_WITH_PREVIEW_TYPE;
+                    case Post.GALLERY_TYPE:
+                        return VIEW_TYPE_POST_CARD_2_GALLERY_TYPE;
+                    case Post.LINK_TYPE:
+                    case Post.NO_PREVIEW_LINK_TYPE:
+                        switch (mDefaultLinkPostLayout) {
+                            case SharedPreferencesUtils.POST_LAYOUT_CARD:
+                                return VIEW_TYPE_POST_CARD_WITH_PREVIEW_TYPE;
+                            case SharedPreferencesUtils.POST_LAYOUT_GALLERY:
+                                return VIEW_TYPE_POST_GALLERY;
+                            case SharedPreferencesUtils.POST_LAYOUT_COMPACT:
+                                return VIEW_TYPE_POST_COMPACT;
+                        }
+                        return VIEW_TYPE_POST_CARD_2_WITH_PREVIEW_TYPE;
+                    default:
+                        return VIEW_TYPE_POST_CARD_2_TEXT_TYPE;
+                }
+            }
+            return VIEW_TYPE_POST_CARD_2_TEXT_TYPE;
+        }
+    }
+
+    @NonNull
+    @Override
+    public RecyclerView.ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        if (viewType == VIEW_TYPE_POST_CARD_VIDEO_AUTOPLAY_TYPE) {
+            if (mDataSavingMode) {
+                return new PostWithPreviewTypeViewHolder(LayoutInflater.from(parent.getContext()).inflate(R.layout.item_post_with_preview, parent, false));
+            }
+            return new PostVideoAutoplayViewHolder(LayoutInflater.from(parent.getContext()).inflate(mLegacyAutoplayVideoControllerUI ? R.layout.item_post_video_type_autoplay_legacy_controller : R.layout.item_post_video_type_autoplay, parent, false));
+        } else if (viewType == VIEW_TYPE_POST_CARD_WITH_PREVIEW_TYPE) {
+            return new PostWithPreviewTypeViewHolder(LayoutInflater.from(parent.getContext()).inflate(R.layout.item_post_with_preview, parent, false));
+        } else if (viewType == VIEW_TYPE_POST_CARD_GALLERY_TYPE) {
+            return new PostGalleryTypeViewHolder(ItemPostGalleryTypeBinding.inflate(LayoutInflater.from(parent.getContext()), parent, false));
+        } else if (viewType == VIEW_TYPE_POST_CARD_TEXT_TYPE) {
+            return new PostTextTypeViewHolder(LayoutInflater.from(parent.getContext()).inflate(R.layout.item_post_text, parent, false));
+        } else if (viewType == VIEW_TYPE_POST_COMPACT) {
+            if (mShowThumbnailOnTheRightInCompactLayout) {
+                return new PostCompactRightThumbnailViewHolder(LayoutInflater.from(parent.getContext()).inflate(R.layout.item_post_compact_right_thumbnail, parent, false));
+            } else {
+                return new PostCompactLeftThumbnailViewHolder(LayoutInflater.from(parent.getContext()).inflate(R.layout.item_post_compact, parent, false));
+            }
+        } else if (viewType == VIEW_TYPE_POST_GALLERY) {
+            return new PostGalleryViewHolder(LayoutInflater.from(parent.getContext()).inflate(R.layout.item_post_gallery, parent, false));
+        } else if (viewType == VIEW_TYPE_POST_GALLERY_GALLERY_TYPE) {
+            return new PostGalleryGalleryTypeViewHolder(ItemPostGalleryGalleryTypeBinding.inflate(LayoutInflater.from(parent.getContext()), parent, false));
+        } else if (viewType == VIEW_TYPE_POST_CARD_2_VIDEO_AUTOPLAY_TYPE) {
+            if (mDataSavingMode) {
+                return new PostCard2WithPreviewViewHolder(LayoutInflater.from(parent.getContext()).inflate(R.layout.item_post_card_2_with_preview, parent, false));
+            }
+            return new PostCard2VideoAutoplayViewHolder(LayoutInflater.from(parent.getContext()).inflate(mLegacyAutoplayVideoControllerUI ? R.layout.item_post_card_2_video_autoplay_legacy_controller : R.layout.item_post_card_2_video_autoplay, parent, false));
+        } else if (viewType == VIEW_TYPE_POST_CARD_2_WITH_PREVIEW_TYPE) {
+            return new PostCard2WithPreviewViewHolder(LayoutInflater.from(parent.getContext()).inflate(R.layout.item_post_card_2_with_preview, parent, false));
+        } else if (viewType == VIEW_TYPE_POST_CARD_2_GALLERY_TYPE) {
+            return new PostCard2GalleryTypeViewHolder(ItemPostCard2GalleryTypeBinding.inflate(LayoutInflater.from(parent.getContext()), parent, false));
+        } else {
+            //VIEW_TYPE_POST_CARD_2_TEXT_TYPE
+            return new PostCard2TextTypeViewHolder(LayoutInflater.from(parent.getContext()).inflate(R.layout.item_post_card_2_text, parent, false));
+        }
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull final RecyclerView.ViewHolder holder, int position) {
+        if (holder instanceof PostBaseViewHolder) {
+            Post post = getItem(position);
+            if (post != null) {
+                ((PostBaseViewHolder) holder).post = post;
+                String authorPrefixed = "u/" + post.getAuthor();
+
+                if (mHideSubredditAndUserPrefix) {
+                    ((PostBaseViewHolder) holder).subredditTextView.setText(post.getSubredditName());
+                    ((PostBaseViewHolder) holder).userTextView.setText(post.getAuthor());
+                } else {
+                    ((PostBaseViewHolder) holder).subredditTextView.setText("r/" + post.getSubredditName());
+                    ((PostBaseViewHolder) holder).userTextView.setText(authorPrefixed);
+                }
+
+                ((PostBaseViewHolder) holder).userTextView.setTextColor(
+                        post.isModerator() ? mModeratorColor : mUsernameColor);
+
+                if (mDisplaySubredditName) {
+                    if (authorPrefixed.equals(post.getSubredditNamePrefixed())) {
+                        if (post.getAuthorIconUrl() == null) {
+                            mFragment.loadIcon(post.getAuthor(), false, (subredditOrUserName, iconUrl) -> {
+                                if (mActivity != null && getItemCount() > 0 && post.getAuthor().equals(subredditOrUserName)) {
+                                    if (iconUrl == null || iconUrl.equals("")) {
+                                        mGlide.load(R.drawable.subreddit_default_icon)
+                                                .apply(RequestOptions.bitmapTransform(new RoundedCornersTransformation(72, 0)))
+                                                .into(((PostBaseViewHolder) holder).iconGifImageView);
+                                    } else {
+                                        mGlide.load(iconUrl)
+                                                .apply(RequestOptions.bitmapTransform(new RoundedCornersTransformation(72, 0)))
+                                                .error(mGlide.load(R.drawable.subreddit_default_icon)
+                                                        .apply(RequestOptions.bitmapTransform(new RoundedCornersTransformation(72, 0))))
+                                                .into(((PostBaseViewHolder) holder).iconGifImageView);
+                                    }
+
+                                    if (holder.getBindingAdapterPosition() >= 0) {
+                                        post.setAuthorIconUrl(iconUrl);
+                                    }
+                                }
+                            });
+                        } else if (!post.getAuthorIconUrl().equals("")) {
+                            mGlide.load(post.getAuthorIconUrl())
+                                    .apply(RequestOptions.bitmapTransform(new RoundedCornersTransformation(72, 0)))
+                                    .error(mGlide.load(R.drawable.subreddit_default_icon)
+                                            .apply(RequestOptions.bitmapTransform(new RoundedCornersTransformation(72, 0))))
+                                    .into(((PostBaseViewHolder) holder).iconGifImageView);
+                        } else {
+                            mGlide.load(R.drawable.subreddit_default_icon)
+                                    .apply(RequestOptions.bitmapTransform(new RoundedCornersTransformation(72, 0)))
+                                    .into(((PostBaseViewHolder) holder).iconGifImageView);
+                        }
+                    } else {
+                        if (post.getSubredditIconUrl() == null) {
+                            mFragment.loadIcon(post.getSubredditName(), true, (subredditOrUserName, iconUrl) -> {
+                                if (mActivity != null && getItemCount() > 0 && post.getSubredditName().equals(subredditOrUserName)) {
+                                    if (iconUrl == null || iconUrl.equals("")) {
+                                        mGlide.load(R.drawable.subreddit_default_icon)
+                                                .apply(RequestOptions.bitmapTransform(new RoundedCornersTransformation(72, 0)))
+                                                .into(((PostBaseViewHolder) holder).iconGifImageView);
+                                    } else {
+                                        mGlide.load(iconUrl)
+                                                .apply(RequestOptions.bitmapTransform(new RoundedCornersTransformation(72, 0)))
+                                                .error(mGlide.load(R.drawable.subreddit_default_icon)
+                                                        .apply(RequestOptions.bitmapTransform(new RoundedCornersTransformation(72, 0))))
+                                                .into(((PostBaseViewHolder) holder).iconGifImageView);
+                                    }
+
+                                    if (holder.getBindingAdapterPosition() >= 0) {
+                                        post.setSubredditIconUrl(iconUrl);
+                                    }
+                                }
+                            });
+                        } else if (!post.getSubredditIconUrl().equals("")) {
+                            mGlide.load(post.getSubredditIconUrl())
+                                    .apply(RequestOptions.bitmapTransform(new RoundedCornersTransformation(72, 0)))
+                                    .error(mGlide.load(R.drawable.subreddit_default_icon)
+                                            .apply(RequestOptions.bitmapTransform(new RoundedCornersTransformation(72, 0))))
+                                    .into(((PostBaseViewHolder) holder).iconGifImageView);
+                        } else {
+                            mGlide.load(R.drawable.subreddit_default_icon)
+                                    .apply(RequestOptions.bitmapTransform(new RoundedCornersTransformation(72, 0)))
+                                    .into(((PostBaseViewHolder) holder).iconGifImageView);
+                        }
+                    }
+                } else {
+                    if (post.getAuthorIconUrl() == null) {
+                        String authorName = post.isAuthorDeleted() ? post.getSubredditName() : post.getAuthor();
+                        mFragment.loadIcon(authorName, post.isAuthorDeleted(), (subredditOrUserName, iconUrl) -> {
+                            if (mActivity != null && getItemCount() > 0) {
+                                if (iconUrl == null || iconUrl.equals("") && authorName.equals(subredditOrUserName)) {
+                                    mGlide.load(R.drawable.subreddit_default_icon)
+                                            .apply(RequestOptions.bitmapTransform(new RoundedCornersTransformation(72, 0)))
+                                            .into(((PostBaseViewHolder) holder).iconGifImageView);
+                                } else {
+                                    mGlide.load(iconUrl)
+                                            .apply(RequestOptions.bitmapTransform(new RoundedCornersTransformation(72, 0)))
+                                            .error(mGlide.load(R.drawable.subreddit_default_icon)
+                                                    .apply(RequestOptions.bitmapTransform(new RoundedCornersTransformation(72, 0))))
+                                            .into(((PostBaseViewHolder) holder).iconGifImageView);
+                                }
+
+                                if (holder.getBindingAdapterPosition() >= 0) {
+                                    post.setAuthorIconUrl(iconUrl);
+                                }
+                            }
+                        });
+                    } else if (!post.getAuthorIconUrl().equals("")) {
+                        mGlide.load(post.getAuthorIconUrl())
+                                .apply(RequestOptions.bitmapTransform(new RoundedCornersTransformation(72, 0)))
+                                .error(mGlide.load(R.drawable.subreddit_default_icon)
+                                        .apply(RequestOptions.bitmapTransform(new RoundedCornersTransformation(72, 0))))
+                                .into(((PostBaseViewHolder) holder).iconGifImageView);
+                    } else {
+                        mGlide.load(R.drawable.subreddit_default_icon)
+                                .apply(RequestOptions.bitmapTransform(new RoundedCornersTransformation(72, 0)))
+                                .into(((PostBaseViewHolder) holder).iconGifImageView);
+                    }
+                }
+
+                if (mShowElapsedTime) {
+                    ((PostBaseViewHolder) holder).postTimeTextView.setText(
+                            Utils.getElapsedTime(mActivity, post.getPostTimeMillis()));
+                } else {
+                    ((PostBaseViewHolder) holder).postTimeTextView.setText(Utils.getFormattedTime(mLocale, post.getPostTimeMillis(), mTimeFormatPattern));
+                }
+
+                ((PostBaseViewHolder) holder).titleTextView.setText(post.getTitle());
+                if (!mHideTheNumberOfVotes) {
+                    ((PostBaseViewHolder) holder).scoreTextView.setText(Utils.getNVotes(mShowAbsoluteNumberOfVotes, post.getScore() + post.getVoteType()));
+                } else {
+                    ((PostBaseViewHolder) holder).scoreTextView.setText(mActivity.getString(R.string.vote));
+                }
+
+                if (post.isLocked()) {
+                    ((PostBaseViewHolder) holder).lockedImageView.setVisibility(View.VISIBLE);
+                }
+
+                if (post.isNSFW()) {
+                    ((PostBaseViewHolder) holder).nsfwTextView.setVisibility(View.VISIBLE);
+                }
+
+                if (post.isSpoiler()) {
+                    ((PostBaseViewHolder) holder).spoilerTextView.setVisibility(View.VISIBLE);
+                }
+
+                if (post.getFlair() != null && !post.getFlair().equals("")) {
+                    if (mHidePostFlair) {
+                        ((PostBaseViewHolder) holder).flairTextView.setVisibility(View.GONE);
+                    } else {
+                        ((PostBaseViewHolder) holder).flairTextView.setVisibility(View.VISIBLE);
+                        Utils.setHTMLWithImageToTextView(((PostBaseViewHolder) holder).flairTextView, post.getFlair(), false);
+                    }
+                }
+
+                if (post.getNAwards() > 0 && !mHideTheNumberOfAwards) {
+                    ((PostBaseViewHolder) holder).awardsTextView.setVisibility(View.VISIBLE);
+                    if (post.getNAwards() == 1) {
+                        ((PostBaseViewHolder) holder).awardsTextView.setText(mActivity.getString(R.string.one_award));
+                    } else {
+                        ((PostBaseViewHolder) holder).awardsTextView.setText(mActivity.getString(R.string.n_awards, post.getNAwards()));
+                    }
+                }
+
+                switch (post.getVoteType()) {
+                    case 1:
+                        //Upvoted
+                        ((PostBaseViewHolder) holder).upvoteButton.setColorFilter(mUpvotedColor, android.graphics.PorterDuff.Mode.SRC_IN);
+                        ((PostBaseViewHolder) holder).scoreTextView.setTextColor(mUpvotedColor);
+                        break;
+                    case -1:
+                        //Downvoted
+                        ((PostBaseViewHolder) holder).downvoteButton.setColorFilter(mDownvotedColor, android.graphics.PorterDuff.Mode.SRC_IN);
+                        ((PostBaseViewHolder) holder).scoreTextView.setTextColor(mDownvotedColor);
+                        break;
+                }
+
+                if (mPostType == PostPagingSource.TYPE_SUBREDDIT && !mDisplaySubredditName && post.isStickied()) {
+                    ((PostBaseViewHolder) holder).stickiedPostImageView.setVisibility(View.VISIBLE);
+                    mGlide.load(R.drawable.ic_thumbtack_24dp).into(((PostBaseViewHolder) holder).stickiedPostImageView);
+                }
+
+                if (post.isArchived()) {
+                    ((PostBaseViewHolder) holder).archivedImageView.setVisibility(View.VISIBLE);
+
+                    ((PostBaseViewHolder) holder).upvoteButton
+                            .setColorFilter(mVoteAndReplyUnavailableVoteButtonColor, android.graphics.PorterDuff.Mode.SRC_IN);
+                    ((PostBaseViewHolder) holder).downvoteButton
+                            .setColorFilter(mVoteAndReplyUnavailableVoteButtonColor, android.graphics.PorterDuff.Mode.SRC_IN);
+                }
+
+                if (post.isCrosspost()) {
+                    ((PostBaseViewHolder) holder).crosspostImageView.setVisibility(View.VISIBLE);
+                }
+
+                if (!mHideTheNumberOfComments) {
+                    ((PostBaseViewHolder) holder).commentsCountTextView.setVisibility(View.VISIBLE);
+                    ((PostBaseViewHolder) holder).commentsCountTextView.setText(Integer.toString(post.getNComments()));
+                } else {
+                    ((PostBaseViewHolder) holder).commentsCountTextView.setVisibility(View.GONE);
+                }
+
+                if (post.isSaved()) {
+                    ((PostBaseViewHolder) holder).saveButton.setImageResource(R.drawable.ic_bookmark_grey_24dp);
+                } else {
+                    ((PostBaseViewHolder) holder).saveButton.setImageResource(R.drawable.ic_bookmark_border_grey_24dp);
+                }
+
+                if (mHidePostType) {
+                    ((PostBaseViewHolder) holder).typeTextView.setVisibility(View.GONE);
+                } else {
+                    ((PostBaseViewHolder) holder).typeTextView.setVisibility(View.VISIBLE);
+                }
+
+                if (holder instanceof PostVideoAutoplayViewHolder) {
+                    ((PostVideoAutoplayViewHolder) holder).previewImageView.setVisibility(View.VISIBLE);
+                    Post.Preview preview = getSuitablePreview(post.getPreviews());
+                    if (!mFixedHeightPreviewInCard && preview != null) {
+                        ((PostVideoAutoplayViewHolder) holder).aspectRatioFrameLayout.setAspectRatio((float) preview.getPreviewWidth() / preview.getPreviewHeight());
+                        mGlide.load(preview.getPreviewUrl()).centerInside().downsample(mSaveMemoryCenterInsideDownsampleStrategy).into(((PostVideoAutoplayViewHolder) holder).previewImageView);
+                    } else {
+                        ((PostVideoAutoplayViewHolder) holder).aspectRatioFrameLayout.setAspectRatio(1);
+                    }
+                    if (!((PostVideoAutoplayViewHolder) holder).isManuallyPaused) {
+                        if (mFragment.getMasterMutingOption() == null) {
+                            ((PostVideoAutoplayViewHolder) holder).setVolume(mMuteAutoplayingVideos || (post.isNSFW() && mMuteNSFWVideo) ? 0f : 1f);
+                        } else {
+                            ((PostVideoAutoplayViewHolder) holder).setVolume(mFragment.getMasterMutingOption() ? 0f : 1f);
+                        }
+                    }
+
+                    if ((post.isGfycat() || post.isRedgifs()) && !post.isLoadGfycatOrStreamableVideoSuccess()) {
+                        ((PostVideoAutoplayViewHolder) holder).fetchGfycatOrStreamableVideoCall =
+                                post.isGfycat() ? mGfycatRetrofit.create(GfycatAPI.class).getGfycatData(post.getGfycatId()) :
+                                        mRedgifsRetrofit.create(RedgifsAPI.class).getRedgifsData(APIUtils.getRedgifsOAuthHeader(mCurrentAccountSharedPreferences.getString(SharedPreferencesUtils.REDGIFS_ACCESS_TOKEN, "")), post.getGfycatId(), APIUtils.USER_AGENT);
+                        FetchGfycatOrRedgifsVideoLinks.fetchGfycatOrRedgifsVideoLinksInRecyclerViewAdapter(mExecutor, new Handler(),
+                                ((PostVideoAutoplayViewHolder) holder).fetchGfycatOrStreamableVideoCall,
+                                post.isGfycat(), mAutomaticallyTryRedgifs,
+                                new FetchGfycatOrRedgifsVideoLinks.FetchGfycatOrRedgifsVideoLinksListener() {
+                                    @Override
+                                    public void success(String webm, String mp4) {
+                                        post.setVideoDownloadUrl(mp4);
+                                        post.setVideoUrl(mp4);
+                                        post.setLoadGfyOrStreamableVideoSuccess(true);
+                                        if (position == holder.getBindingAdapterPosition()) {
+                                            ((PostVideoAutoplayViewHolder) holder).bindVideoUri(Uri.parse(post.getVideoUrl()));
+                                        }
+                                    }
+
+                                    @Override
+                                    public void failed(int errorCode) {
+                                        if (position == holder.getBindingAdapterPosition()) {
+                                            ((PostVideoAutoplayViewHolder) holder).errorLoadingGfycatImageView.setVisibility(View.VISIBLE);
+                                        }
+                                    }
+                                });
+                    } else if(post.isStreamable() && !post.isLoadGfycatOrStreamableVideoSuccess()) {
+                        ((PostVideoAutoplayViewHolder) holder).fetchGfycatOrStreamableVideoCall =
+                                mStreamableApiProvider.get().getStreamableData(post.getStreamableShortCode());
+                        FetchStreamableVideo.fetchStreamableVideoInRecyclerViewAdapter(mExecutor, new Handler(),
+                                ((PostVideoAutoplayViewHolder) holder).fetchGfycatOrStreamableVideoCall,
+                                new FetchStreamableVideo.FetchStreamableVideoListener() {
+                                    @Override
+                                    public void success(StreamableVideo streamableVideo) {
+                                        StreamableVideo.Media media = streamableVideo.mp4 == null ? streamableVideo.mp4Mobile : streamableVideo.mp4;
+                                        post.setVideoDownloadUrl(media.url);
+                                        post.setVideoUrl(media.url);
+                                        post.setLoadGfyOrStreamableVideoSuccess(true);
+                                        if (position == holder.getBindingAdapterPosition()) {
+                                            ((PostVideoAutoplayViewHolder) holder).bindVideoUri(Uri.parse(post.getVideoUrl()));
+                                        }
+                                    }
+
+                                    @Override
+                                    public void failed() {
+                                        if (position == holder.getBindingAdapterPosition()) {
+                                            ((PostVideoAutoplayViewHolder) holder).errorLoadingGfycatImageView.setVisibility(View.VISIBLE);
+                                        }
+                                    }
+                                });
+                    } else {
+                        ((PostVideoAutoplayViewHolder) holder).bindVideoUri(Uri.parse(post.getVideoUrl()));
+                    }
+                } else if (holder instanceof PostWithPreviewTypeViewHolder) {
+                    if (post.getPostType() == Post.VIDEO_TYPE) {
+                        ((PostWithPreviewTypeViewHolder) holder).videoOrGifIndicatorImageView.setVisibility(View.VISIBLE);
+                        ((PostWithPreviewTypeViewHolder) holder).videoOrGifIndicatorImageView.setImageDrawable(ContextCompat.getDrawable(mActivity, R.drawable.ic_play_circle_36dp));
+                        ((PostWithPreviewTypeViewHolder) holder).typeTextView.setText(mActivity.getString(R.string.video));
+                    } else if (post.getPostType() == Post.GIF_TYPE) {
+                        if (!mAutoplay) {
+                            ((PostWithPreviewTypeViewHolder) holder).videoOrGifIndicatorImageView.setVisibility(View.VISIBLE);
+                            ((PostWithPreviewTypeViewHolder) holder).videoOrGifIndicatorImageView.setImageDrawable(ContextCompat.getDrawable(mActivity, R.drawable.ic_play_circle_36dp));
+                        }
+                        ((PostWithPreviewTypeViewHolder) holder).typeTextView.setText(mActivity.getString(R.string.gif));
+                    } else if (post.getPostType() == Post.IMAGE_TYPE) {
+                        ((PostWithPreviewTypeViewHolder) holder).typeTextView.setText(mActivity.getString(R.string.image));
+                    } else if (post.getPostType() == Post.LINK_TYPE || post.getPostType() == Post.NO_PREVIEW_LINK_TYPE) {
+                        ((PostWithPreviewTypeViewHolder) holder).typeTextView.setText(mActivity.getString(R.string.link));
+                        ((PostWithPreviewTypeViewHolder) holder).linkTextView.setVisibility(View.VISIBLE);
+                        String domain = Uri.parse(post.getUrl()).getHost();
+                        ((PostWithPreviewTypeViewHolder) holder).linkTextView.setText(domain);
+                        if (post.getPostType() == Post.NO_PREVIEW_LINK_TYPE) {
+                            ((PostWithPreviewTypeViewHolder) holder).noPreviewLinkImageView.setVisibility(View.VISIBLE);
+                            ((PostWithPreviewTypeViewHolder) holder).noPreviewLinkImageView.setImageResource(R.drawable.ic_link);
+                        }
+                    }
+
+                    if (post.getPostType() != Post.NO_PREVIEW_LINK_TYPE) {
+                        ((PostWithPreviewTypeViewHolder) holder).progressBar.setVisibility(View.VISIBLE);
+                    }
+
+                    if (mDataSavingMode && mDisableImagePreview) {
+                        ((PostWithPreviewTypeViewHolder) holder).noPreviewLinkImageView.setVisibility(View.VISIBLE);
+                        if (post.getPostType() == Post.VIDEO_TYPE) {
+                            ((PostWithPreviewTypeViewHolder) holder).noPreviewLinkImageView.setImageResource(R.drawable.ic_outline_video_24dp);
+                            ((PostWithPreviewTypeViewHolder) holder).videoOrGifIndicatorImageView.setVisibility(View.GONE);
+                        } else if (post.getPostType() == Post.IMAGE_TYPE || post.getPostType() == Post.GIF_TYPE) {
+                            ((PostWithPreviewTypeViewHolder) holder).noPreviewLinkImageView.setImageResource(R.drawable.ic_image_24dp);
+                            ((PostWithPreviewTypeViewHolder) holder).videoOrGifIndicatorImageView.setVisibility(View.GONE);
+                        } else if (post.getPostType() == Post.LINK_TYPE) {
+                            ((PostWithPreviewTypeViewHolder) holder).noPreviewLinkImageView.setImageResource(R.drawable.ic_link);
+                        }
+                    } else if (mDataSavingMode && mOnlyDisablePreviewInVideoAndGifPosts && (post.getPostType() == Post.VIDEO_TYPE || post.getPostType() == Post.GIF_TYPE)) {
+                        ((PostWithPreviewTypeViewHolder) holder).noPreviewLinkImageView.setVisibility(View.VISIBLE);
+                        ((PostWithPreviewTypeViewHolder) holder).noPreviewLinkImageView.setImageResource(R.drawable.ic_outline_video_24dp);
+                        ((PostWithPreviewTypeViewHolder) holder).videoOrGifIndicatorImageView.setVisibility(View.GONE);
+                    } else {
+                        if (post.getPostType() == Post.GIF_TYPE && ((post.isNSFW() && mNeedBlurNsfw && !(mAutoplay && mAutoplayNsfwVideos)) || (post.isSpoiler() && mNeedBlurSpoiler))) {
+                            ((PostWithPreviewTypeViewHolder) holder).noPreviewLinkImageView.setVisibility(View.VISIBLE);
+                            ((PostWithPreviewTypeViewHolder) holder).noPreviewLinkImageView.setImageResource(R.drawable.ic_image_24dp);
+                            ((PostWithPreviewTypeViewHolder) holder).videoOrGifIndicatorImageView.setVisibility(View.GONE);
+                        } else {
+                            Post.Preview preview = getSuitablePreview(post.getPreviews());
+                            ((PostWithPreviewTypeViewHolder) holder).preview = preview;
+                            if (preview != null) {
+                                ((PostWithPreviewTypeViewHolder) holder).imageWrapperRelativeLayout.setVisibility(View.VISIBLE);
+                                if (mFixedHeightPreviewInCard || (preview.getPreviewWidth() <= 0 || preview.getPreviewHeight() <= 0)) {
+                                    int height = (int) (400 * mScale);
+                                    ((PostWithPreviewTypeViewHolder) holder).imageView.setScaleType(ImageView.ScaleType.CENTER_CROP);
+                                    ((PostWithPreviewTypeViewHolder) holder).imageView.getLayoutParams().height = height;
+                                } else {
+                                    ((PostWithPreviewTypeViewHolder) holder).imageView
+                                            .setRatio((float) preview.getPreviewHeight() / preview.getPreviewWidth());
+                                }
+                                ((PostWithPreviewTypeViewHolder) holder).imageView.addOnLayoutChangeListener(new View.OnLayoutChangeListener() {
+                                    @Override
+                                    public void onLayoutChange(View v, int left, int top, int right, int bottom, int oldLeft, int oldTop, int oldRight, int oldBottom) {
+                                        ((PostWithPreviewTypeViewHolder) holder).imageView.removeOnLayoutChangeListener(this);
+                                        loadImage(holder);
+                                    }
+                                });
+                            } else {
+                                ((PostWithPreviewTypeViewHolder) holder).noPreviewLinkImageView.setVisibility(View.VISIBLE);
+                                if (post.getPostType() == Post.VIDEO_TYPE) {
+                                    ((PostWithPreviewTypeViewHolder) holder).noPreviewLinkImageView.setImageResource(R.drawable.ic_outline_video_24dp);
+                                    ((PostWithPreviewTypeViewHolder) holder).videoOrGifIndicatorImageView.setVisibility(View.GONE);
+                                } else if (post.getPostType() == Post.IMAGE_TYPE || post.getPostType() == Post.GIF_TYPE) {
+                                    ((PostWithPreviewTypeViewHolder) holder).noPreviewLinkImageView.setImageResource(R.drawable.ic_image_24dp);
+                                    ((PostWithPreviewTypeViewHolder) holder).videoOrGifIndicatorImageView.setVisibility(View.GONE);
+                                } else if (post.getPostType() == Post.LINK_TYPE) {
+                                    ((PostWithPreviewTypeViewHolder) holder).noPreviewLinkImageView.setImageResource(R.drawable.ic_link);
+                                }
+                            }
+                        }
+                    }
+                } else if (holder instanceof PostBaseGalleryTypeViewHolder) {
+                    if (mDataSavingMode && mDisableImagePreview) {
+                        ((PostBaseGalleryTypeViewHolder) holder).noPreviewImageView.setVisibility(View.VISIBLE);
+                        ((PostBaseGalleryTypeViewHolder) holder).noPreviewImageView.setImageResource(R.drawable.ic_gallery_24dp);
+                    } else {
+                        ((PostBaseGalleryTypeViewHolder) holder).frameLayout.setVisibility(View.VISIBLE);
+                        ((PostBaseGalleryTypeViewHolder) holder).imageIndexTextView.setText(mActivity.getString(R.string.image_index_in_gallery, 1, post.getGallery().size()));
+                        Post.Preview preview = getSuitablePreview(post.getPreviews());
+                        if (preview != null) {
+                            if (mFixedHeightPreviewInCard || (preview.getPreviewWidth() <= 0 || preview.getPreviewHeight() <= 0)) {
+                                ((PostBaseGalleryTypeViewHolder) holder).adapter.setRatio(-1);
+                            } else {
+                                ((PostBaseGalleryTypeViewHolder) holder).adapter.setRatio((float) preview.getPreviewHeight() / preview.getPreviewWidth());
+                            }
+                        } else {
+                            ((PostBaseGalleryTypeViewHolder) holder).adapter.setRatio(-1);
+                        }
+                        ((PostBaseGalleryTypeViewHolder) holder).adapter.setGalleryImages(post.getGallery());
+                        ((PostBaseGalleryTypeViewHolder) holder).adapter.setBlurImage(
+                                (post.isNSFW() && mNeedBlurNsfw) || (post.isSpoiler() && mNeedBlurSpoiler));
+                    }
+                } else if (holder instanceof PostTextTypeViewHolder) {
+                    if (!mHideTextPostContent && !post.isSpoiler() && post.getSelfTextPlainTrimmed() != null && !post.getSelfTextPlainTrimmed().equals("")) {
+                        ((PostTextTypeViewHolder) holder).contentTextView.setVisibility(View.VISIBLE);
+                        ((PostTextTypeViewHolder) holder).contentTextView.setText(post.getSelfTextPlainTrimmed());
+                    }
+                } else if (holder instanceof PostCard2VideoAutoplayViewHolder) {
+                    ((PostCard2VideoAutoplayViewHolder) holder).previewImageView.setVisibility(View.VISIBLE);
+                    Post.Preview preview = getSuitablePreview(post.getPreviews());
+                    if (!mFixedHeightPreviewInCard && preview != null) {
+                        ((PostCard2VideoAutoplayViewHolder) holder).aspectRatioFrameLayout.setAspectRatio((float) preview.getPreviewWidth() / preview.getPreviewHeight());
+                        mGlide.load(preview.getPreviewUrl()).centerInside().downsample(mSaveMemoryCenterInsideDownsampleStrategy).into(((PostCard2VideoAutoplayViewHolder) holder).previewImageView);
+                    } else {
+                        ((PostCard2VideoAutoplayViewHolder) holder).aspectRatioFrameLayout.setAspectRatio(1);
+                    }
+                    if (!((PostCard2VideoAutoplayViewHolder) holder).isManuallyPaused) {
+                        if (mFragment.getMasterMutingOption() == null) {
+                            ((PostCard2VideoAutoplayViewHolder) holder).setVolume(mMuteAutoplayingVideos || (post.isNSFW() && mMuteNSFWVideo) ? 0f : 1f);
+                        } else {
+                            ((PostCard2VideoAutoplayViewHolder) holder).setVolume(mFragment.getMasterMutingOption() ? 0f : 1f);
+                        }
+                    }
+
+                    if ((post.isGfycat() || post.isRedgifs()) && !post.isLoadGfycatOrStreamableVideoSuccess()) {
+                        ((PostCard2VideoAutoplayViewHolder) holder).fetchGfycatOrStreamableVideoCall =
+                                post.isGfycat() ? mGfycatRetrofit.create(GfycatAPI.class).getGfycatData(post.getGfycatId()) :
+                                        mRedgifsRetrofit.create(RedgifsAPI.class).getRedgifsData(APIUtils.getRedgifsOAuthHeader(mCurrentAccountSharedPreferences.getString(SharedPreferencesUtils.REDGIFS_ACCESS_TOKEN, "")), post.getGfycatId(), APIUtils.USER_AGENT);
+                        FetchGfycatOrRedgifsVideoLinks.fetchGfycatOrRedgifsVideoLinksInRecyclerViewAdapter(mExecutor, new Handler(),
+                                ((PostCard2VideoAutoplayViewHolder) holder).fetchGfycatOrStreamableVideoCall,
+                                post.isGfycat(), mAutomaticallyTryRedgifs,
+                                new FetchGfycatOrRedgifsVideoLinks.FetchGfycatOrRedgifsVideoLinksListener() {
+                                    @Override
+                                    public void success(String webm, String mp4) {
+                                        post.setVideoDownloadUrl(mp4);
+                                        post.setVideoUrl(mp4);
+                                        post.setLoadGfyOrStreamableVideoSuccess(true);
+                                        if (position == holder.getBindingAdapterPosition()) {
+                                            ((PostCard2VideoAutoplayViewHolder) holder).bindVideoUri(Uri.parse(post.getVideoUrl()));
+                                        }
+                                    }
+
+                                    @Override
+                                    public void failed(int errorCode) {
+                                        if (position == holder.getBindingAdapterPosition()) {
+                                            ((PostCard2VideoAutoplayViewHolder) holder).errorLoadingGfycatImageView.setVisibility(View.VISIBLE);
+                                        }
+                                    }
+                                });
+                    } else if(post.isStreamable() && !post.isLoadGfycatOrStreamableVideoSuccess()) {
+                        ((PostCard2VideoAutoplayViewHolder) holder).fetchGfycatOrStreamableVideoCall =
+                                mStreamableApiProvider.get().getStreamableData(post.getStreamableShortCode());
+                        FetchStreamableVideo.fetchStreamableVideoInRecyclerViewAdapter(mExecutor, new Handler(),
+                                ((PostCard2VideoAutoplayViewHolder) holder).fetchGfycatOrStreamableVideoCall,
+                                new FetchStreamableVideo.FetchStreamableVideoListener() {
+                                    @Override
+                                    public void success(StreamableVideo streamableVideo) {
+                                        StreamableVideo.Media media = streamableVideo.mp4 == null ? streamableVideo.mp4Mobile : streamableVideo.mp4;
+                                        post.setVideoDownloadUrl(media.url);
+                                        post.setVideoUrl(media.url);
+                                        post.setLoadGfyOrStreamableVideoSuccess(true);
+                                        if (position == holder.getBindingAdapterPosition()) {
+                                            ((PostCard2VideoAutoplayViewHolder) holder).bindVideoUri(Uri.parse(post.getVideoUrl()));
+                                        }
+                                    }
+
+                                    @Override
+                                    public void failed() {
+                                        if (position == holder.getBindingAdapterPosition()) {
+                                            ((PostCard2VideoAutoplayViewHolder) holder).errorLoadingGfycatImageView.setVisibility(View.VISIBLE);
+                                        }
+                                    }
+                                });
+                    } else {
+                        ((PostCard2VideoAutoplayViewHolder) holder).bindVideoUri(Uri.parse(post.getVideoUrl()));
+                    }
+                } else if (holder instanceof PostCard2WithPreviewViewHolder) {
+                    if (post.getPostType() == Post.VIDEO_TYPE) {
+                        ((PostCard2WithPreviewViewHolder) holder).videoOrGifIndicatorImageView.setVisibility(View.VISIBLE);
+                        ((PostCard2WithPreviewViewHolder) holder).videoOrGifIndicatorImageView.setImageDrawable(ContextCompat.getDrawable(mActivity, R.drawable.ic_play_circle_36dp));
+                        ((PostCard2WithPreviewViewHolder) holder).typeTextView.setText(mActivity.getString(R.string.video));
+                    } else if (post.getPostType() == Post.GIF_TYPE) {
+                        if (!mAutoplay) {
+                            ((PostCard2WithPreviewViewHolder) holder).videoOrGifIndicatorImageView.setVisibility(View.VISIBLE);
+                            ((PostCard2WithPreviewViewHolder) holder).videoOrGifIndicatorImageView.setImageDrawable(ContextCompat.getDrawable(mActivity, R.drawable.ic_play_circle_36dp));
+                        }
+                        ((PostCard2WithPreviewViewHolder) holder).typeTextView.setText(mActivity.getString(R.string.gif));
+                    } else if (post.getPostType() == Post.IMAGE_TYPE) {
+                        ((PostCard2WithPreviewViewHolder) holder).typeTextView.setText(mActivity.getString(R.string.image));
+                    } else if (post.getPostType() == Post.LINK_TYPE || post.getPostType() == Post.NO_PREVIEW_LINK_TYPE) {
+                        ((PostCard2WithPreviewViewHolder) holder).typeTextView.setText(mActivity.getString(R.string.link));
+                        ((PostCard2WithPreviewViewHolder) holder).linkTextView.setVisibility(View.VISIBLE);
+                        String domain = Uri.parse(post.getUrl()).getHost();
+                        ((PostCard2WithPreviewViewHolder) holder).linkTextView.setText(domain);
+                        if (post.getPostType() == Post.NO_PREVIEW_LINK_TYPE) {
+                            ((PostCard2WithPreviewViewHolder) holder).noPreviewImageView.setVisibility(View.VISIBLE);
+                            ((PostCard2WithPreviewViewHolder) holder).noPreviewImageView.setImageResource(R.drawable.ic_link);
+                        }
+                    }
+
+                    if (post.getPostType() != Post.NO_PREVIEW_LINK_TYPE) {
+                        ((PostCard2WithPreviewViewHolder) holder).progressBar.setVisibility(View.VISIBLE);
+                    }
+
+                    if (mDataSavingMode && mDisableImagePreview) {
+                        ((PostCard2WithPreviewViewHolder) holder).progressBar.setVisibility(View.GONE);
+                        ((PostCard2WithPreviewViewHolder) holder).noPreviewImageView.setVisibility(View.VISIBLE);
+                        if (post.getPostType() == Post.VIDEO_TYPE) {
+                            ((PostCard2WithPreviewViewHolder) holder).noPreviewImageView.setImageResource(R.drawable.ic_outline_video_24dp);
+                            ((PostCard2WithPreviewViewHolder) holder).videoOrGifIndicatorImageView.setVisibility(View.GONE);
+                        } else if (post.getPostType() == Post.IMAGE_TYPE || post.getPostType() == Post.GIF_TYPE) {
+                            ((PostCard2WithPreviewViewHolder) holder).noPreviewImageView.setImageResource(R.drawable.ic_image_24dp);
+                            ((PostCard2WithPreviewViewHolder) holder).videoOrGifIndicatorImageView.setVisibility(View.GONE);
+                        } else if (post.getPostType() == Post.LINK_TYPE) {
+                            ((PostCard2WithPreviewViewHolder) holder).noPreviewImageView.setImageResource(R.drawable.ic_link);
+                        }
+                    } else if (mDataSavingMode && mOnlyDisablePreviewInVideoAndGifPosts && (post.getPostType() == Post.VIDEO_TYPE || post.getPostType() == Post.GIF_TYPE)) {
+                        ((PostCard2WithPreviewViewHolder) holder).progressBar.setVisibility(View.GONE);
+                        ((PostCard2WithPreviewViewHolder) holder).noPreviewImageView.setVisibility(View.VISIBLE);
+                        ((PostCard2WithPreviewViewHolder) holder).noPreviewImageView.setImageResource(R.drawable.ic_outline_video_24dp);
+                        ((PostCard2WithPreviewViewHolder) holder).videoOrGifIndicatorImageView.setVisibility(View.GONE);
+                    } else {
+                        if (post.getPostType() == Post.GIF_TYPE && ((post.isNSFW() && mNeedBlurNsfw && !(mAutoplay && mAutoplayNsfwVideos)) || (post.isSpoiler() && mNeedBlurSpoiler))) {
+                            ((PostCard2WithPreviewViewHolder) holder).noPreviewImageView.setVisibility(View.VISIBLE);
+                            ((PostCard2WithPreviewViewHolder) holder).noPreviewImageView.setImageResource(R.drawable.ic_image_24dp);
+                            ((PostCard2WithPreviewViewHolder) holder).videoOrGifIndicatorImageView.setVisibility(View.GONE);
+                        } else {
+                            Post.Preview preview = getSuitablePreview(post.getPreviews());
+                            ((PostCard2WithPreviewViewHolder) holder).preview = preview;
+                            if (preview != null) {
+                                ((PostCard2WithPreviewViewHolder) holder).imageView.setVisibility(View.VISIBLE);
+                                if (mFixedHeightPreviewInCard || (preview.getPreviewWidth() <= 0 || preview.getPreviewHeight() <= 0)) {
+                                    int height = (int) (400 * mScale);
+                                    ((PostCard2WithPreviewViewHolder) holder).imageView.setScaleType(ImageView.ScaleType.CENTER_CROP);
+                                    ((PostCard2WithPreviewViewHolder) holder).imageView.getLayoutParams().height = height;
+                                } else {
+                                    ((PostCard2WithPreviewViewHolder) holder).imageView
+                                            .setRatio((float) preview.getPreviewHeight() / preview.getPreviewWidth());
+                                }
+                                ((PostCard2WithPreviewViewHolder) holder).imageView.addOnLayoutChangeListener(new View.OnLayoutChangeListener() {
+                                    @Override
+                                    public void onLayoutChange(View v, int left, int top, int right, int bottom, int oldLeft, int oldTop, int oldRight, int oldBottom) {
+                                        ((PostCard2WithPreviewViewHolder) holder).imageView.removeOnLayoutChangeListener(this);
+                                        loadImage(holder);
+                                    }
+                                });
+                            } else {
+                                ((PostCard2WithPreviewViewHolder) holder).progressBar.setVisibility(View.GONE);
+                                ((PostCard2WithPreviewViewHolder) holder).noPreviewImageView.setVisibility(View.VISIBLE);
+                                if (post.getPostType() == Post.VIDEO_TYPE) {
+                                    ((PostCard2WithPreviewViewHolder) holder).noPreviewImageView.setImageResource(R.drawable.ic_outline_video_24dp);
+                                    ((PostCard2WithPreviewViewHolder) holder).videoOrGifIndicatorImageView.setVisibility(View.GONE);
+                                } else if (post.getPostType() == Post.IMAGE_TYPE || post.getPostType() == Post.GIF_TYPE) {
+                                    ((PostCard2WithPreviewViewHolder) holder).noPreviewImageView.setImageResource(R.drawable.ic_image_24dp);
+                                    ((PostCard2WithPreviewViewHolder) holder).videoOrGifIndicatorImageView.setVisibility(View.GONE);
+                                } else if (post.getPostType() == Post.LINK_TYPE) {
+                                    ((PostCard2WithPreviewViewHolder) holder).noPreviewImageView.setImageResource(R.drawable.ic_link);
+                                }
+                            }
+                        }
+
+                    }
+                } else if (holder instanceof PostCard2TextTypeViewHolder) {
+                    if (!mHideTextPostContent && !post.isSpoiler() && post.getSelfTextPlainTrimmed() != null && !post.getSelfTextPlainTrimmed().equals("")) {
+                        ((PostCard2TextTypeViewHolder) holder).contentTextView.setVisibility(View.VISIBLE);
+                        ((PostCard2TextTypeViewHolder) holder).contentTextView.setText(post.getSelfTextPlainTrimmed());
+                    }
+                }
+                mCallback.currentlyBindItem(holder.getBindingAdapterPosition());
+            }
+        } else if (holder instanceof PostCompactBaseViewHolder) {
+            Post post = getItem(position);
+            if (post != null) {
+                ((PostCompactBaseViewHolder) holder).post = post;
+                final String subredditNamePrefixed = post.getSubredditNamePrefixed();
+                String subredditName = subredditNamePrefixed.substring(2);
+                String authorPrefixed = "u/" + post.getAuthor();
+                final String title = post.getTitle();
+                int voteType = post.getVoteType();
+                boolean nsfw = post.isNSFW();
+                boolean spoiler = post.isSpoiler();
+                String flair = post.getFlair();
+                int nAwards = post.getNAwards();
+                boolean isArchived = post.isArchived();
+
+                if (mDisplaySubredditName) {
+                    if (authorPrefixed.equals(subredditNamePrefixed)) {
+                        if (post.getAuthorIconUrl() == null) {
+                            mFragment.loadIcon(post.getAuthor(), false, (subredditOrUserName, iconUrl) -> {
+                                if (mActivity != null && getItemCount() > 0 && post.getAuthor().equals(subredditOrUserName)) {
+                                    if (iconUrl == null || iconUrl.equals("")) {
+                                        mGlide.load(R.drawable.subreddit_default_icon)
+                                                .apply(RequestOptions.bitmapTransform(new RoundedCornersTransformation(72, 0)))
+                                                .into(((PostCompactBaseViewHolder) holder).iconGifImageView);
+                                    } else {
+                                        mGlide.load(iconUrl)
+                                                .apply(RequestOptions.bitmapTransform(new RoundedCornersTransformation(72, 0)))
+                                                .error(mGlide.load(R.drawable.subreddit_default_icon)
+                                                        .apply(RequestOptions.bitmapTransform(new RoundedCornersTransformation(72, 0))))
+                                                .into(((PostCompactBaseViewHolder) holder).iconGifImageView);
+                                    }
+
+                                    if (holder.getBindingAdapterPosition() >= 0) {
+                                        post.setAuthorIconUrl(iconUrl);
+                                    }
+                                }
+                            });
+                        } else if (!post.getAuthorIconUrl().equals("")) {
+                            mGlide.load(post.getAuthorIconUrl())
+                                    .apply(RequestOptions.bitmapTransform(new RoundedCornersTransformation(72, 0)))
+                                    .error(mGlide.load(R.drawable.subreddit_default_icon)
+                                            .apply(RequestOptions.bitmapTransform(new RoundedCornersTransformation(72, 0))))
+                                    .into(((PostCompactBaseViewHolder) holder).iconGifImageView);
+                        } else {
+                            mGlide.load(R.drawable.subreddit_default_icon)
+                                    .apply(RequestOptions.bitmapTransform(new RoundedCornersTransformation(72, 0)))
+                                    .into(((PostCompactBaseViewHolder) holder).iconGifImageView);
+                        }
+                    } else {
+                        if (post.getSubredditIconUrl() == null) {
+                            mFragment.loadIcon(subredditName, true, (subredditOrUserName, iconUrl) -> {
+                                if (mActivity != null && getItemCount() > 0 && subredditName.equals(subredditOrUserName)) {
+                                    if (iconUrl == null || iconUrl.equals("")) {
+                                        mGlide.load(R.drawable.subreddit_default_icon)
+                                                .apply(RequestOptions.bitmapTransform(new RoundedCornersTransformation(72, 0)))
+                                                .into(((PostCompactBaseViewHolder) holder).iconGifImageView);
+                                    } else {
+                                        mGlide.load(iconUrl)
+                                                .apply(RequestOptions.bitmapTransform(new RoundedCornersTransformation(72, 0)))
+                                                .error(mGlide.load(R.drawable.subreddit_default_icon)
+                                                        .apply(RequestOptions.bitmapTransform(new RoundedCornersTransformation(72, 0))))
+                                                .into(((PostCompactBaseViewHolder) holder).iconGifImageView);
+                                    }
+
+                                    if (holder.getBindingAdapterPosition() >= 0) {
+                                        post.setSubredditIconUrl(iconUrl);
+                                    }
+                                }
+                            });
+                        } else if (!post.getSubredditIconUrl().equals("")) {
+                            mGlide.load(post.getSubredditIconUrl())
+                                    .apply(RequestOptions.bitmapTransform(new RoundedCornersTransformation(72, 0)))
+                                    .error(mGlide.load(R.drawable.subreddit_default_icon)
+                                            .apply(RequestOptions.bitmapTransform(new RoundedCornersTransformation(72, 0))))
+                                    .into(((PostCompactBaseViewHolder) holder).iconGifImageView);
+                        } else {
+                            mGlide.load(R.drawable.subreddit_default_icon)
+                                    .apply(RequestOptions.bitmapTransform(new RoundedCornersTransformation(72, 0)))
+                                    .into(((PostCompactBaseViewHolder) holder).iconGifImageView);
+                        }
+                    }
+
+                    ((PostCompactBaseViewHolder) holder).nameTextView.setTextColor(mSubredditColor);
+                    if (mHideSubredditAndUserPrefix) {
+                        ((PostCompactBaseViewHolder) holder).nameTextView.setText(post.getSubredditName());
+                    } else {
+                        ((PostCompactBaseViewHolder) holder).nameTextView.setText("r/" + post.getSubredditName());
+                    }
+                } else {
+                    if (post.getAuthorIconUrl() == null) {
+                        String authorName = post.isAuthorDeleted() ? post.getSubredditName() : post.getAuthor();
+                        mFragment.loadIcon(authorName, post.isAuthorDeleted(), (subredditOrUserName, iconUrl) -> {
+                            if (mActivity != null && getItemCount() > 0 && authorName.equals(subredditOrUserName)) {
+                                if (iconUrl == null || iconUrl.equals("")) {
+                                    mGlide.load(R.drawable.subreddit_default_icon)
+                                            .apply(RequestOptions.bitmapTransform(new RoundedCornersTransformation(72, 0)))
+                                            .into(((PostCompactBaseViewHolder) holder).iconGifImageView);
+                                } else {
+                                    mGlide.load(iconUrl)
+                                            .apply(RequestOptions.bitmapTransform(new RoundedCornersTransformation(72, 0)))
+                                            .error(mGlide.load(R.drawable.subreddit_default_icon)
+                                                    .apply(RequestOptions.bitmapTransform(new RoundedCornersTransformation(72, 0))))
+                                            .into(((PostCompactBaseViewHolder) holder).iconGifImageView);
+                                }
+
+                                if (holder.getBindingAdapterPosition() >= 0) {
+                                    post.setAuthorIconUrl(iconUrl);
+                                }
+                            }
+                        });
+                    } else if (!post.getAuthorIconUrl().equals("")) {
+                        mGlide.load(post.getAuthorIconUrl())
+                                .apply(RequestOptions.bitmapTransform(new RoundedCornersTransformation(72, 0)))
+                                .error(mGlide.load(R.drawable.subreddit_default_icon)
+                                        .apply(RequestOptions.bitmapTransform(new RoundedCornersTransformation(72, 0))))
+                                .into(((PostCompactBaseViewHolder) holder).iconGifImageView);
+                    } else {
+                        mGlide.load(R.drawable.subreddit_default_icon)
+                                .apply(RequestOptions.bitmapTransform(new RoundedCornersTransformation(72, 0)))
+                                .into(((PostCompactBaseViewHolder) holder).iconGifImageView);
+                    }
+
+                    ((PostCompactBaseViewHolder) holder).nameTextView.setTextColor(
+                            post.isModerator() ? mModeratorColor : mUsernameColor);
+                    if (mHideSubredditAndUserPrefix) {
+                        ((PostCompactBaseViewHolder) holder).nameTextView.setText(post.getAuthor());
+                    } else {
+                        ((PostCompactBaseViewHolder) holder).nameTextView.setText(authorPrefixed);
+                    }
+                }
+
+                if (mShowElapsedTime) {
+                    ((PostCompactBaseViewHolder) holder).postTimeTextView.setText(
+                            Utils.getElapsedTime(mActivity, post.getPostTimeMillis()));
+                } else {
+                    ((PostCompactBaseViewHolder) holder).postTimeTextView.setText(Utils.getFormattedTime(mLocale, post.getPostTimeMillis(), mTimeFormatPattern));
+                }
+
+                if (mCompactLayoutToolbarHiddenByDefault) {
+                    ViewGroup.LayoutParams params = ((PostCompactBaseViewHolder) holder).bottomConstraintLayout.getLayoutParams();
+                    params.height = 0;
+                    ((PostCompactBaseViewHolder) holder).bottomConstraintLayout.setLayoutParams(params);
+                } else {
+                    ViewGroup.LayoutParams params = ((PostCompactBaseViewHolder) holder).bottomConstraintLayout.getLayoutParams();
+                    params.height = LinearLayout.LayoutParams.WRAP_CONTENT;
+                    ((PostCompactBaseViewHolder) holder).bottomConstraintLayout.setLayoutParams(params);
+                }
+
+                if (mShowDividerInCompactLayout) {
+                    ((PostCompactBaseViewHolder) holder).divider.setVisibility(View.VISIBLE);
+                } else {
+                    ((PostCompactBaseViewHolder) holder).divider.setVisibility(View.GONE);
+                }
+
+                ((PostCompactBaseViewHolder) holder).titleTextView.setText(title);
+                if (!mHideTheNumberOfVotes) {
+                    ((PostCompactBaseViewHolder) holder).scoreTextView.setText(Utils.getNVotes(mShowAbsoluteNumberOfVotes, post.getScore() + post.getVoteType()));
+                } else {
+                    ((PostCompactBaseViewHolder) holder).scoreTextView.setText(mActivity.getString(R.string.vote));
+                }
+
+                if (post.isLocked()) {
+                    ((PostCompactBaseViewHolder) holder).lockedImageView.setVisibility(View.VISIBLE);
+                }
+
+                if (nsfw) {
+                    ((PostCompactBaseViewHolder) holder).nsfwTextView.setVisibility(View.VISIBLE);
+                }
+
+                if (spoiler) {
+                    ((PostCompactBaseViewHolder) holder).spoilerTextView.setVisibility(View.VISIBLE);
+                }
+
+                if (flair != null && !flair.equals("")) {
+                    if (mHidePostFlair) {
+                        ((PostCompactBaseViewHolder) holder).flairTextView.setVisibility(View.GONE);
+                    } else {
+                        ((PostCompactBaseViewHolder) holder).flairTextView.setVisibility(View.VISIBLE);
+                        Utils.setHTMLWithImageToTextView(((PostCompactBaseViewHolder) holder).flairTextView, flair, false);
+                    }
+                }
+
+                if (nAwards > 0 && !mHideTheNumberOfAwards) {
+                    ((PostCompactBaseViewHolder) holder).awardsTextView.setVisibility(View.VISIBLE);
+                    if (nAwards == 1) {
+                        ((PostCompactBaseViewHolder) holder).awardsTextView.setText(mActivity.getString(R.string.one_award));
+                    } else {
+                        ((PostCompactBaseViewHolder) holder).awardsTextView.setText(mActivity.getString(R.string.n_awards, nAwards));
+                    }
+                }
+
+                switch (voteType) {
+                    case 1:
+                        //Upvoted
+                        ((PostCompactBaseViewHolder) holder).upvoteButton.setColorFilter(mUpvotedColor, android.graphics.PorterDuff.Mode.SRC_IN);
+                        ((PostCompactBaseViewHolder) holder).scoreTextView.setTextColor(mUpvotedColor);
+                        break;
+                    case -1:
+                        //Downvoted
+                        ((PostCompactBaseViewHolder) holder).downvoteButton.setColorFilter(mDownvotedColor, android.graphics.PorterDuff.Mode.SRC_IN);
+                        ((PostCompactBaseViewHolder) holder).scoreTextView.setTextColor(mDownvotedColor);
+                        break;
+                }
+
+                if (post.getPostType() != Post.TEXT_TYPE && post.getPostType() != Post.NO_PREVIEW_LINK_TYPE && !(mDataSavingMode && mDisableImagePreview)) {
+                    ((PostCompactBaseViewHolder) holder).relativeLayout.setVisibility(View.VISIBLE);
+                    if (post.getPostType() == Post.GALLERY_TYPE && post.getPreviews() != null && post.getPreviews().isEmpty()) {
+                        ((PostCompactBaseViewHolder) holder).noPreviewPostImageFrameLayout.setVisibility(View.VISIBLE);
+                        ((PostCompactBaseViewHolder) holder).noPreviewPostImageView.setImageResource(R.drawable.ic_gallery_24dp);
+                    }
+                    if (post.getPreviews() != null && !post.getPreviews().isEmpty()) {
+                        ((PostCompactBaseViewHolder) holder).imageView.setVisibility(View.VISIBLE);
+                        ((PostCompactBaseViewHolder) holder).progressBar.setVisibility(View.VISIBLE);
+                        loadImage(holder);
+                    }
+                }
+
+                if (mPostType == PostPagingSource.TYPE_SUBREDDIT && !mDisplaySubredditName && post.isStickied()) {
+                    ((PostCompactBaseViewHolder) holder).stickiedPostImageView.setVisibility(View.VISIBLE);
+                    mGlide.load(R.drawable.ic_thumbtack_24dp).into(((PostCompactBaseViewHolder) holder).stickiedPostImageView);
+                }
+
+                if (isArchived) {
+                    ((PostCompactBaseViewHolder) holder).archivedImageView.setVisibility(View.VISIBLE);
+
+                    ((PostCompactBaseViewHolder) holder).upvoteButton
+                            .setColorFilter(mVoteAndReplyUnavailableVoteButtonColor, android.graphics.PorterDuff.Mode.SRC_IN);
+                    ((PostCompactBaseViewHolder) holder).downvoteButton
+                            .setColorFilter(mVoteAndReplyUnavailableVoteButtonColor, android.graphics.PorterDuff.Mode.SRC_IN);
+                }
+
+                if (post.isCrosspost()) {
+                    ((PostCompactBaseViewHolder) holder).crosspostImageView.setVisibility(View.VISIBLE);
+                }
+
+                if (mHidePostType) {
+                    ((PostCompactBaseViewHolder) holder).typeTextView.setVisibility(View.GONE);
+                } else {
+                    ((PostCompactBaseViewHolder) holder).typeTextView.setVisibility(View.VISIBLE);
+                }
+
+                switch (post.getPostType()) {
+                    case Post.IMAGE_TYPE:
+                        ((PostCompactBaseViewHolder) holder).typeTextView.setText(R.string.image);
+                        if (mDataSavingMode && mDisableImagePreview) {
+                            ((PostCompactBaseViewHolder) holder).noPreviewPostImageFrameLayout.setVisibility(View.VISIBLE);
+                            ((PostCompactBaseViewHolder) holder).noPreviewPostImageView.setImageResource(R.drawable.ic_image_24dp);
+                        }
+                        break;
+                    case Post.LINK_TYPE:
+                        ((PostCompactBaseViewHolder) holder).typeTextView.setText(R.string.link);
+                        if (mDataSavingMode && mDisableImagePreview) {
+                            ((PostCompactBaseViewHolder) holder).noPreviewPostImageFrameLayout.setVisibility(View.VISIBLE);
+                            ((PostCompactBaseViewHolder) holder).noPreviewPostImageView.setImageResource(R.drawable.ic_link);
+                        }
+
+                        ((PostCompactBaseViewHolder) holder).linkTextView.setVisibility(View.VISIBLE);
+                        String domain = Uri.parse(post.getUrl()).getHost();
+                        ((PostCompactBaseViewHolder) holder).linkTextView.setText(domain);
+                        break;
+                    case Post.GIF_TYPE:
+                        ((PostCompactBaseViewHolder) holder).typeTextView.setText(R.string.gif);
+                        if (mDataSavingMode && (mDisableImagePreview || mOnlyDisablePreviewInVideoAndGifPosts)) {
+                            ((PostCompactBaseViewHolder) holder).noPreviewPostImageFrameLayout.setVisibility(View.VISIBLE);
+                            ((PostCompactBaseViewHolder) holder).noPreviewPostImageView.setImageResource(R.drawable.ic_image_24dp);
+                        } else {
+                            ((PostCompactBaseViewHolder) holder).playButtonImageView.setVisibility(View.VISIBLE);
+                            ((PostCompactBaseViewHolder) holder).playButtonImageView.setImageDrawable(ContextCompat.getDrawable(mActivity, R.drawable.ic_play_circle_24dp));
+                        }
+                        break;
+                    case Post.VIDEO_TYPE:
+                        ((PostCompactBaseViewHolder) holder).typeTextView.setText(R.string.video);
+                        if (mDataSavingMode && (mDisableImagePreview || mOnlyDisablePreviewInVideoAndGifPosts)) {
+                            ((PostCompactBaseViewHolder) holder).noPreviewPostImageFrameLayout.setVisibility(View.VISIBLE);
+                            ((PostCompactBaseViewHolder) holder).noPreviewPostImageView.setImageResource(R.drawable.ic_outline_video_24dp);
+                        } else {
+                            ((PostCompactBaseViewHolder) holder).playButtonImageView.setVisibility(View.VISIBLE);
+                            ((PostCompactBaseViewHolder) holder).playButtonImageView.setImageDrawable(ContextCompat.getDrawable(mActivity, R.drawable.ic_play_circle_24dp));
+                        }
+                        break;
+                    case Post.NO_PREVIEW_LINK_TYPE:
+                        ((PostCompactBaseViewHolder) holder).typeTextView.setText(R.string.link);
+
+                        String noPreviewLinkUrl = post.getUrl();
+                        ((PostCompactBaseViewHolder) holder).linkTextView.setVisibility(View.VISIBLE);
+                        String noPreviewLinkDomain = Uri.parse(noPreviewLinkUrl).getHost();
+                        ((PostCompactBaseViewHolder) holder).linkTextView.setText(noPreviewLinkDomain);
+                        ((PostCompactBaseViewHolder) holder).noPreviewPostImageFrameLayout.setVisibility(View.VISIBLE);
+                        ((PostCompactBaseViewHolder) holder).noPreviewPostImageView.setImageResource(R.drawable.ic_link);
+                        break;
+                    case Post.GALLERY_TYPE:
+                        ((PostCompactBaseViewHolder) holder).typeTextView.setText(R.string.gallery);
+                        if (mDataSavingMode && mDisableImagePreview) {
+                            ((PostCompactBaseViewHolder) holder).noPreviewPostImageFrameLayout.setVisibility(View.VISIBLE);
+                            ((PostCompactBaseViewHolder) holder).noPreviewPostImageView.setImageResource(R.drawable.ic_gallery_24dp);
+                        } else {
+                            ((PostCompactBaseViewHolder) holder).playButtonImageView.setVisibility(View.VISIBLE);
+                            ((PostCompactBaseViewHolder) holder).playButtonImageView.setImageDrawable(ContextCompat.getDrawable(mActivity, R.drawable.ic_gallery_24dp));
+                        }
+                        break;
+                    case Post.TEXT_TYPE:
+                        ((PostCompactBaseViewHolder) holder).typeTextView.setText(R.string.text);
+                        break;
+                }
+
+                if (!mHideTheNumberOfComments) {
+                    ((PostCompactBaseViewHolder) holder).commentsCountTextView.setVisibility(View.VISIBLE);
+                    ((PostCompactBaseViewHolder) holder).commentsCountTextView.setText(Integer.toString(post.getNComments()));
+                } else {
+                    ((PostCompactBaseViewHolder) holder).commentsCountTextView.setVisibility(View.GONE);
+                }
+
+                if (post.isSaved()) {
+                    ((PostCompactBaseViewHolder) holder).saveButton.setImageResource(R.drawable.ic_bookmark_grey_24dp);
+                } else {
+                    ((PostCompactBaseViewHolder) holder).saveButton.setImageResource(R.drawable.ic_bookmark_border_grey_24dp);
+                }
+
+                mCallback.currentlyBindItem(holder.getBindingAdapterPosition());
+            }
+        } else if (holder instanceof PostGalleryViewHolder) {
+            Post post = getItem(position);
+            if (post != null) {
+                ((PostGalleryViewHolder) holder).post = post;
+
+                switch (post.getPostType()) {
+                    case Post.IMAGE_TYPE: {
+                        Post.Preview preview = getSuitablePreview(post.getPreviews());
+                        ((PostGalleryViewHolder) holder).preview = preview;
+                        if (preview != null) {
+                            ((PostGalleryViewHolder) holder).imageView.setVisibility(View.VISIBLE);
+                            ((PostGalleryViewHolder) holder).progressBar.setVisibility(View.VISIBLE);
+
+                            if (mFixedHeightPreviewInCard || (preview.getPreviewWidth() <= 0 || preview.getPreviewHeight() <= 0)) {
+                                int height = (int) (400 * mScale);
+                                ((PostGalleryViewHolder) holder).imageView.setScaleType(ImageView.ScaleType.CENTER_CROP);
+                                ((PostGalleryViewHolder) holder).imageView.getLayoutParams().height = height;
+                            } else {
+                                ((PostGalleryViewHolder) holder).imageView
+                                        .setRatio((float) preview.getPreviewHeight() / preview.getPreviewWidth());
+                            }
+                            ((PostGalleryViewHolder) holder).imageView.addOnLayoutChangeListener(new View.OnLayoutChangeListener() {
+                                @Override
+                                public void onLayoutChange(View v, int left, int top, int right, int bottom, int oldLeft, int oldTop, int oldRight, int oldBottom) {
+                                    ((PostGalleryViewHolder) holder).imageView.removeOnLayoutChangeListener(this);
+                                    loadImage(holder);
+                                }
+                            });
+                        } else {
+                            ((PostGalleryViewHolder) holder).noPreviewImageView.setVisibility(View.VISIBLE);
+                            if (post.getPostType() == Post.VIDEO_TYPE) {
+                                ((PostGalleryViewHolder) holder).noPreviewImageView.setImageResource(R.drawable.ic_outline_video_24dp);
+                                ((PostGalleryViewHolder) holder).videoOrGifIndicatorImageView.setVisibility(View.GONE);
+                            } else if (post.getPostType() == Post.IMAGE_TYPE || post.getPostType() == Post.GIF_TYPE) {
+                                ((PostGalleryViewHolder) holder).videoOrGifIndicatorImageView.setVisibility(View.GONE);
+                            } else if (post.getPostType() == Post.LINK_TYPE) {
+                                ((PostGalleryViewHolder) holder).noPreviewImageView.setImageResource(R.drawable.ic_link);
+                            }
+                            ((PostGalleryViewHolder) holder).noPreviewImageView.setImageResource(R.drawable.ic_image_24dp);
+                        }
+                        break;
+                    }
+                    case Post.GIF_TYPE: {
+                        if (post.getPostType() == Post.GIF_TYPE && ((post.isNSFW() && mNeedBlurNsfw && !(mAutoplay && mAutoplayNsfwVideos)) || (post.isSpoiler() && mNeedBlurSpoiler))) {
+                            ((PostGalleryViewHolder) holder).noPreviewImageView.setVisibility(View.VISIBLE);
+                            ((PostGalleryViewHolder) holder).noPreviewImageView.setImageResource(R.drawable.ic_image_24dp);
+                        } else {
+                            Post.Preview preview = getSuitablePreview(post.getPreviews());
+                            ((PostGalleryViewHolder) holder).preview = preview;
+                            if (preview != null) {
+                                ((PostGalleryViewHolder) holder).imageView.setVisibility(View.VISIBLE);
+                                ((PostGalleryViewHolder) holder).progressBar.setVisibility(View.VISIBLE);
+                                ((PostGalleryViewHolder) holder).videoOrGifIndicatorImageView.setVisibility(View.VISIBLE);
+                                ((PostGalleryViewHolder) holder).videoOrGifIndicatorImageView.setImageDrawable(ContextCompat.getDrawable(mActivity, R.drawable.ic_play_circle_36dp));
+
+                                if (mFixedHeightPreviewInCard || (preview.getPreviewWidth() <= 0 || preview.getPreviewHeight() <= 0)) {
+                                    int height = (int) (400 * mScale);
+                                    ((PostGalleryViewHolder) holder).imageView.setScaleType(ImageView.ScaleType.CENTER_CROP);
+                                    ((PostGalleryViewHolder) holder).imageView.getLayoutParams().height = height;
+                                } else {
+                                    ((PostGalleryViewHolder) holder).imageView
+                                            .setRatio((float) preview.getPreviewHeight() / preview.getPreviewWidth());
+                                }
+                                ((PostGalleryViewHolder) holder).imageView.addOnLayoutChangeListener(new View.OnLayoutChangeListener() {
+                                    @Override
+                                    public void onLayoutChange(View v, int left, int top, int right, int bottom, int oldLeft, int oldTop, int oldRight, int oldBottom) {
+                                        ((PostGalleryViewHolder) holder).imageView.removeOnLayoutChangeListener(this);
+                                        loadImage(holder);
+                                    }
+                                });
+                            } else {
+                                ((PostGalleryViewHolder) holder).noPreviewImageView.setVisibility(View.VISIBLE);
+                                ((PostGalleryViewHolder) holder).noPreviewImageView.setImageResource(R.drawable.ic_image_24dp);
+                            }
+                        }
+                        break;
+                    }
+                    case Post.VIDEO_TYPE: {
+                        Post.Preview preview = getSuitablePreview(post.getPreviews());
+                        ((PostGalleryViewHolder) holder).preview = preview;
+                        if (preview != null) {
+                            ((PostGalleryViewHolder) holder).imageView.setVisibility(View.VISIBLE);
+                            ((PostGalleryViewHolder) holder).progressBar.setVisibility(View.VISIBLE);
+                            ((PostGalleryViewHolder) holder).videoOrGifIndicatorImageView.setVisibility(View.VISIBLE);
+                            ((PostGalleryViewHolder) holder).videoOrGifIndicatorImageView.setImageDrawable(ContextCompat.getDrawable(mActivity, R.drawable.ic_play_circle_36dp));
+
+                            if (mFixedHeightPreviewInCard || (preview.getPreviewWidth() <= 0 || preview.getPreviewHeight() <= 0)) {
+                                int height = (int) (400 * mScale);
+                                ((PostGalleryViewHolder) holder).imageView.setScaleType(ImageView.ScaleType.CENTER_CROP);
+                                ((PostGalleryViewHolder) holder).imageView.getLayoutParams().height = height;
+                            } else {
+                                ((PostGalleryViewHolder) holder).imageView
+                                        .setRatio((float) preview.getPreviewHeight() / preview.getPreviewWidth());
+                            }
+                            ((PostGalleryViewHolder) holder).imageView.addOnLayoutChangeListener(new View.OnLayoutChangeListener() {
+                                @Override
+                                public void onLayoutChange(View v, int left, int top, int right, int bottom, int oldLeft, int oldTop, int oldRight, int oldBottom) {
+                                    ((PostGalleryViewHolder) holder).imageView.removeOnLayoutChangeListener(this);
+                                    loadImage(holder);
+                                }
+                            });
+                        } else {
+                            ((PostGalleryViewHolder) holder).noPreviewImageView.setVisibility(View.VISIBLE);
+                            ((PostGalleryViewHolder) holder).noPreviewImageView.setImageResource(R.drawable.ic_outline_video_24dp);
+                        }
+                        break;
+                    }
+                    case Post.LINK_TYPE: {
+                        Post.Preview preview = getSuitablePreview(post.getPreviews());
+                        ((PostGalleryViewHolder) holder).preview = preview;
+                        if (preview != null) {
+                            ((PostGalleryViewHolder) holder).imageView.setVisibility(View.VISIBLE);
+                            ((PostGalleryViewHolder) holder).progressBar.setVisibility(View.VISIBLE);
+                            ((PostGalleryViewHolder) holder).videoOrGifIndicatorImageView.setVisibility(View.VISIBLE);
+                            ((PostGalleryViewHolder) holder).videoOrGifIndicatorImageView.setImageDrawable(ContextCompat.getDrawable(mActivity, R.drawable.ic_link_post_type_indicator));
+
+                            if (mFixedHeightPreviewInCard || (preview.getPreviewWidth() <= 0 || preview.getPreviewHeight() <= 0)) {
+                                int height = (int) (400 * mScale);
+                                ((PostGalleryViewHolder) holder).imageView.setScaleType(ImageView.ScaleType.CENTER_CROP);
+                                ((PostGalleryViewHolder) holder).imageView.getLayoutParams().height = height;
+                            } else {
+                                ((PostGalleryViewHolder) holder).imageView
+                                        .setRatio((float) preview.getPreviewHeight() / preview.getPreviewWidth());
+                            }
+                            ((PostGalleryViewHolder) holder).imageView.addOnLayoutChangeListener(new View.OnLayoutChangeListener() {
+                                @Override
+                                public void onLayoutChange(View v, int left, int top, int right, int bottom, int oldLeft, int oldTop, int oldRight, int oldBottom) {
+                                    ((PostGalleryViewHolder) holder).imageView.removeOnLayoutChangeListener(this);
+                                    loadImage(holder);
+                                }
+                            });
+                        } else {
+                            ((PostGalleryViewHolder) holder).noPreviewImageView.setVisibility(View.VISIBLE);
+                            ((PostGalleryViewHolder) holder).noPreviewImageView.setImageResource(R.drawable.ic_link);
+                        }
+                        break;
+                    }
+                    case Post.NO_PREVIEW_LINK_TYPE: {
+                        ((PostGalleryViewHolder) holder).noPreviewImageView.setVisibility(View.VISIBLE);
+                        ((PostGalleryViewHolder) holder).noPreviewImageView.setImageResource(R.drawable.ic_link);
+                        break;
+                    }
+                    case Post.TEXT_TYPE: {
+                        ((PostGalleryViewHolder) holder).titleTextView.setVisibility(View.VISIBLE);
+                        ((PostGalleryViewHolder) holder).titleTextView.setText(post.getTitle());
+                        break;
+                    }
+                }
+            }
+        } else if (holder instanceof PostGalleryBaseGalleryTypeViewHolder) {
+            Post post = getItem(position);
+            if (post != null) {
+                ((PostGalleryBaseGalleryTypeViewHolder) holder).post = post;
+                ((PostGalleryBaseGalleryTypeViewHolder) holder).currentPosition = position;
+
+                if (mDataSavingMode && mDisableImagePreview) {
+                    ((PostGalleryBaseGalleryTypeViewHolder) holder).noPreviewImageView.setVisibility(View.VISIBLE);
+                    ((PostGalleryBaseGalleryTypeViewHolder) holder).noPreviewImageView.setImageResource(R.drawable.ic_gallery_24dp);
+                } else {
+                    Post.Preview preview = getSuitablePreview(post.getPreviews());
+                    ((PostGalleryBaseGalleryTypeViewHolder) holder).preview = preview;
+
+                    ((PostGalleryBaseGalleryTypeViewHolder) holder).frameLayout.setVisibility(View.VISIBLE);
+                    ((PostGalleryBaseGalleryTypeViewHolder) holder).imageIndexTextView.setText(mActivity.getString(R.string.image_index_in_gallery, 1, post.getGallery().size()));
+                    if (preview != null) {
+                        if (mFixedHeightPreviewInCard || (preview.getPreviewWidth() <= 0 || preview.getPreviewHeight() <= 0)) {
+                            ((PostGalleryBaseGalleryTypeViewHolder) holder).adapter.setRatio(-1);
+                        } else {
+                            ((PostGalleryBaseGalleryTypeViewHolder) holder).adapter.setRatio((float) preview.getPreviewHeight() / preview.getPreviewWidth());
+                        }
+                    } else {
+                        ((PostGalleryBaseGalleryTypeViewHolder) holder).adapter.setRatio(-1);
+                    }
+                    ((PostGalleryBaseGalleryTypeViewHolder) holder).adapter.setGalleryImages(post.getGallery());
+                    ((PostGalleryBaseGalleryTypeViewHolder) holder).adapter.setBlurImage(
+                            (post.isNSFW() && mNeedBlurNsfw) || (post.isSpoiler() && mNeedBlurSpoiler));
+                }
+            }
+        }
+    }
+
+    @Nullable
+    private Post.Preview getSuitablePreview(ArrayList<Post.Preview> previews) {
+        Post.Preview preview;
+        if (!previews.isEmpty()) {
+            int previewIndex;
+            if (mDataSavingMode && previews.size() > 2) {
+                previewIndex = previews.size() / 2;
+            } else {
+                previewIndex = 0;
+            }
+            preview = previews.get(previewIndex);
+            if (preview.getPreviewWidth() * preview.getPreviewHeight() > mMaxResolution) {
+                for (int i = previews.size() - 1; i >= 1; i--) {
+                    preview = previews.get(i);
+                    if (preview.getPreviewWidth() * preview.getPreviewHeight() <= mMaxResolution) {
+                        return preview;
+                    }
+                }
+            }
+            return preview;
+        }
+
+        return null;
+    }
+
+    private void loadImage(final RecyclerView.ViewHolder holder) {
+        if (holder instanceof PostWithPreviewTypeViewHolder) {
+            Post post = ((PostWithPreviewTypeViewHolder) holder).post;
+            Post.Preview preview = ((PostWithPreviewTypeViewHolder) holder).preview;
+            if (preview != null) {
+                String url;
+                boolean blurImage = (post.isNSFW() && mNeedBlurNsfw && !(post.getPostType() == Post.GIF_TYPE && mAutoplay && mAutoplayNsfwVideos)) || (post.isSpoiler() && mNeedBlurSpoiler);
+                if (post.getPostType() == Post.GIF_TYPE && mAutoplay && !blurImage) {
+                    url = post.getUrl();
+                } else {
+                    url = preview.getPreviewUrl();
+                }
+                RequestBuilder<Drawable> imageRequestBuilder = mGlide.load(url).listener(((PostWithPreviewTypeViewHolder) holder).glideRequestListener);
+                if (blurImage) {
+                    imageRequestBuilder.apply(RequestOptions.bitmapTransform(new BlurTransformation(50, 10)))
+                            .into(((PostWithPreviewTypeViewHolder) holder).imageView);
+                } else {
+                    imageRequestBuilder.centerInside().downsample(mSaveMemoryCenterInsideDownsampleStrategy).into(((PostWithPreviewTypeViewHolder) holder).imageView);
+                }
+            }
+        } else if (holder instanceof PostCompactBaseViewHolder) {
+            Post post = ((PostCompactBaseViewHolder) holder).post;
+            String postCompactThumbnailPreviewUrl;
+            ArrayList<Post.Preview> previews = post.getPreviews();
+            if (previews != null && !previews.isEmpty()) {
+                if (previews.size() >= 2) {
+                    postCompactThumbnailPreviewUrl = previews.get(1).getPreviewUrl();
+                } else {
+                    postCompactThumbnailPreviewUrl = previews.get(0).getPreviewUrl();
+                }
+
+                RequestBuilder<Drawable> imageRequestBuilder = mGlide.load(postCompactThumbnailPreviewUrl)
+                        .error(R.drawable.ic_error_outline_black_24dp).listener(((PostCompactBaseViewHolder) holder).requestListener);
+                if ((post.isNSFW() && mNeedBlurNsfw) || (post.isSpoiler() && mNeedBlurSpoiler)) {
+                    imageRequestBuilder
+                            .transform(new BlurTransformation(50, 2)).into(((PostCompactBaseViewHolder) holder).imageView);
+                } else {
+                    imageRequestBuilder.into(((PostCompactBaseViewHolder) holder).imageView);
+                }
+            }
+        } else if (holder instanceof PostGalleryViewHolder) {
+            Post post = ((PostGalleryViewHolder) holder).post;
+            Post.Preview preview = ((PostGalleryViewHolder) holder).preview;
+            if (preview != null) {
+                String url;
+                boolean blurImage = (post.isNSFW() && mNeedBlurNsfw && !(post.getPostType() == Post.GIF_TYPE && mAutoplay && mAutoplayNsfwVideos)) || post.isSpoiler() && mNeedBlurSpoiler;
+                if (post.getPostType() == Post.GIF_TYPE && mAutoplay && !blurImage) {
+                    url = post.getUrl();
+                } else {
+                    url = preview.getPreviewUrl();
+                }
+                RequestBuilder<Drawable> imageRequestBuilder = mGlide.load(url).listener(((PostGalleryViewHolder) holder).requestListener);
+
+                if (blurImage) {
+                    imageRequestBuilder.apply(RequestOptions.bitmapTransform(new BlurTransformation(50, 10)))
+                            .into(((PostGalleryViewHolder) holder).imageView);
+                } else {
+                    imageRequestBuilder.centerInside().downsample(mSaveMemoryCenterInsideDownsampleStrategy).into(((PostGalleryViewHolder) holder).imageView);
+                }
+            }
+        } else if (holder instanceof PostCard2WithPreviewViewHolder) {
+            Post post = ((PostCard2WithPreviewViewHolder) holder).post;
+            Post.Preview preview = ((PostCard2WithPreviewViewHolder) holder).preview;
+            if (preview != null) {
+                String url;
+                boolean blurImage = (post.isNSFW() && mNeedBlurNsfw && !(post.getPostType() == Post.GIF_TYPE && mAutoplay && mAutoplayNsfwVideos)) || (post.isSpoiler() && mNeedBlurSpoiler);
+                if (post.getPostType() == Post.GIF_TYPE && mAutoplay && !blurImage) {
+                    url = post.getUrl();
+                } else {
+                    url = preview.getPreviewUrl();
+                }
+                RequestBuilder<Drawable> imageRequestBuilder = mGlide.load(url).listener(((PostCard2WithPreviewViewHolder) holder).requestListener);
+
+                if (blurImage) {
+                    imageRequestBuilder.apply(RequestOptions.bitmapTransform(new BlurTransformation(50, 10)))
+                            .into(((PostCard2WithPreviewViewHolder) holder).imageView);
+                } else {
+                    imageRequestBuilder.centerInside().downsample(mSaveMemoryCenterInsideDownsampleStrategy).into(((PostCard2WithPreviewViewHolder) holder).imageView);
+                }
+            }
+        }
+    }
+
+    private void shareLink(Post post) {
+        Bundle bundle = new Bundle();
+        bundle.putString(ShareLinkBottomSheetFragment.EXTRA_POST_LINK, post.getPermalink());
+        bundle.putString(ShareLinkBottomSheetFragment.EXTRA_POST_ID, post.getId());
+        bundle.putString(ShareLinkBottomSheetFragment.EXTRA_POST_TITLE, post.getTitle());
+        bundle.putString(ShareLinkBottomSheetFragment.EXTRA_POST_SUBREDDIT, post.getSubredditName());
+        bundle.putString(ShareLinkBottomSheetFragment.EXTRA_POST_FLAIR, post.getFlair());
+        if (post.getPostType() != Post.TEXT_TYPE) {
+            bundle.putInt(ShareLinkBottomSheetFragment.EXTRA_MEDIA_TYPE, post.getPostType());
+            switch (post.getPostType()) {
+                case Post.IMAGE_TYPE:
+                case Post.GIF_TYPE:
+                case Post.LINK_TYPE:
+                case Post.NO_PREVIEW_LINK_TYPE:
+                    bundle.putString(ShareLinkBottomSheetFragment.EXTRA_MEDIA_LINK, post.getUrl());
+                    break;
+                case Post.VIDEO_TYPE:
+                    bundle.putString(ShareLinkBottomSheetFragment.EXTRA_MEDIA_LINK, post.getVideoDownloadUrl());
+                    break;
+            }
+        }
+        ShareLinkBottomSheetFragment shareLinkBottomSheetFragment = new ShareLinkBottomSheetFragment();
+        shareLinkBottomSheetFragment.setArguments(bundle);
+        shareLinkBottomSheetFragment.show(mActivity.getSupportFragmentManager(), shareLinkBottomSheetFragment.getTag());
+    }
+
+    @Nullable
+    public Post getItemByPosition(int position) {
+        if (position >= 0 && super.getItemCount() > position) {
+            return super.getItem(position);
+        }
+
+        return null;
+    }
+
+    public void setVoteButtonsPosition(boolean voteButtonsOnTheRight) {
+        mVoteButtonsOnTheRight = voteButtonsOnTheRight;
+    }
+
+    public void setPostLayout(int postLayout) {
+        mPostLayout = postLayout;
+    }
+
+    public void setBlurNsfwAndDoNotBlurNsfwInNsfwSubreddits(boolean needBlurNsfw) {
+        mNeedBlurNsfw = needBlurNsfw;
+    }
+
+    public void setBlurSpoiler(boolean needBlurSpoiler) {
+        mNeedBlurSpoiler = needBlurSpoiler;
+    }
+
+    public void setShowElapsedTime(boolean showElapsedTime) {
+        mShowElapsedTime = showElapsedTime;
+    }
+
+    public void setTimeFormat(String timeFormat) {
+        mTimeFormatPattern = timeFormat;
+    }
+
+    public void setShowDividerInCompactLayout(boolean showDividerInCompactLayout) {
+        mShowDividerInCompactLayout = showDividerInCompactLayout;
+    }
+
+    public void setShowAbsoluteNumberOfVotes(boolean showAbsoluteNumberOfVotes) {
+        mShowAbsoluteNumberOfVotes = showAbsoluteNumberOfVotes;
+    }
+
+    public void setAutoplay(boolean autoplay) {
+        mAutoplay = autoplay;
+    }
+
+    public boolean isAutoplay() {
+        return mAutoplay;
+    }
+
+    public void setAutoplayNsfwVideos(boolean autoplayNsfwVideos) {
+        mAutoplayNsfwVideos = autoplayNsfwVideos;
+    }
+
+    public void setMuteAutoplayingVideos(boolean muteAutoplayingVideos) {
+        mMuteAutoplayingVideos = muteAutoplayingVideos;
+    }
+
+    public void setShowThumbnailOnTheRightInCompactLayout(boolean showThumbnailOnTheRightInCompactLayout) {
+        mShowThumbnailOnTheRightInCompactLayout = showThumbnailOnTheRightInCompactLayout;
+    }
+
+    public void setStartAutoplayVisibleAreaOffset(double startAutoplayVisibleAreaOffset) {
+        this.mStartAutoplayVisibleAreaOffset = startAutoplayVisibleAreaOffset / 100.0;
+    }
+
+    public void setMuteNSFWVideo(boolean muteNSFWVideo) {
+        this.mMuteNSFWVideo = muteNSFWVideo;
+    }
+
+    public void setLongPressToHideToolbarInCompactLayout(boolean longPressToHideToolbarInCompactLayout) {
+        mLongPressToHideToolbarInCompactLayout = longPressToHideToolbarInCompactLayout;
+    }
+
+    public void setCompactLayoutToolbarHiddenByDefault(boolean compactLayoutToolbarHiddenByDefault) {
+        mCompactLayoutToolbarHiddenByDefault = compactLayoutToolbarHiddenByDefault;
+    }
+
+    public void setDataSavingMode(boolean dataSavingMode) {
+        mDataSavingMode = dataSavingMode;
+    }
+
+    public void setDisableImagePreview(boolean disableImagePreview) {
+        mDisableImagePreview = disableImagePreview;
+    }
+
+    public void setOnlyDisablePreviewInVideoPosts(boolean onlyDisablePreviewInVideoAndGifPosts) {
+        mOnlyDisablePreviewInVideoAndGifPosts = onlyDisablePreviewInVideoAndGifPosts;
+    }
+
+    public void setHidePostType(boolean hidePostType) {
+        mHidePostType = hidePostType;
+    }
+
+    public void setHidePostFlair(boolean hidePostFlair) {
+        mHidePostFlair = hidePostFlair;
+    }
+
+    public void setHideTheNumberOfAwards(boolean hideTheNumberOfAwards) {
+        mHideTheNumberOfAwards = hideTheNumberOfAwards;
+    }
+
+    public void setHideSubredditAndUserPrefix(boolean hideSubredditAndUserPrefix) {
+        mHideSubredditAndUserPrefix = hideSubredditAndUserPrefix;
+    }
+
+    public void setHideTheNumberOfVotes(boolean hideTheNumberOfVotes) {
+        mHideTheNumberOfVotes = hideTheNumberOfVotes;
+    }
+
+    public void setHideTheNumberOfComments(boolean hideTheNumberOfComments) {
+        mHideTheNumberOfComments = hideTheNumberOfComments;
+    }
+
+    public void setDefaultLinkPostLayout(int defaultLinkPostLayout) {
+        mDefaultLinkPostLayout = defaultLinkPostLayout;
+    }
+
+    public void setFixedHeightPreviewInCard(boolean fixedHeightPreviewInCard) {
+        mFixedHeightPreviewInCard = fixedHeightPreviewInCard;
+    }
+
+    public void setHideTextPostContent(boolean hideTextPostContent) {
+        mHideTextPostContent = hideTextPostContent;
+    }
+
+    public void setPostFeedMaxResolution(int postFeedMaxResolution) {
+        mMaxResolution = postFeedMaxResolution;
+        if (mSaveMemoryCenterInsideDownsampleStrategy != null) {
+            mSaveMemoryCenterInsideDownsampleStrategy.setThreshold(postFeedMaxResolution);
+        }
+    }
+
+    public void setEasierToWatchInFullScreen(boolean easierToWatchInFullScreen) {
+        this.mEasierToWatchInFullScreen = easierToWatchInFullScreen;
+    }
+
+    @Override
+    public void onViewRecycled(@NonNull RecyclerView.ViewHolder holder) {
+        if (holder instanceof PostBaseViewHolder) {
+            if (((PostBaseViewHolder) holder).itemViewIsNotCardView) {
+                holder.itemView.setBackgroundColor(mCardViewBackgroundColor);
+            } else {
+                holder.itemView.setBackgroundTintList(ColorStateList.valueOf(mCardViewBackgroundColor));
+            }
+            mGlide.clear(((PostBaseViewHolder) holder).iconGifImageView);
+            ((PostBaseViewHolder) holder).titleTextView.setTextColor(mPostTitleColor);
+            if (holder instanceof PostVideoAutoplayViewHolder) {
+                ((PostVideoAutoplayViewHolder) holder).mediaUri = null;
+                if (((PostVideoAutoplayViewHolder) holder).fetchGfycatOrStreamableVideoCall != null && !((PostVideoAutoplayViewHolder) holder).fetchGfycatOrStreamableVideoCall.isCanceled()) {
+                    ((PostVideoAutoplayViewHolder) holder).fetchGfycatOrStreamableVideoCall.cancel();
+                    ((PostVideoAutoplayViewHolder) holder).fetchGfycatOrStreamableVideoCall = null;
+                }
+                ((PostVideoAutoplayViewHolder) holder).errorLoadingGfycatImageView.setVisibility(View.GONE);
+                ((PostVideoAutoplayViewHolder) holder).muteButton.setVisibility(View.GONE);
+                if (!((PostVideoAutoplayViewHolder) holder).isManuallyPaused) {
+                    ((PostVideoAutoplayViewHolder) holder).resetVolume();
+                }
+                mGlide.clear(((PostVideoAutoplayViewHolder) holder).previewImageView);
+                ((PostVideoAutoplayViewHolder) holder).previewImageView.setVisibility(View.GONE);
+            } else if (holder instanceof PostWithPreviewTypeViewHolder) {
+                mGlide.clear(((PostWithPreviewTypeViewHolder) holder).imageView);
+                ((PostWithPreviewTypeViewHolder) holder).imageWrapperRelativeLayout.setVisibility(View.GONE);
+                ((PostWithPreviewTypeViewHolder) holder).errorTextView.setVisibility(View.GONE);
+                ((PostWithPreviewTypeViewHolder) holder).noPreviewLinkImageView.setVisibility(View.GONE);
+                ((PostWithPreviewTypeViewHolder) holder).progressBar.setVisibility(View.GONE);
+                ((PostWithPreviewTypeViewHolder) holder).videoOrGifIndicatorImageView.setVisibility(View.GONE);
+                ((PostWithPreviewTypeViewHolder) holder).linkTextView.setVisibility(View.GONE);
+            } else if (holder instanceof PostBaseGalleryTypeViewHolder) {
+                ((PostBaseGalleryTypeViewHolder) holder).frameLayout.setVisibility(View.GONE);
+                ((PostBaseGalleryTypeViewHolder) holder).noPreviewImageView.setVisibility(View.GONE);
+                ((PostBaseGalleryTypeViewHolder) holder).adapter.setGalleryImages(null);
+            } else if (holder instanceof PostTextTypeViewHolder) {
+                ((PostTextTypeViewHolder) holder).contentTextView.setText("");
+                ((PostTextTypeViewHolder) holder).contentTextView.setTextColor(mPostContentColor);
+                ((PostTextTypeViewHolder) holder).contentTextView.setVisibility(View.GONE);
+            } else if (holder instanceof PostCard2VideoAutoplayViewHolder) {
+                ((PostCard2VideoAutoplayViewHolder) holder).mediaUri = null;
+                if (((PostCard2VideoAutoplayViewHolder) holder).fetchGfycatOrStreamableVideoCall != null && !((PostCard2VideoAutoplayViewHolder) holder).fetchGfycatOrStreamableVideoCall.isCanceled()) {
+                    ((PostCard2VideoAutoplayViewHolder) holder).fetchGfycatOrStreamableVideoCall.cancel();
+                    ((PostCard2VideoAutoplayViewHolder) holder).fetchGfycatOrStreamableVideoCall = null;
+                }
+                ((PostCard2VideoAutoplayViewHolder) holder).errorLoadingGfycatImageView.setVisibility(View.GONE);
+                ((PostCard2VideoAutoplayViewHolder) holder).muteButton.setVisibility(View.GONE);
+                ((PostCard2VideoAutoplayViewHolder) holder).resetVolume();
+                mGlide.clear(((PostCard2VideoAutoplayViewHolder) holder).previewImageView);
+                ((PostCard2VideoAutoplayViewHolder) holder).previewImageView.setVisibility(View.GONE);
+            } else if (holder instanceof PostCard2WithPreviewViewHolder) {
+                mGlide.clear(((PostCard2WithPreviewViewHolder) holder).imageView);
+                ((PostCard2WithPreviewViewHolder) holder).imageView.setVisibility(View.GONE);
+                ((PostCard2WithPreviewViewHolder) holder).errorTextView.setVisibility(View.GONE);
+                ((PostCard2WithPreviewViewHolder) holder).noPreviewImageView.setVisibility(View.GONE);
+                ((PostCard2WithPreviewViewHolder) holder).progressBar.setVisibility(View.GONE);
+                ((PostCard2WithPreviewViewHolder) holder).videoOrGifIndicatorImageView.setVisibility(View.GONE);
+                ((PostCard2WithPreviewViewHolder) holder).linkTextView.setVisibility(View.GONE);
+            } else if (holder instanceof PostCard2TextTypeViewHolder) {
+                ((PostCard2TextTypeViewHolder) holder).contentTextView.setText("");
+                ((PostCard2TextTypeViewHolder) holder).contentTextView.setTextColor(mPostContentColor);
+                ((PostCard2TextTypeViewHolder) holder).contentTextView.setVisibility(View.GONE);
+            }
+
+            mGlide.clear(((PostBaseViewHolder) holder).iconGifImageView);
+            ((PostBaseViewHolder) holder).stickiedPostImageView.setVisibility(View.GONE);
+            ((PostBaseViewHolder) holder).crosspostImageView.setVisibility(View.GONE);
+            ((PostBaseViewHolder) holder).archivedImageView.setVisibility(View.GONE);
+            ((PostBaseViewHolder) holder).lockedImageView.setVisibility(View.GONE);
+            ((PostBaseViewHolder) holder).nsfwTextView.setVisibility(View.GONE);
+            ((PostBaseViewHolder) holder).spoilerTextView.setVisibility(View.GONE);
+            ((PostBaseViewHolder) holder).flairTextView.setText("");
+            ((PostBaseViewHolder) holder).flairTextView.setVisibility(View.GONE);
+            ((PostBaseViewHolder) holder).awardsTextView.setText("");
+            ((PostBaseViewHolder) holder).awardsTextView.setVisibility(View.GONE);
+            ((PostBaseViewHolder) holder).upvoteButton.setColorFilter(mPostIconAndInfoColor, android.graphics.PorterDuff.Mode.SRC_IN);
+            ((PostBaseViewHolder) holder).scoreTextView.setTextColor(mPostIconAndInfoColor);
+            ((PostBaseViewHolder) holder).downvoteButton.setColorFilter(mPostIconAndInfoColor, android.graphics.PorterDuff.Mode.SRC_IN);
+        } else if (holder instanceof PostCompactBaseViewHolder) {
+            holder.itemView.setBackgroundColor(mCardViewBackgroundColor);
+            ((PostCompactBaseViewHolder) holder).titleTextView.setTextColor(mPostTitleColor);
+            mGlide.clear(((PostCompactBaseViewHolder) holder).imageView);
+            mGlide.clear(((PostCompactBaseViewHolder) holder).iconGifImageView);
+            ((PostCompactBaseViewHolder) holder).stickiedPostImageView.setVisibility(View.GONE);
+            ((PostCompactBaseViewHolder) holder).relativeLayout.setVisibility(View.GONE);
+            ((PostCompactBaseViewHolder) holder).crosspostImageView.setVisibility(View.GONE);
+            ((PostCompactBaseViewHolder) holder).archivedImageView.setVisibility(View.GONE);
+            ((PostCompactBaseViewHolder) holder).lockedImageView.setVisibility(View.GONE);
+            ((PostCompactBaseViewHolder) holder).nsfwTextView.setVisibility(View.GONE);
+            ((PostCompactBaseViewHolder) holder).spoilerTextView.setVisibility(View.GONE);
+            ((PostCompactBaseViewHolder) holder).flairTextView.setVisibility(View.GONE);
+            ((PostCompactBaseViewHolder) holder).flairTextView.setText("");
+            ((PostCompactBaseViewHolder) holder).awardsTextView.setVisibility(View.GONE);
+            ((PostCompactBaseViewHolder) holder).awardsTextView.setText("");
+            ((PostCompactBaseViewHolder) holder).linkTextView.setVisibility(View.GONE);
+            ((PostCompactBaseViewHolder) holder).progressBar.setVisibility(View.GONE);
+            ((PostCompactBaseViewHolder) holder).imageView.setVisibility(View.GONE);
+            ((PostCompactBaseViewHolder) holder).playButtonImageView.setVisibility(View.GONE);
+            ((PostCompactBaseViewHolder) holder).noPreviewPostImageFrameLayout.setVisibility(View.GONE);
+            ((PostCompactBaseViewHolder) holder).upvoteButton.setColorFilter(mPostIconAndInfoColor, android.graphics.PorterDuff.Mode.SRC_IN);
+            ((PostCompactBaseViewHolder) holder).scoreTextView.setTextColor(mPostIconAndInfoColor);
+            ((PostCompactBaseViewHolder) holder).downvoteButton.setColorFilter(mPostIconAndInfoColor, android.graphics.PorterDuff.Mode.SRC_IN);
+        } else if (holder instanceof PostGalleryViewHolder) {
+            holder.itemView.setBackgroundTintList(ColorStateList.valueOf(mCardViewBackgroundColor));
+
+            ((PostGalleryViewHolder) holder).titleTextView.setText("");
+            ((PostGalleryViewHolder) holder).titleTextView.setVisibility(View.GONE);
+            mGlide.clear(((PostGalleryViewHolder) holder).imageView);
+            ((PostGalleryViewHolder) holder).imageView.setVisibility(View.GONE);
+            ((PostGalleryViewHolder) holder).progressBar.setVisibility(View.GONE);
+            ((PostGalleryViewHolder) holder).errorTextView.setVisibility(View.GONE);
+            ((PostGalleryViewHolder) holder).videoOrGifIndicatorImageView.setVisibility(View.GONE);
+            ((PostGalleryViewHolder) holder).noPreviewImageView.setVisibility(View.GONE);
+        } else if (holder instanceof PostGalleryBaseGalleryTypeViewHolder) {
+            holder.itemView.setBackgroundTintList(ColorStateList.valueOf(mCardViewBackgroundColor));
+            ((PostGalleryBaseGalleryTypeViewHolder) holder).frameLayout.setVisibility(View.GONE);
+            ((PostGalleryBaseGalleryTypeViewHolder) holder).noPreviewImageView.setVisibility(View.GONE);
+        }
+    }
+
+    @Nullable
+    @Override
+    public Object getKeyForOrder(int order) {
+        if (super.getItemCount() <= 0 || order >= super.getItemCount()) {
+            return null;
+        }
+        return order;
+    }
+
+    @Nullable
+    @Override
+    public Integer getOrderForKey(@NonNull Object key) {
+        if (key instanceof Integer) {
+            return (Integer) key;
+        }
+
+        return null;
+    }
+
+    public void onItemSwipe(RecyclerView.ViewHolder viewHolder, int direction, int swipeLeftAction, int swipeRightAction) {
+        if (viewHolder instanceof PostBaseViewHolder) {
+            if (direction == ItemTouchHelper.LEFT || direction == ItemTouchHelper.START) {
+                if (swipeLeftAction == SharedPreferencesUtils.SWIPE_ACITON_UPVOTE) {
+                    ((PostBaseViewHolder) viewHolder).upvoteButton.performClick();
+                } else if (swipeLeftAction == SharedPreferencesUtils.SWIPE_ACITON_DOWNVOTE) {
+                    ((PostBaseViewHolder) viewHolder).downvoteButton.performClick();
+                }
+            } else {
+                if (swipeRightAction == SharedPreferencesUtils.SWIPE_ACITON_UPVOTE) {
+                    ((PostBaseViewHolder) viewHolder).upvoteButton.performClick();
+                } else if (swipeRightAction == SharedPreferencesUtils.SWIPE_ACITON_DOWNVOTE) {
+                    ((PostBaseViewHolder) viewHolder).downvoteButton.performClick();
+                }
+            }
+        } else if (viewHolder instanceof PostCompactBaseViewHolder) {
+            if (direction == ItemTouchHelper.LEFT || direction == ItemTouchHelper.START) {
+                if (swipeLeftAction == SharedPreferencesUtils.SWIPE_ACITON_UPVOTE) {
+                    ((PostCompactBaseViewHolder) viewHolder).upvoteButton.performClick();
+                } else if (swipeLeftAction == SharedPreferencesUtils.SWIPE_ACITON_DOWNVOTE) {
+                    ((PostCompactBaseViewHolder) viewHolder).downvoteButton.performClick();
+                }
+            } else {
+                if (swipeRightAction == SharedPreferencesUtils.SWIPE_ACITON_UPVOTE) {
+                    ((PostCompactBaseViewHolder) viewHolder).upvoteButton.performClick();
+                } else if (swipeRightAction == SharedPreferencesUtils.SWIPE_ACITON_DOWNVOTE) {
+                    ((PostCompactBaseViewHolder) viewHolder).downvoteButton.performClick();
+                }
+            }
+        }
+    }
+
+    public interface Callback {
+        void typeChipClicked(int filter);
+
+        void flairChipClicked(String flair);
+
+        void nsfwChipClicked();
+
+        void currentlyBindItem(int position);
+
+        void delayTransition();
+    }
+
+    private void openViewPostDetailActivity(Post post, int position) {
+        if (canStartActivity) {
+            canStartActivity = false;
+            Intent intent = new Intent(mActivity, ViewPostDetailActivity.class);
+            intent.putExtra(ViewPostDetailActivity.EXTRA_POST_DATA, post);
+            intent.putExtra(ViewPostDetailActivity.EXTRA_POST_LIST_POSITION, position);
+            intent.putExtra(ViewPostDetailActivity.EXTRA_POST_FRAGMENT_ID, mFragment.getLocalPostFragmentId());
+            mActivity.startActivity(intent);
+        }
+    }
+
+    private void openMedia(Post post) {
+        openMedia(post, 0);
+    }
+
+    private void openMedia(Post post, int galleryItemIndex) {
+        if (canStartActivity) {
+            canStartActivity = false;
+            if (post.getPostType() == Post.VIDEO_TYPE) {
+                Intent intent = new Intent(mActivity, ViewVideoActivity.class);
+                if (post.isImgur()) {
+                    intent.setData(Uri.parse(post.getVideoUrl()));
+                    intent.putExtra(ViewVideoActivity.EXTRA_VIDEO_TYPE, ViewVideoActivity.VIDEO_TYPE_IMGUR);
+                } else if (post.isGfycat()) {
+                    intent.putExtra(ViewVideoActivity.EXTRA_VIDEO_TYPE, ViewVideoActivity.VIDEO_TYPE_GFYCAT);
+                    intent.putExtra(ViewVideoActivity.EXTRA_GFYCAT_ID, post.getGfycatId());
+                } else if (post.isRedgifs()) {
+                    intent.putExtra(ViewVideoActivity.EXTRA_VIDEO_TYPE, ViewVideoActivity.VIDEO_TYPE_REDGIFS);
+                    intent.putExtra(ViewVideoActivity.EXTRA_GFYCAT_ID, post.getGfycatId());
+                } else if (post.isStreamable()) {
+                    intent.putExtra(ViewVideoActivity.EXTRA_VIDEO_TYPE, ViewVideoActivity.VIDEO_TYPE_STREAMABLE);
+                    intent.putExtra(ViewVideoActivity.EXTRA_STREAMABLE_SHORT_CODE, post.getStreamableShortCode());
+                } else {
+                    intent.setData(Uri.parse(post.getVideoUrl()));
+                    intent.putExtra(ViewVideoActivity.EXTRA_SUBREDDIT, post.getSubredditName());
+                    intent.putExtra(ViewVideoActivity.EXTRA_ID, post.getId());
+                    intent.putExtra(ViewVideoActivity.EXTRA_VIDEO_DOWNLOAD_URL, post.getVideoDownloadUrl());
+                }
+                intent.putExtra(ViewVideoActivity.EXTRA_POST_TITLE, post.getTitle());
+                intent.putExtra(ViewVideoActivity.EXTRA_IS_NSFW, post.isNSFW());
+                mActivity.startActivity(intent);
+            } else if (post.getPostType() == Post.IMAGE_TYPE) {
+                Intent intent = new Intent(mActivity, ViewImageOrGifActivity.class);
+                intent.putExtra(ViewImageOrGifActivity.EXTRA_IMAGE_URL_KEY, post.getUrl());
+                intent.putExtra(ViewImageOrGifActivity.EXTRA_FILE_NAME_KEY, post.getSubredditName()
+                        + "-" + post.getId() + ".jpg");
+                intent.putExtra(ViewImageOrGifActivity.EXTRA_POST_TITLE_KEY, post.getTitle());
+                intent.putExtra(ViewImageOrGifActivity.EXTRA_SUBREDDIT_OR_USERNAME_KEY, post.getSubredditName());
+                intent.putExtra(ViewImageOrGifActivity.EXTRA_IS_NSFW, post.isNSFW());
+                mActivity.startActivity(intent);
+            } else if (post.getPostType() == Post.GIF_TYPE) {
+                Intent intent = new Intent(mActivity, ViewImageOrGifActivity.class);
+                intent.putExtra(ViewImageOrGifActivity.EXTRA_FILE_NAME_KEY, post.getSubredditName()
+                        + "-" + post.getId() + ".gif");
+                intent.putExtra(ViewImageOrGifActivity.EXTRA_GIF_URL_KEY, post.getVideoUrl());
+                intent.putExtra(ViewImageOrGifActivity.EXTRA_POST_TITLE_KEY, post.getTitle());
+                intent.putExtra(ViewImageOrGifActivity.EXTRA_SUBREDDIT_OR_USERNAME_KEY, post.getSubredditName());
+                intent.putExtra(ViewImageOrGifActivity.EXTRA_IS_NSFW, post.isNSFW());
+                mActivity.startActivity(intent);
+            } else if (post.getPostType() == Post.LINK_TYPE || post.getPostType() == Post.NO_PREVIEW_LINK_TYPE) {
+                Intent intent = new Intent(mActivity, LinkResolverActivity.class);
+                Uri uri = Uri.parse(post.getUrl());
+                intent.setData(uri);
+                intent.putExtra(LinkResolverActivity.EXTRA_IS_NSFW, post.isNSFW());
+                mActivity.startActivity(intent);
+            } else if (post.getPostType() == Post.GALLERY_TYPE) {
+                Intent intent = new Intent(mActivity, ViewRedditGalleryActivity.class);
+                intent.putParcelableArrayListExtra(ViewRedditGalleryActivity.EXTRA_REDDIT_GALLERY, post.getGallery());
+                intent.putExtra(ViewRedditGalleryActivity.EXTRA_SUBREDDIT_NAME, post.getSubredditName());
+                intent.putExtra(ViewRedditGalleryActivity.EXTRA_IS_NSFW, post.isNSFW());
+                intent.putExtra(ViewRedditGalleryActivity.EXTRA_GALLERY_ITEM_INDEX, galleryItemIndex);
+                mActivity.startActivity(intent);
+            }
+        }
+    }
+
+    public void setCanPlayVideo(boolean canPlayVideo) {
+        this.canPlayVideo = canPlayVideo;
+    }
+
+    public class PostBaseViewHolder extends RecyclerView.ViewHolder {
+        AspectRatioGifImageView iconGifImageView;
+        TextView subredditTextView;
+        TextView userTextView;
+        ImageView stickiedPostImageView;
+        TextView postTimeTextView;
+        TextView titleTextView;
+        CustomTextView typeTextView;
+        ImageView archivedImageView;
+        ImageView lockedImageView;
+        ImageView crosspostImageView;
+        CustomTextView nsfwTextView;
+        CustomTextView spoilerTextView;
+        CustomTextView flairTextView;
+        CustomTextView awardsTextView;
+        ConstraintLayout bottomConstraintLayout;
+        ImageView upvoteButton;
+        TextView scoreTextView;
+        ImageView downvoteButton;
+        TextView commentsCountTextView;
+        ImageView saveButton;
+        ImageView shareButton;
+        Post post;
+        Post.Preview preview;
+
+        boolean itemViewIsNotCardView = false;
+
+        PostBaseViewHolder(@NonNull View itemView) {
+            super(itemView);
+        }
+
+        void setBaseView(AspectRatioGifImageView iconGifImageView,
+                         TextView subredditTextView,
+                         TextView userTextView,
+                         ImageView stickiedPostImageView,
+                         TextView postTimeTextView,
+                         TextView titleTextView,
+                         CustomTextView typeTextView,
+                         ImageView archivedImageView,
+                         ImageView lockedImageView,
+                         ImageView crosspostImageView,
+                         CustomTextView nsfwTextView,
+                         CustomTextView spoilerTextView,
+                         CustomTextView flairTextView,
+                         CustomTextView awardsTextView,
+                         ConstraintLayout bottomConstraintLayout,
+                         ImageView upvoteButton,
+                         TextView scoreTextView,
+                         ImageView downvoteButton,
+                         TextView commentsCountTextView,
+                         ImageView saveButton,
+                         ImageView shareButton) {
+            this.iconGifImageView = iconGifImageView;
+            this.subredditTextView = subredditTextView;
+            this.userTextView = userTextView;
+            this.stickiedPostImageView = stickiedPostImageView;
+            this.postTimeTextView = postTimeTextView;
+            this.titleTextView = titleTextView;
+            this.typeTextView = typeTextView;
+            this.archivedImageView = archivedImageView;
+            this.lockedImageView = lockedImageView;
+            this.crosspostImageView = crosspostImageView;
+            this.nsfwTextView = nsfwTextView;
+            this.spoilerTextView = spoilerTextView;
+            this.flairTextView = flairTextView;
+            this.awardsTextView = awardsTextView;
+            this.bottomConstraintLayout = bottomConstraintLayout;
+            this.upvoteButton = upvoteButton;
+            this.scoreTextView = scoreTextView;
+            this.downvoteButton = downvoteButton;
+            this.commentsCountTextView = commentsCountTextView;
+            this.saveButton = saveButton;
+            this.shareButton = shareButton;
+
+            scoreTextView.setOnClickListener(null);
+
+            if (mVoteButtonsOnTheRight) {
+                ConstraintSet constraintSet = new ConstraintSet();
+                constraintSet.clone(bottomConstraintLayout);
+                constraintSet.clear(upvoteButton.getId(), ConstraintSet.START);
+                constraintSet.clear(scoreTextView.getId(), ConstraintSet.START);
+                constraintSet.clear(downvoteButton.getId(), ConstraintSet.START);
+                constraintSet.clear(saveButton.getId(), ConstraintSet.END);
+                constraintSet.clear(shareButton.getId(), ConstraintSet.END);
+                constraintSet.connect(upvoteButton.getId(), ConstraintSet.END, scoreTextView.getId(), ConstraintSet.START);
+                constraintSet.connect(scoreTextView.getId(), ConstraintSet.END, downvoteButton.getId(), ConstraintSet.START);
+                constraintSet.connect(downvoteButton.getId(), ConstraintSet.END, ConstraintSet.PARENT_ID, ConstraintSet.END);
+                constraintSet.connect(commentsCountTextView.getId(), ConstraintSet.START, saveButton.getId(), ConstraintSet.END);
+                constraintSet.connect(commentsCountTextView.getId(), ConstraintSet.END, upvoteButton.getId(), ConstraintSet.START);
+                constraintSet.connect(saveButton.getId(), ConstraintSet.START, shareButton.getId(), ConstraintSet.END);
+                constraintSet.connect(shareButton.getId(), ConstraintSet.START, ConstraintSet.PARENT_ID, ConstraintSet.START);
+                constraintSet.setHorizontalBias(commentsCountTextView.getId(), 0);
+                constraintSet.applyTo(bottomConstraintLayout);
+            }
+
+            if (itemViewIsNotCardView) {
+                itemView.setBackgroundColor(mCardViewBackgroundColor);
+            } else {
+                itemView.setBackgroundTintList(ColorStateList.valueOf(mCardViewBackgroundColor));
+            }
+
+            if (mActivity.typeface != null) {
+                subredditTextView.setTypeface(mActivity.typeface);
+                userTextView.setTypeface(mActivity.typeface);
+                postTimeTextView.setTypeface(mActivity.typeface);
+                typeTextView.setTypeface(mActivity.typeface);
+                spoilerTextView.setTypeface(mActivity.typeface);
+                nsfwTextView.setTypeface(mActivity.typeface);
+                flairTextView.setTypeface(mActivity.typeface);
+                awardsTextView.setTypeface(mActivity.typeface);
+                scoreTextView.setTypeface(mActivity.typeface);
+                commentsCountTextView.setTypeface(mActivity.typeface);
+            }
+            if (mActivity.titleTypeface != null) {
+                titleTextView.setTypeface(mActivity.titleTypeface);
+            }
+
+            subredditTextView.setTextColor(mSubredditColor);
+            userTextView.setTextColor(mUsernameColor);
+            postTimeTextView.setTextColor(mSecondaryTextColor);
+            titleTextView.setTextColor(mPostTitleColor);
+            stickiedPostImageView.setColorFilter(mStickiedPostIconTint, PorterDuff.Mode.SRC_IN);
+            typeTextView.setBackgroundColor(mPostTypeBackgroundColor);
+            typeTextView.setBorderColor(mPostTypeBackgroundColor);
+            typeTextView.setTextColor(mPostTypeTextColor);
+            spoilerTextView.setBackgroundColor(mSpoilerBackgroundColor);
+            spoilerTextView.setBorderColor(mSpoilerBackgroundColor);
+            spoilerTextView.setTextColor(mSpoilerTextColor);
+            nsfwTextView.setBackgroundColor(mNSFWBackgroundColor);
+            nsfwTextView.setBorderColor(mNSFWBackgroundColor);
+            nsfwTextView.setTextColor(mNSFWTextColor);
+            flairTextView.setBackgroundColor(mFlairBackgroundColor);
+            flairTextView.setBorderColor(mFlairBackgroundColor);
+            flairTextView.setTextColor(mFlairTextColor);
+            awardsTextView.setBackgroundColor(mAwardsBackgroundColor);
+            awardsTextView.setBorderColor(mAwardsBackgroundColor);
+            awardsTextView.setTextColor(mAwardsTextColor);
+            archivedImageView.setColorFilter(mArchivedIconTint, PorterDuff.Mode.SRC_IN);
+            lockedImageView.setColorFilter(mLockedIconTint, PorterDuff.Mode.SRC_IN);
+            crosspostImageView.setColorFilter(mCrosspostIconTint, PorterDuff.Mode.SRC_IN);
+            upvoteButton.setColorFilter(mPostIconAndInfoColor, android.graphics.PorterDuff.Mode.SRC_IN);
+            scoreTextView.setTextColor(mPostIconAndInfoColor);
+            downvoteButton.setColorFilter(mPostIconAndInfoColor, android.graphics.PorterDuff.Mode.SRC_IN);
+            commentsCountTextView.setTextColor(mPostIconAndInfoColor);
+            commentsCountTextView.setCompoundDrawablesWithIntrinsicBounds(mCommentIcon, null, null, null);
+            saveButton.setColorFilter(mPostIconAndInfoColor, android.graphics.PorterDuff.Mode.SRC_IN);
+            shareButton.setColorFilter(mPostIconAndInfoColor, android.graphics.PorterDuff.Mode.SRC_IN);
+
+            itemView.setOnClickListener(view -> {
+                int position = getBindingAdapterPosition();
+                if (position >= 0 && canStartActivity) {
+                    Post post = getItem(position);
+                    if (post != null) {
+                        openViewPostDetailActivity(post, getBindingAdapterPosition());
+                    }
+                }
+            });
+
+            itemView.setOnTouchListener((v, event) -> {
+                if (event.getActionMasked() == MotionEvent.ACTION_UP || event.getActionMasked() == MotionEvent.ACTION_CANCEL) {
+                    if (mFragment.isRecyclerViewItemSwipeable(PostBaseViewHolder.this)) {
+                        mActivity.unlockSwipeRightToGoBack();
+                    }
+                } else {
+                    if (mFragment.isRecyclerViewItemSwipeable(PostBaseViewHolder.this)) {
+                        mActivity.lockSwipeRightToGoBack();
+                    }
+                }
+                return false;
+            });
+
+            userTextView.setOnClickListener(view -> {
+                if (canStartActivity) {
+                    int position = getBindingAdapterPosition();
+                    if (position < 0) {
+                        return;
+                    }
+                    Post post = getItem(position);
+                    if (post == null || post.isAuthorDeleted()) {
+                        return;
+                    }
+                    canStartActivity = false;
+                    Intent intent = new Intent(mActivity, ViewUserDetailActivity.class);
+                    intent.putExtra(ViewUserDetailActivity.EXTRA_USER_NAME_KEY, post.getAuthor());
+                    mActivity.startActivity(intent);
+                }
+            });
+
+            if (mDisplaySubredditName) {
+                subredditTextView.setOnClickListener(view -> {
+                    int position = getBindingAdapterPosition();
+                    if (position < 0) {
+                        return;
+                    }
+                    Post post = getItem(position);
+                    if (post != null) {
+                        if (canStartActivity) {
+                            canStartActivity = false;
+                            Intent intent = new Intent(mActivity, ViewSubredditDetailActivity.class);
+                            intent.putExtra(ViewSubredditDetailActivity.EXTRA_SUBREDDIT_NAME_KEY,
+                                    post.getSubredditName());
+                            mActivity.startActivity(intent);
+                        }
+                    }
+                });
+
+                iconGifImageView.setOnClickListener(view -> subredditTextView.performClick());
+            } else {
+                subredditTextView.setOnClickListener(view -> {
+                    int position = getBindingAdapterPosition();
+                    if (position < 0) {
+                        return;
+                    }
+                    Post post = getItem(position);
+                    if (post != null) {
+                        if (canStartActivity) {
+                            canStartActivity = false;
+                            Intent intent = new Intent(mActivity, ViewSubredditDetailActivity.class);
+                            intent.putExtra(ViewSubredditDetailActivity.EXTRA_SUBREDDIT_NAME_KEY,
+                                    post.getSubredditName());
+                            mActivity.startActivity(intent);
+                        }
+                    }
+                });
+
+                iconGifImageView.setOnClickListener(view -> userTextView.performClick());
+            }
+
+            if (!(mActivity instanceof FilteredPostsActivity)) {
+                nsfwTextView.setOnClickListener(view -> {
+                    int position = getBindingAdapterPosition();
+                    if (position < 0) {
+                        return;
+                    }
+                    Post post = getItem(position);
+                    if (post != null) {
+                        mCallback.nsfwChipClicked();
+                    }
+                });
+                typeTextView.setOnClickListener(view -> {
+                    int position = getBindingAdapterPosition();
+                    if (position < 0) {
+                        return;
+                    }
+                    Post post = getItem(position);
+                    if (post != null) {
+                        mCallback.typeChipClicked(post.getPostType());
+                    }
+                });
+
+                flairTextView.setOnClickListener(view -> {
+                    int position = getBindingAdapterPosition();
+                    if (position < 0) {
+                        return;
+                    }
+                    Post post = getItem(position);
+                    if (post != null) {
+                        mCallback.flairChipClicked(post.getFlair());
+                    }
+                });
+            }
+
+            upvoteButton.setOnClickListener(view -> {
+                int position = getBindingAdapterPosition();
+                if (position < 0) {
+                    return;
+                }
+                Post post = getItem(position);
+                if (post != null) {
+                    if (mAccessToken == null) {
+                        Toast.makeText(mActivity, R.string.login_first, Toast.LENGTH_SHORT).show();
+                        return;
+                    }
+
+                    if (post.isArchived()) {
+                        Toast.makeText(mActivity, R.string.archived_post_vote_unavailable, Toast.LENGTH_SHORT).show();
+                        return;
+                    }
+
+                    ColorFilter previousUpvoteButtonColorFilter = upvoteButton.getColorFilter();
+                    ColorFilter previousDownvoteButtonColorFilter = downvoteButton.getColorFilter();
+                    int previousScoreTextViewColor = scoreTextView.getCurrentTextColor();
+
+                    int previousVoteType = post.getVoteType();
+                    String newVoteType;
+
+                    downvoteButton.setColorFilter(mPostIconAndInfoColor, android.graphics.PorterDuff.Mode.SRC_IN);
+
+                    if (previousVoteType != 1) {
+                        //Not upvoted before
+                        post.setVoteType(1);
+                        newVoteType = APIUtils.DIR_UPVOTE;
+                        upvoteButton
+                                .setColorFilter(mUpvotedColor, android.graphics.PorterDuff.Mode.SRC_IN);
+                        scoreTextView.setTextColor(mUpvotedColor);
+                    } else {
+                        //Upvoted before
+                        post.setVoteType(0);
+                        newVoteType = APIUtils.DIR_UNVOTE;
+                        upvoteButton.setColorFilter(mPostIconAndInfoColor, android.graphics.PorterDuff.Mode.SRC_IN);
+                        scoreTextView.setTextColor(mPostIconAndInfoColor);
+                    }
+
+                    if (!mHideTheNumberOfVotes) {
+                        scoreTextView.setText(Utils.getNVotes(mShowAbsoluteNumberOfVotes, post.getScore() + post.getVoteType()));
+                    }
+
+                    VoteThing.voteThing(mActivity, mOauthRetrofit, mAccessToken, new VoteThing.VoteThingListener() {
+                        @Override
+                        public void onVoteThingSuccess(int position1) {
+                            int currentPosition = getBindingAdapterPosition();
+                            if (newVoteType.equals(APIUtils.DIR_UPVOTE)) {
+                                post.setVoteType(1);
+                                if (currentPosition == position) {
+                                    upvoteButton.setColorFilter(mUpvotedColor, android.graphics.PorterDuff.Mode.SRC_IN);
+                                    scoreTextView.setTextColor(mUpvotedColor);
+                                }
+                            } else {
+                                post.setVoteType(0);
+                                if (currentPosition == position) {
+                                    upvoteButton.setColorFilter(mPostIconAndInfoColor, android.graphics.PorterDuff.Mode.SRC_IN);
+                                    scoreTextView.setTextColor(mPostIconAndInfoColor);
+                                }
+                            }
+
+                            if (currentPosition == position) {
+                                downvoteButton.setColorFilter(mPostIconAndInfoColor, android.graphics.PorterDuff.Mode.SRC_IN);
+                                if (!mHideTheNumberOfVotes) {
+                                    scoreTextView.setText(Utils.getNVotes(mShowAbsoluteNumberOfVotes, post.getScore() + post.getVoteType()));
+                                }
+                            }
+
+                            EventBus.getDefault().post(new PostUpdateEventToPostDetailFragment(post));
+                        }
+
+                        @Override
+                        public void onVoteThingFail(int position1) {
+                            Toast.makeText(mActivity, R.string.vote_failed, Toast.LENGTH_SHORT).show();
+                            post.setVoteType(previousVoteType);
+                            if (getBindingAdapterPosition() == position) {
+                                if (!mHideTheNumberOfVotes) {
+                                    scoreTextView.setText(Utils.getNVotes(mShowAbsoluteNumberOfVotes, post.getScore() + previousVoteType));
+                                }
+                                upvoteButton.setColorFilter(previousUpvoteButtonColorFilter);
+                                downvoteButton.setColorFilter(previousDownvoteButtonColorFilter);
+                                scoreTextView.setTextColor(previousScoreTextViewColor);
+                            }
+
+                            EventBus.getDefault().post(new PostUpdateEventToPostDetailFragment(post));
+                        }
+                    }, post.getFullName(), newVoteType, getBindingAdapterPosition());
+                }
+            });
+
+            downvoteButton.setOnClickListener(view -> {
+                int position = getBindingAdapterPosition();
+                if (position < 0) {
+                    return;
+                }
+                Post post = getItem(position);
+                if (post != null) {
+                    if (mAccessToken == null) {
+                        Toast.makeText(mActivity, R.string.login_first, Toast.LENGTH_SHORT).show();
+                        return;
+                    }
+
+                    if (post.isArchived()) {
+                        Toast.makeText(mActivity, R.string.archived_post_vote_unavailable, Toast.LENGTH_SHORT).show();
+                        return;
+                    }
+
+                    ColorFilter previousUpvoteButtonColorFilter = upvoteButton.getColorFilter();
+                    ColorFilter previousDownvoteButtonColorFilter = downvoteButton.getColorFilter();
+                    int previousScoreTextViewColor = scoreTextView.getCurrentTextColor();
+
+                    int previousVoteType = post.getVoteType();
+                    String newVoteType;
+
+                    upvoteButton.setColorFilter(mPostIconAndInfoColor, android.graphics.PorterDuff.Mode.SRC_IN);
+
+                    if (previousVoteType != -1) {
+                        //Not downvoted before
+                        post.setVoteType(-1);
+                        newVoteType = APIUtils.DIR_DOWNVOTE;
+                        downvoteButton
+                                .setColorFilter(mDownvotedColor, android.graphics.PorterDuff.Mode.SRC_IN);
+                        scoreTextView.setTextColor(mDownvotedColor);
+                    } else {
+                        //Downvoted before
+                        post.setVoteType(0);
+                        newVoteType = APIUtils.DIR_UNVOTE;
+                        downvoteButton.setColorFilter(mPostIconAndInfoColor, android.graphics.PorterDuff.Mode.SRC_IN);
+                        scoreTextView.setTextColor(mPostIconAndInfoColor);
+                    }
+
+                    if (!mHideTheNumberOfVotes) {
+                        scoreTextView.setText(Utils.getNVotes(mShowAbsoluteNumberOfVotes, post.getScore() + post.getVoteType()));
+                    }
+
+                    VoteThing.voteThing(mActivity, mOauthRetrofit, mAccessToken, new VoteThing.VoteThingListener() {
+                        @Override
+                        public void onVoteThingSuccess(int position1) {
+                            int currentPosition = getBindingAdapterPosition();
+                            if (newVoteType.equals(APIUtils.DIR_DOWNVOTE)) {
+                                post.setVoteType(-1);
+                                if (currentPosition == position) {
+                                    downvoteButton.setColorFilter(mDownvotedColor, android.graphics.PorterDuff.Mode.SRC_IN);
+                                    scoreTextView.setTextColor(mDownvotedColor);
+                                }
+                            } else {
+                                post.setVoteType(0);
+                                if (currentPosition == position) {
+                                    downvoteButton.setColorFilter(mPostIconAndInfoColor, android.graphics.PorterDuff.Mode.SRC_IN);
+                                    scoreTextView.setTextColor(mPostIconAndInfoColor);
+                                }
+                            }
+
+                            if (currentPosition == position) {
+                                upvoteButton.setColorFilter(mPostIconAndInfoColor, android.graphics.PorterDuff.Mode.SRC_IN);
+                                if (!mHideTheNumberOfVotes) {
+                                    scoreTextView.setText(Utils.getNVotes(mShowAbsoluteNumberOfVotes, post.getScore() + post.getVoteType()));
+                                }
+                            }
+
+                            EventBus.getDefault().post(new PostUpdateEventToPostDetailFragment(post));
+                        }
+
+                        @Override
+                        public void onVoteThingFail(int position1) {
+                            Toast.makeText(mActivity, R.string.vote_failed, Toast.LENGTH_SHORT).show();
+                            post.setVoteType(previousVoteType);
+                            if (getBindingAdapterPosition() == position) {
+                                if (!mHideTheNumberOfVotes) {
+                                    scoreTextView.setText(Utils.getNVotes(mShowAbsoluteNumberOfVotes, post.getScore() + previousVoteType));
+                                }
+                                upvoteButton.setColorFilter(previousUpvoteButtonColorFilter);
+                                downvoteButton.setColorFilter(previousDownvoteButtonColorFilter);
+                                scoreTextView.setTextColor(previousScoreTextViewColor);
+                            }
+
+                            EventBus.getDefault().post(new PostUpdateEventToPostDetailFragment(post));
+                        }
+                    }, post.getFullName(), newVoteType, getBindingAdapterPosition());
+                }
+            });
+
+            saveButton.setOnClickListener(view -> {
+                int position = getBindingAdapterPosition();
+                if (position < 0) {
+                    return;
+                }
+                Post post = getItem(position);
+                if (post != null) {
+                    if (mAccessToken == null) {
+                        Toast.makeText(mActivity, R.string.login_first, Toast.LENGTH_SHORT).show();
+                        return;
+                    }
+
+                    if (post.isSaved()) {
+                        saveButton.setImageResource(R.drawable.ic_bookmark_border_grey_24dp);
+                        SaveThing.unsaveThing(mOauthRetrofit, mAccessToken, post.getFullName(),
+                                new SaveThing.SaveThingListener() {
+                                    @Override
+                                    public void success() {
+                                        post.setSaved(false);
+                                        if (getBindingAdapterPosition() == position) {
+                                            saveButton.setImageResource(R.drawable.ic_bookmark_border_grey_24dp);
+                                        }
+                                        Toast.makeText(mActivity, R.string.post_unsaved_success, Toast.LENGTH_SHORT).show();
+                                        EventBus.getDefault().post(new PostUpdateEventToPostDetailFragment(post));
+                                    }
+
+                                    @Override
+                                    public void failed() {
+                                        post.setSaved(true);
+                                        if (getBindingAdapterPosition() == position) {
+                                            saveButton.setImageResource(R.drawable.ic_bookmark_grey_24dp);
+                                        }
+                                        Toast.makeText(mActivity, R.string.post_unsaved_failed, Toast.LENGTH_SHORT).show();
+                                        EventBus.getDefault().post(new PostUpdateEventToPostDetailFragment(post));
+                                    }
+                                });
+                    } else {
+                        saveButton.setImageResource(R.drawable.ic_bookmark_grey_24dp);
+                        SaveThing.saveThing(mOauthRetrofit, mAccessToken, post.getFullName(),
+                                new SaveThing.SaveThingListener() {
+                                    @Override
+                                    public void success() {
+                                        post.setSaved(true);
+                                        if (getBindingAdapterPosition() == position) {
+                                            saveButton.setImageResource(R.drawable.ic_bookmark_grey_24dp);
+                                        }
+                                        Toast.makeText(mActivity, R.string.post_saved_success, Toast.LENGTH_SHORT).show();
+                                        EventBus.getDefault().post(new PostUpdateEventToPostDetailFragment(post));
+                                    }
+
+                                    @Override
+                                    public void failed() {
+                                        post.setSaved(false);
+                                        if (getBindingAdapterPosition() == position) {
+                                            saveButton.setImageResource(R.drawable.ic_bookmark_border_grey_24dp);
+                                        }
+                                        Toast.makeText(mActivity, R.string.post_saved_failed, Toast.LENGTH_SHORT).show();
+                                        EventBus.getDefault().post(new PostUpdateEventToPostDetailFragment(post));
+                                    }
+                                });
+                    }
+                }
+            });
+
+            saveButton.setOnLongClickListener(view ->
+            {
+                int position = getBindingAdapterPosition();
+                if (position < 0) {
+                    return false;
+                }
+                Post post = getItem(position);
+                if (post != null) {
+                    LocalSave.RemovePost(post.getPermalink());
+                    return true;
+                }
+                return false;
+            });
+
+            shareButton.setOnClickListener(view -> {
+                int position = getBindingAdapterPosition();
+                if (position < 0) {
+                    return;
+                }
+                Post post = getItem(position);
+                if (post != null) {
+                    shareLink(post);
+                }
+            });
+
+            shareButton.setOnLongClickListener(view -> {
+                int position = getBindingAdapterPosition();
+                if (position < 0) {
+                    return false;
+                }
+                Post post = getItem(position);
+                if (post != null) {
+                    mActivity.copyLink(post.getPermalink());
+                    return true;
+                }
+                return false;
+            });
+        }
+
+        void setBaseView(AspectRatioGifImageView iconGifImageView,
+                         TextView subredditTextView,
+                         TextView userTextView,
+                         ImageView stickiedPostImageView,
+                         TextView postTimeTextView,
+                         TextView titleTextView,
+                         CustomTextView typeTextView,
+                         ImageView archivedImageView,
+                         ImageView lockedImageView,
+                         ImageView crosspostImageView,
+                         CustomTextView nsfwTextView,
+                         CustomTextView spoilerTextView,
+                         CustomTextView flairTextView,
+                         CustomTextView awardsTextView,
+                         ConstraintLayout bottomConstraintLayout,
+                         ImageView upvoteButton,
+                         TextView scoreTextView,
+                         ImageView downvoteButton,
+                         TextView commentsCountTextView,
+                         ImageView saveButton,
+                         ImageView shareButton, boolean itemViewIsNotCardView) {
+            this.itemViewIsNotCardView = itemViewIsNotCardView;
+
+            setBaseView(iconGifImageView, subredditTextView, userTextView, stickiedPostImageView, postTimeTextView,
+                    titleTextView, typeTextView, archivedImageView, lockedImageView, crosspostImageView,
+                    nsfwTextView, spoilerTextView, flairTextView, awardsTextView, bottomConstraintLayout,
+                    upvoteButton, scoreTextView, downvoteButton, commentsCountTextView, saveButton, shareButton);
+        }
+    }
+
+    class PostVideoAutoplayViewHolder extends PostBaseViewHolder implements ToroPlayer {
+        @BindView(R.id.icon_gif_image_view_item_post_video_type_autoplay)
+        AspectRatioGifImageView iconGifImageView;
+        @BindView(R.id.subreddit_name_text_view_item_post_video_type_autoplay)
+        TextView subredditTextView;
+        @BindView(R.id.user_text_view_item_post_video_type_autoplay)
+        TextView userTextView;
+        @BindView(R.id.stickied_post_image_view_item_post_video_type_autoplay)
+        ImageView stickiedPostImageView;
+        @BindView(R.id.post_time_text_view_item_post_video_type_autoplay)
+        TextView postTimeTextView;
+        @BindView(R.id.title_text_view_item_post_video_type_autoplay)
+        TextView titleTextView;
+        @BindView(R.id.type_text_view_item_post_video_type_autoplay)
+        CustomTextView typeTextView;
+        @BindView(R.id.archived_image_view_item_post_video_type_autoplay)
+        ImageView archivedImageView;
+        @BindView(R.id.locked_image_view_item_post_video_type_autoplay)
+        ImageView lockedImageView;
+        @BindView(R.id.crosspost_image_view_item_post_video_type_autoplay)
+        ImageView crosspostImageView;
+        @BindView(R.id.nsfw_text_view_item_post_video_type_autoplay)
+        CustomTextView nsfwTextView;
+        @BindView(R.id.spoiler_custom_text_view_item_post_video_type_autoplay)
+        CustomTextView spoilerTextView;
+        @BindView(R.id.flair_custom_text_view_item_post_video_type_autoplay)
+        CustomTextView flairTextView;
+        @BindView(R.id.awards_text_view_item_post_video_type_autoplay)
+        CustomTextView awardsTextView;
+        @BindView(R.id.aspect_ratio_frame_layout_item_post_video_type_autoplay)
+        AspectRatioFrameLayout aspectRatioFrameLayout;
+        @BindView(R.id.preview_image_view_item_post_video_type_autoplay)
+        GifImageView previewImageView;
+        @BindView(R.id.error_loading_gfycat_image_view_item_post_video_type_autoplay)
+        ImageView errorLoadingGfycatImageView;
+        @BindView(R.id.player_view_item_post_video_type_autoplay)
+        PlayerView videoPlayer;
+        @BindView(R.id.mute_exo_playback_control_view)
+        ImageView muteButton;
+        @BindView(R.id.fullscreen_exo_playback_control_view)
+        ImageView fullscreenButton;
+        @BindView(R.id.exo_pause)
+        ImageView pauseButton;
+        @BindView(R.id.exo_play)
+        ImageView playButton;
+        @BindView(R.id.exo_progress)
+        DefaultTimeBar progressBar;
+        @BindView(R.id.bottom_constraint_layout_item_post_video_type_autoplay)
+        ConstraintLayout bottomConstraintLayout;
+        @BindView(R.id.plus_button_item_post_video_type_autoplay)
+        ImageView upvoteButton;
+        @BindView(R.id.score_text_view_item_post_video_type_autoplay)
+        TextView scoreTextView;
+        @BindView(R.id.minus_button_item_post_video_type_autoplay)
+        ImageView downvoteButton;
+        @BindView(R.id.comments_count_item_post_video_type_autoplay)
+        TextView commentsCountTextView;
+        @BindView(R.id.save_button_item_post_video_type_autoplay)
+        ImageView saveButton;
+        @BindView(R.id.share_button_item_post_video_type_autoplay)
+        ImageView shareButton;
+
+        @Nullable
+        Container container;
+        @Nullable
+        ExoPlayerViewHelper helper;
+        private Uri mediaUri;
+        private float volume;
+        public Call<String> fetchGfycatOrStreamableVideoCall;
+        private boolean isManuallyPaused;
+
+        PostVideoAutoplayViewHolder(View itemView) {
+            super(itemView);
+            ButterKnife.bind(this, itemView);
+            setBaseView(
+                    iconGifImageView,
+                    subredditTextView,
+                    userTextView,
+                    stickiedPostImageView,
+                    postTimeTextView,
+                    titleTextView,
+                    typeTextView,
+                    archivedImageView,
+                    lockedImageView,
+                    crosspostImageView,
+                    nsfwTextView,
+                    spoilerTextView,
+                    flairTextView,
+                    awardsTextView,
+                    bottomConstraintLayout,
+                    upvoteButton,
+                    scoreTextView,
+                    downvoteButton,
+                    commentsCountTextView,
+                    saveButton,
+                    shareButton);
+
+            aspectRatioFrameLayout.setOnClickListener(null);
+
+            muteButton.setOnClickListener(view -> {
+                if (helper != null) {
+                    if (helper.getVolume() != 0) {
+                        muteButton.setImageDrawable(ContextCompat.getDrawable(mActivity, R.drawable.ic_mute_white_rounded_24dp));
+                        helper.setVolume(0f);
+                        volume = 0f;
+                        mFragment.videoAutoplayChangeMutingOption(true);
+                    } else {
+                        muteButton.setImageDrawable(ContextCompat.getDrawable(mActivity, R.drawable.ic_unmute_white_rounded_24dp));
+                        helper.setVolume(1f);
+                        volume = 1f;
+                        mFragment.videoAutoplayChangeMutingOption(false);
+                    }
+                }
+            });
+
+            fullscreenButton.setOnClickListener(view -> {
+                if (canStartActivity) {
+                    canStartActivity = false;
+                    int position = getBindingAdapterPosition();
+                    if (position < 0) {
+                        return;
+                    }
+                    Post post = getItem(position);
+                    if (post != null) {
+                        Intent intent = new Intent(mActivity, ViewVideoActivity.class);
+                        if (post.isImgur()) {
+                            intent.setData(Uri.parse(post.getVideoUrl()));
+                            intent.putExtra(ViewVideoActivity.EXTRA_VIDEO_TYPE, ViewVideoActivity.VIDEO_TYPE_IMGUR);
+                        } else if (post.isGfycat()) {
+                            intent.putExtra(ViewVideoActivity.EXTRA_VIDEO_TYPE, ViewVideoActivity.VIDEO_TYPE_GFYCAT);
+                            intent.putExtra(ViewVideoActivity.EXTRA_GFYCAT_ID, post.getGfycatId());
+                            if (post.isLoadGfycatOrStreamableVideoSuccess()) {
+                                intent.setData(Uri.parse(post.getVideoUrl()));
+                                intent.putExtra(ViewVideoActivity.EXTRA_VIDEO_DOWNLOAD_URL, post.getVideoDownloadUrl());
+                            }
+                        } else if (post.isRedgifs()) {
+                            intent.putExtra(ViewVideoActivity.EXTRA_VIDEO_TYPE, ViewVideoActivity.VIDEO_TYPE_REDGIFS);
+                            intent.putExtra(ViewVideoActivity.EXTRA_GFYCAT_ID, post.getGfycatId());
+                            if (post.isLoadGfycatOrStreamableVideoSuccess()) {
+                                intent.setData(Uri.parse(post.getVideoUrl()));
+                                intent.putExtra(ViewVideoActivity.EXTRA_VIDEO_DOWNLOAD_URL, post.getVideoDownloadUrl());
+                            }
+                        } else if (post.isStreamable()) {
+                            intent.putExtra(ViewVideoActivity.EXTRA_VIDEO_TYPE, ViewVideoActivity.VIDEO_TYPE_STREAMABLE);
+                            intent.putExtra(ViewVideoActivity.EXTRA_STREAMABLE_SHORT_CODE, post.getStreamableShortCode());
+                        } else {
+                            intent.setData(Uri.parse(post.getVideoUrl()));
+                            intent.putExtra(ViewVideoActivity.EXTRA_VIDEO_DOWNLOAD_URL, post.getVideoDownloadUrl());
+                            intent.putExtra(ViewVideoActivity.EXTRA_SUBREDDIT, post.getSubredditName());
+                            intent.putExtra(ViewVideoActivity.EXTRA_ID, post.getId());
+                        }
+                        intent.putExtra(ViewVideoActivity.EXTRA_POST_TITLE, post.getTitle());
+                        if (helper != null) {
+                            intent.putExtra(ViewVideoActivity.EXTRA_PROGRESS_SECONDS, helper.getLatestPlaybackInfo().getResumePosition());
+                        }
+                        intent.putExtra(ViewVideoActivity.EXTRA_IS_NSFW, post.isNSFW());
+                        mActivity.startActivity(intent);
+                    }
+                }
+            });
+
+            pauseButton.setOnClickListener(view -> {
+                pause();
+                isManuallyPaused = true;
+                savePlaybackInfo(getPlayerOrder(), getCurrentPlaybackInfo());
+            });
+
+            playButton.setOnClickListener(view -> {
+                isManuallyPaused = false;
+                play();
+            });
+
+            progressBar.addListener(new TimeBar.OnScrubListener() {
+                @Override
+                public void onScrubStart(TimeBar timeBar, long position) {
+
+                }
+
+                @Override
+                public void onScrubMove(TimeBar timeBar, long position) {
+
+                }
+
+                @Override
+                public void onScrubStop(TimeBar timeBar, long position, boolean canceled) {
+                    if (!canceled) {
+                        savePlaybackInfo(getPlayerOrder(), getCurrentPlaybackInfo());
+                    }
+                }
+            });
+
+            previewImageView.setOnClickListener(view -> fullscreenButton.performClick());
+
+            videoPlayer.setOnClickListener(view -> {
+                if (mEasierToWatchInFullScreen && videoPlayer.isControllerVisible()) {
+                    fullscreenButton.performClick();
+                }
+            });
+        }
+
+        void bindVideoUri(Uri videoUri) {
+            mediaUri = videoUri;
+        }
+
+        void setVolume(float volume) {
+            this.volume = volume;
+        }
+
+        void resetVolume() {
+            volume = 0f;
+        }
+
+        private void savePlaybackInfo(int order, @Nullable PlaybackInfo playbackInfo) {
+            if (container != null) container.savePlaybackInfo(order, playbackInfo);
+        }
+
+        @NonNull
+        @Override
+        public View getPlayerView() {
+            return videoPlayer;
+        }
+
+        @NonNull
+        @Override
+        public PlaybackInfo getCurrentPlaybackInfo() {
+            return helper != null && mediaUri != null ? helper.getLatestPlaybackInfo() : new PlaybackInfo();
+        }
+
+        @Override
+        public void initialize(@NonNull Container container, @NonNull PlaybackInfo playbackInfo) {
+            if (mediaUri == null) {
+                return;
+            }
+            if (this.container == null) {
+                this.container = container;
+            }
+            if (helper == null) {
+                helper = new ExoPlayerViewHelper(this, mediaUri, null, mExoCreator);
+                helper.addEventListener(new Playable.DefaultEventListener() {
+                    @Override
+                    public void onTracksChanged(@NonNull Tracks tracks) {
+                        ImmutableList<Tracks.Group> trackGroups = tracks.getGroups();
+                        if (!trackGroups.isEmpty()) {
+                            for (int i = 0; i < trackGroups.size(); i++) {
+                                String mimeType = trackGroups.get(i).getTrackFormat(0).sampleMimeType;
+                                if (mimeType != null && mimeType.contains("audio")) {
+                                    if (mFragment.getMasterMutingOption() != null) {
+                                        volume = mFragment.getMasterMutingOption() ? 0f : 1f;
+                                    }
+                                    helper.setVolume(volume);
+                                    muteButton.setVisibility(View.VISIBLE);
+                                    if (volume != 0f) {
+                                        muteButton.setImageDrawable(ContextCompat.getDrawable(mActivity, R.drawable.ic_unmute_white_rounded_24dp));
+                                    } else {
+                                        muteButton.setImageDrawable(ContextCompat.getDrawable(mActivity, R.drawable.ic_mute_white_rounded_24dp));
+                                    }
+                                    break;
+                                }
+                            }
+                        } else {
+                            muteButton.setVisibility(View.GONE);
+                        }
+                    }
+
+                    @Override
+                    public void onRenderedFirstFrame() {
+                        mGlide.clear(previewImageView);
+                        previewImageView.setVisibility(View.GONE);
+                    }
+                });
+            }
+            helper.initialize(container, playbackInfo);
+        }
+
+        @Override
+        public void play() {
+            if (helper != null && mediaUri != null) {
+                if (!isPlaying() && isManuallyPaused) {
+                    helper.play();
+                    pause();
+                    helper.setVolume(volume);
+                } else {
+                    helper.play();
+                }
+            }
+        }
+
+        @Override
+        public void pause() {
+            if (helper != null) helper.pause();
+        }
+
+        @Override
+        public boolean isPlaying() {
+            return helper != null && helper.isPlaying();
+        }
+
+        @Override
+        public void release() {
+            if (helper != null) {
+                helper.release();
+                helper = null;
+            }
+            isManuallyPaused = false;
+            container = null;
+        }
+
+        @Override
+        public boolean wantsToPlay() {
+            return canPlayVideo && mediaUri != null && ToroUtil.visibleAreaOffset(this, itemView.getParent()) >= mStartAutoplayVisibleAreaOffset;
+        }
+
+        @Override
+        public int getPlayerOrder() {
+            return getBindingAdapterPosition();
+        }
+    }
+
+    class PostWithPreviewTypeViewHolder extends PostBaseViewHolder {
+        @BindView(R.id.icon_gif_image_view_item_post_with_preview)
+        AspectRatioGifImageView iconGifImageView;
+        @BindView(R.id.subreddit_name_text_view_item_post_with_preview)
+        TextView subredditTextView;
+        @BindView(R.id.user_text_view_item_post_with_preview)
+        TextView userTextView;
+        @BindView(R.id.stickied_post_image_view_item_post_with_preview)
+        ImageView stickiedPostImageView;
+        @BindView(R.id.post_time_text_view_item_post_with_preview)
+        TextView postTimeTextView;
+        @BindView(R.id.title_text_view_item_post_with_preview)
+        TextView titleTextView;
+        @BindView(R.id.type_text_view_item_post_with_preview)
+        CustomTextView typeTextView;
+        @BindView(R.id.archived_image_view_item_post_with_preview)
+        ImageView archivedImageView;
+        @BindView(R.id.locked_image_view_item_post_with_preview)
+        ImageView lockedImageView;
+        @BindView(R.id.crosspost_image_view_item_post_with_preview)
+        ImageView crosspostImageView;
+        @BindView(R.id.nsfw_text_view_item_post_with_preview)
+        CustomTextView nsfwTextView;
+        @BindView(R.id.spoiler_custom_text_view_item_post_with_preview)
+        CustomTextView spoilerTextView;
+        @BindView(R.id.flair_custom_text_view_item_post_with_preview)
+        CustomTextView flairTextView;
+        @BindView(R.id.awards_text_view_item_post_with_preview)
+        CustomTextView awardsTextView;
+        @BindView(R.id.link_text_view_item_post_with_preview)
+        TextView linkTextView;
+        @BindView(R.id.video_or_gif_indicator_image_view_item_post_with_preview)
+        ImageView videoOrGifIndicatorImageView;
+        @BindView(R.id.image_wrapper_relative_layout_item_post_with_preview)
+        FrameLayout imageWrapperRelativeLayout;
+        @BindView(R.id.progress_bar_item_post_with_preview)
+        ProgressBar progressBar;
+        @BindView(R.id.image_view_item_post_with_preview)
+        AspectRatioGifImageView imageView;
+        @BindView(R.id.load_image_error_text_view_item_post_with_preview)
+        TextView errorTextView;
+        @BindView(R.id.image_view_no_preview_gallery_item_post_with_preview)
+        ImageView noPreviewLinkImageView;
+        @BindView(R.id.bottom_constraint_layout_item_post_with_preview)
+        ConstraintLayout bottomConstraintLayout;
+        @BindView(R.id.plus_button_item_post_with_preview)
+        ImageView upvoteButton;
+        @BindView(R.id.score_text_view_item_post_with_preview)
+        TextView scoreTextView;
+        @BindView(R.id.minus_button_item_post_with_preview)
+        ImageView downvoteButton;
+        @BindView(R.id.comments_count_item_post_with_preview)
+        TextView commentsCountTextView;
+        @BindView(R.id.save_button_item_post_with_preview)
+        ImageView saveButton;
+        @BindView(R.id.share_button_item_post_with_preview)
+        ImageView shareButton;
+        RequestListener<Drawable> glideRequestListener;
+
+        PostWithPreviewTypeViewHolder(View itemView) {
+            super(itemView);
+            ButterKnife.bind(this, itemView);
+            setBaseView(
+                    iconGifImageView,
+                    subredditTextView,
+                    userTextView,
+                    stickiedPostImageView,
+                    postTimeTextView,
+                    titleTextView,
+                    typeTextView,
+                    archivedImageView,
+                    lockedImageView,
+                    crosspostImageView,
+                    nsfwTextView,
+                    spoilerTextView,
+                    flairTextView,
+                    awardsTextView,
+                    bottomConstraintLayout,
+                    upvoteButton,
+                    scoreTextView,
+                    downvoteButton,
+                    commentsCountTextView,
+                    saveButton,
+                    shareButton);
+
+            if (mActivity.typeface != null) {
+                linkTextView.setTypeface(mActivity.typeface);
+                errorTextView.setTypeface(mActivity.typeface);
+            }
+            linkTextView.setTextColor(mSecondaryTextColor);
+            noPreviewLinkImageView.setBackgroundColor(mNoPreviewPostTypeBackgroundColor);
+            noPreviewLinkImageView.setColorFilter(mNoPreviewPostTypeIconTint, android.graphics.PorterDuff.Mode.SRC_IN);
+            progressBar.setIndeterminateTintList(ColorStateList.valueOf(mColorAccent));
+            videoOrGifIndicatorImageView.setColorFilter(mMediaIndicatorIconTint, PorterDuff.Mode.SRC_IN);
+            videoOrGifIndicatorImageView.setBackgroundTintList(ColorStateList.valueOf(mMediaIndicatorBackgroundColor));
+            errorTextView.setTextColor(mPrimaryTextColor);
+
+            imageView.setOnClickListener(view -> {
+                int position = getBindingAdapterPosition();
+                if (position < 0) {
+                    return;
+                }
+                Post post = getItem(position);
+                if (post != null) {
+                    openMedia(post);
+                }
+            });
+
+            errorTextView.setOnClickListener(view -> {
+                progressBar.setVisibility(View.VISIBLE);
+                errorTextView.setVisibility(View.GONE);
+                loadImage(this);
+            });
+
+            noPreviewLinkImageView.setOnClickListener(view -> {
+                imageView.performClick();
+            });
+
+            glideRequestListener = new RequestListener<>() {
+                @Override
+                public boolean onLoadFailed(@Nullable GlideException e, Object model, Target<Drawable> target, boolean isFirstResource) {
+                    progressBar.setVisibility(View.GONE);
+                    errorTextView.setVisibility(View.VISIBLE);
+                    return false;
+                }
+
+                @Override
+                public boolean onResourceReady(Drawable resource, Object model, Target<Drawable> target, DataSource dataSource, boolean isFirstResource) {
+                    errorTextView.setVisibility(View.GONE);
+                    progressBar.setVisibility(View.GONE);
+                    return false;
+                }
+            };
+        }
+    }
+
+    public class PostBaseGalleryTypeViewHolder extends PostBaseViewHolder {
+        FrameLayout frameLayout;
+        RecyclerView galleryRecyclerView;
+        CustomTextView imageIndexTextView;
+        ImageView noPreviewImageView;
+
+        PostGalleryTypeImageRecyclerViewAdapter adapter;
+        private boolean swipeLocked;
+
+        PostBaseGalleryTypeViewHolder(View rootView,
+                                      AspectRatioGifImageView iconGifImageView,
+                                      TextView subredditTextView,
+                                      TextView userTextView,
+                                      ImageView stickiedPostImageView,
+                                      TextView postTimeTextView,
+                                      TextView titleTextView,
+                                      CustomTextView typeTextView,
+                                      ImageView archivedImageView,
+                                      ImageView lockedImageView,
+                                      ImageView crosspostImageView,
+                                      CustomTextView nsfwTextView,
+                                      CustomTextView spoilerTextView,
+                                      CustomTextView flairTextView,
+                                      CustomTextView awardsTextView,
+                                      FrameLayout frameLayout,
+                                      RecyclerView galleryRecyclerView,
+                                      CustomTextView imageIndexTextView,
+                                      ImageView noPreviewImageView,
+                                      ConstraintLayout bottomConstraintLayout,
+                                      ImageView upvoteButton,
+                                      TextView scoreTextView,
+                                      ImageView downvoteButton,
+                                      TextView commentsCountTextView,
+                                      ImageView saveButton,
+                                      ImageView shareButton,
+                                      boolean itemViewIsNotCardView) {
+            super(rootView);
+            setBaseView(
+                    iconGifImageView,
+                    subredditTextView,
+                    userTextView,
+                    stickiedPostImageView,
+                    postTimeTextView,
+                    titleTextView,
+                    typeTextView,
+                    archivedImageView,
+                    lockedImageView,
+                    crosspostImageView,
+                    nsfwTextView,
+                    spoilerTextView,
+                    flairTextView,
+                    awardsTextView,
+                    bottomConstraintLayout,
+                    upvoteButton,
+                    scoreTextView,
+                    downvoteButton,
+                    commentsCountTextView,
+                    saveButton,
+                    shareButton,
+                    itemViewIsNotCardView);
+
+            this.frameLayout = frameLayout;
+            this.galleryRecyclerView = galleryRecyclerView;
+            this.imageIndexTextView = imageIndexTextView;
+            this.noPreviewImageView = noPreviewImageView;
+
+            imageIndexTextView.setTextColor(mMediaIndicatorIconTint);
+            imageIndexTextView.setBackgroundColor(mMediaIndicatorBackgroundColor);
+            imageIndexTextView.setBorderColor(mMediaIndicatorBackgroundColor);
+            if (mActivity.typeface != null) {
+                imageIndexTextView.setTypeface(mActivity.typeface);
+            }
+
+            noPreviewImageView.setBackgroundColor(mNoPreviewPostTypeBackgroundColor);
+            noPreviewImageView.setColorFilter(mNoPreviewPostTypeIconTint, android.graphics.PorterDuff.Mode.SRC_IN);
+
+            adapter = new PostGalleryTypeImageRecyclerViewAdapter(mGlide, mActivity.typeface,
+                    mSaveMemoryCenterInsideDownsampleStrategy, mColorAccent, mPrimaryTextColor, mScale);
+            galleryRecyclerView.setOnTouchListener((v, motionEvent) -> {
+                if (motionEvent.getActionMasked() == MotionEvent.ACTION_UP || motionEvent.getActionMasked() == MotionEvent.ACTION_CANCEL) {
+                    if (mActivity.mSliderPanel != null) {
+                        mActivity.mSliderPanel.requestDisallowInterceptTouchEvent(false);
+                    }
+
+                    if (mActivity.mViewPager2 != null) {
+                        mActivity.mViewPager2.setUserInputEnabled(true);
+                    }
+                    mActivity.unlockSwipeRightToGoBack();
+                    swipeLocked = false;
+                } else {
+                    if (mActivity.mSliderPanel != null) {
+                        mActivity.mSliderPanel.requestDisallowInterceptTouchEvent(true);
+                    }
+                    if (mActivity.mViewPager2 != null) {
+                        mActivity.mViewPager2.setUserInputEnabled(false);
+                    }
+                    mActivity.lockSwipeRightToGoBack();
+                    swipeLocked = true;
+                }
+
+                return false;
+            });
+            galleryRecyclerView.setAdapter(adapter);
+            new PagerSnapHelper().attachToRecyclerView(galleryRecyclerView);
+            galleryRecyclerView.setRecycledViewPool(mGalleryRecycledViewPool);
+            LinearLayoutManagerBugFixed layoutManager = new LinearLayoutManagerBugFixed(mActivity, RecyclerView.HORIZONTAL, false);
+            galleryRecyclerView.setLayoutManager(layoutManager);
+            galleryRecyclerView.addOnScrollListener(new RecyclerView.OnScrollListener() {
+                @Override
+                public void onScrollStateChanged(@NonNull RecyclerView recyclerView, int newState) {
+                    super.onScrollStateChanged(recyclerView, newState);
+                }
+
+                @Override
+                public void onScrolled(@NonNull RecyclerView recyclerView, int dx, int dy) {
+                    super.onScrolled(recyclerView, dx, dy);
+                    imageIndexTextView.setText(mActivity.getString(R.string.image_index_in_gallery, layoutManager.findFirstVisibleItemPosition() + 1, post.getGallery().size()));
+                }
+            });
+            galleryRecyclerView.addOnItemTouchListener(new RecyclerView.OnItemTouchListener() {
+                private float downX;
+                private float downY;
+                private boolean dragged;
+                private final int minTouchSlop = ViewConfiguration.get(mActivity).getScaledTouchSlop();
+
+                @Override
+                public boolean onInterceptTouchEvent(@NonNull RecyclerView rv, @NonNull MotionEvent e) {
+                    int action = e.getAction();
+                    switch (action) {
+                        case MotionEvent.ACTION_DOWN:
+                            downX = e.getRawX();
+                            downY = e.getRawY();
+                            break;
+                        case MotionEvent.ACTION_MOVE:
+                            if(Math.abs(e.getRawX() - downX) > minTouchSlop || Math.abs(e.getRawY() - downY) > minTouchSlop) {
+                                dragged = true;
+                            }
+                            break;
+                        case MotionEvent.ACTION_UP:
+                            if (!dragged) {
+                                int position = getBindingAdapterPosition();
+                                if (position >= 0) {
+                                    if (post != null) {
+                                        openMedia(post, layoutManager.findFirstVisibleItemPosition());
+                                    }
+                                }
+                            }
+
+                            downX = 0;
+                            downY = 0;
+                            dragged = false;
+                    }
+                    return false;
+                }
+
+                @Override
+                public void onTouchEvent(@NonNull RecyclerView rv, @NonNull MotionEvent e) {
+
+                }
+
+                @Override
+                public void onRequestDisallowInterceptTouchEvent(boolean disallowIntercept) {
+
+                }
+            });
+
+            noPreviewImageView.setOnClickListener(view -> {
+                int position = getBindingAdapterPosition();
+                if (position < 0) {
+                    return;
+                }
+                if (post != null) {
+                    openMedia(post, 0);
+                }
+            });
+        }
+
+        public boolean isSwipeLocked() {
+            return swipeLocked;
+        }
+    }
+
+    public class PostGalleryTypeViewHolder extends PostBaseGalleryTypeViewHolder {
+
+        PostGalleryTypeViewHolder(ItemPostGalleryTypeBinding binding) {
+            super(binding.getRoot(),
+                    binding.iconGifImageViewItemPostGalleryType,
+                    binding.subredditNameTextViewItemPostGalleryType,
+                    binding.userTextViewItemPostGalleryType,
+                    binding.stickiedPostImageViewItemPostGalleryType,
+                    binding.postTimeTextViewItemPostGalleryType,
+                    binding.titleTextViewItemPostGalleryType,
+                    binding.typeTextViewItemPostGalleryType,
+                    binding.archivedImageViewItemPostGalleryType,
+                    binding.lockedImageViewItemPostGalleryType,
+                    binding.crosspostImageViewItemPostGalleryType,
+                    binding.nsfwTextViewItemPostGalleryType,
+                    binding.spoilerTextViewItemPostGalleryType,
+                    binding.flairTextViewItemPostGalleryType,
+                    binding.awardsTextViewItemPostGalleryType,
+                    binding.galleryFrameLayoutItemPostGalleryType,
+                    binding.galleryRecyclerViewItemPostGalleryType,
+                    binding.imageIndexTextViewItemPostGalleryType,
+                    binding.noPreviewImageViewItemPostGalleryType,
+                    binding.bottomConstraintLayoutItemPostGalleryType,
+                    binding.upvoteButtonItemPostGalleryType,
+                    binding.scoreTextViewItemPostGalleryType,
+                    binding.downvoteButtonItemPostGalleryType,
+                    binding.commentsCountTextViewItemPostGalleryType,
+                    binding.saveButtonItemPostGalleryType,
+                    binding.shareButtonItemPostGalleryType,
+                    false);
+        }
+    }
+
+    class PostTextTypeViewHolder extends PostBaseViewHolder {
+        @BindView(R.id.icon_gif_image_view_item_post_text_type)
+        AspectRatioGifImageView iconGifImageView;
+        @BindView(R.id.subreddit_name_text_view_item_post_text_type)
+        TextView subredditTextView;
+        @BindView(R.id.user_text_view_item_post_text_type)
+        TextView userTextView;
+        @BindView(R.id.stickied_post_image_view_item_post_text_type)
+        ImageView stickiedPostImageView;
+        @BindView(R.id.post_time_text_view_item_post_text_type)
+        TextView postTimeTextView;
+        @BindView(R.id.title_text_view_item_post_text_type)
+        TextView titleTextView;
+        @BindView(R.id.type_text_view_item_post_text_type)
+        CustomTextView typeTextView;
+        @BindView(R.id.archived_image_view_item_post_text_type)
+        ImageView archivedImageView;
+        @BindView(R.id.locked_image_view_item_post_text_type)
+        ImageView lockedImageView;
+        @BindView(R.id.crosspost_image_view_item_post_text_type)
+        ImageView crosspostImageView;
+        @BindView(R.id.nsfw_text_view_item_post_text_type)
+        CustomTextView nsfwTextView;
+        @BindView(R.id.spoiler_custom_text_view_item_post_text_type)
+        CustomTextView spoilerTextView;
+        @BindView(R.id.flair_custom_text_view_item_post_text_type)
+        CustomTextView flairTextView;
+        @BindView(R.id.awards_text_view_item_post_text_type)
+        CustomTextView awardsTextView;
+        @BindView(R.id.content_text_view_item_post_text_type)
+        TextView contentTextView;
+        @BindView(R.id.bottom_constraint_layout_item_post_text_type)
+        ConstraintLayout bottomConstraintLayout;
+        @BindView(R.id.plus_button_item_post_text_type)
+        ImageView upvoteButton;
+        @BindView(R.id.score_text_view_item_post_text_type)
+        TextView scoreTextView;
+        @BindView(R.id.minus_button_item_post_text_type)
+        ImageView downvoteButton;
+        @BindView(R.id.comments_count_item_post_text_type)
+        TextView commentsCountTextView;
+        @BindView(R.id.save_button_item_post_text_type)
+        ImageView saveButton;
+        @BindView(R.id.share_button_item_post_text_type)
+        ImageView shareButton;
+
+        PostTextTypeViewHolder(View itemView) {
+            super(itemView);
+            ButterKnife.bind(this, itemView);
+            setBaseView(
+                    iconGifImageView,
+                    subredditTextView,
+                    userTextView,
+                    stickiedPostImageView,
+                    postTimeTextView,
+                    titleTextView,
+                    typeTextView,
+                    archivedImageView,
+                    lockedImageView,
+                    crosspostImageView,
+                    nsfwTextView,
+                    spoilerTextView,
+                    flairTextView,
+                    awardsTextView,
+                    bottomConstraintLayout,
+                    upvoteButton,
+                    scoreTextView,
+                    downvoteButton,
+                    commentsCountTextView,
+                    saveButton,
+                    shareButton);
+
+            if (mActivity.contentTypeface != null) {
+                contentTextView.setTypeface(mActivity.titleTypeface);
+            }
+            contentTextView.setTextColor(mPostContentColor);
+        }
+    }
+
+    public class PostCompactBaseViewHolder extends RecyclerView.ViewHolder {
+        AspectRatioGifImageView iconGifImageView;
+        TextView nameTextView;
+        ImageView stickiedPostImageView;
+        TextView postTimeTextView;
+        ConstraintLayout titleAndImageConstraintLayout;
+        TextView titleTextView;
+        CustomTextView typeTextView;
+        ImageView archivedImageView;
+        ImageView lockedImageView;
+        ImageView crosspostImageView;
+        CustomTextView nsfwTextView;
+        CustomTextView spoilerTextView;
+        CustomTextView flairTextView;
+        CustomTextView awardsTextView;
+        TextView linkTextView;
+        RelativeLayout relativeLayout;
+        ProgressBar progressBar;
+        ImageView imageView;
+        ImageView playButtonImageView;
+        FrameLayout noPreviewPostImageFrameLayout;
+        ImageView noPreviewPostImageView;
+        Barrier imageBarrier;
+        ConstraintLayout bottomConstraintLayout;
+        ImageView upvoteButton;
+        TextView scoreTextView;
+        ImageView downvoteButton;
+        TextView commentsCountTextView;
+        ImageView saveButton;
+        ImageView shareButton;
+        View divider;
+        RequestListener<Drawable> requestListener;
+        Post post;
+
+        PostCompactBaseViewHolder(View itemView) {
+            super(itemView);
+        }
+
+        void setBaseView(AspectRatioGifImageView iconGifImageView,
+                         TextView nameTextView, ImageView stickiedPostImageView,
+                         TextView postTimeTextView, ConstraintLayout titleAndImageConstraintLayout,
+                         TextView titleTextView, CustomTextView typeTextView,
+                         ImageView archivedImageView, ImageView lockedImageView,
+                         ImageView crosspostImageView, CustomTextView nsfwTextView,
+                         CustomTextView spoilerTextView, CustomTextView flairTextView,
+                         CustomTextView awardsTextView, TextView linkTextView,
+                         RelativeLayout relativeLayout, ProgressBar progressBar,
+                         ImageView imageView, ImageView playButtonImageView,
+                         FrameLayout noPreviewLinkImageFrameLayout,
+                         ImageView noPreviewLinkImageView, Barrier imageBarrier,
+                         ConstraintLayout bottomConstraintLayout, ImageView upvoteButton,
+                         TextView scoreTextView, ImageView downvoteButton,
+                         TextView commentsCountTextView, ImageView saveButton,
+                         ImageView shareButton, View divider) {
+            this.iconGifImageView = iconGifImageView;
+            this.nameTextView = nameTextView;
+            this.stickiedPostImageView = stickiedPostImageView;
+            this.postTimeTextView = postTimeTextView;
+            this.titleAndImageConstraintLayout = titleAndImageConstraintLayout;
+            this.titleTextView = titleTextView;
+            this.typeTextView = typeTextView;
+            this.archivedImageView = archivedImageView;
+            this.lockedImageView = lockedImageView;
+            this.crosspostImageView = crosspostImageView;
+            this.nsfwTextView = nsfwTextView;
+            this.spoilerTextView = spoilerTextView;
+            this.flairTextView = flairTextView;
+            this.awardsTextView = awardsTextView;
+            this.linkTextView = linkTextView;
+            this.relativeLayout = relativeLayout;
+            this.progressBar = progressBar;
+            this.imageView = imageView;
+            this.playButtonImageView = playButtonImageView;
+            this.noPreviewPostImageFrameLayout = noPreviewLinkImageFrameLayout;
+            this.noPreviewPostImageView = noPreviewLinkImageView;
+            this.imageBarrier = imageBarrier;
+            this.bottomConstraintLayout = bottomConstraintLayout;
+            this.upvoteButton = upvoteButton;
+            this.scoreTextView = scoreTextView;
+            this.downvoteButton = downvoteButton;
+            this.commentsCountTextView = commentsCountTextView;
+            this.saveButton = saveButton;
+            this.shareButton = shareButton;
+            this.divider = divider;
+
+            scoreTextView.setOnClickListener(null);
+
+            if (mVoteButtonsOnTheRight) {
+                ConstraintSet constraintSet = new ConstraintSet();
+                constraintSet.clone(bottomConstraintLayout);
+                constraintSet.clear(upvoteButton.getId(), ConstraintSet.START);
+                constraintSet.clear(scoreTextView.getId(), ConstraintSet.START);
+                constraintSet.clear(downvoteButton.getId(), ConstraintSet.START);
+                constraintSet.clear(saveButton.getId(), ConstraintSet.END);
+                constraintSet.clear(shareButton.getId(), ConstraintSet.END);
+                constraintSet.connect(upvoteButton.getId(), ConstraintSet.END, scoreTextView.getId(), ConstraintSet.START);
+                constraintSet.connect(scoreTextView.getId(), ConstraintSet.END, downvoteButton.getId(), ConstraintSet.START);
+                constraintSet.connect(downvoteButton.getId(), ConstraintSet.END, ConstraintSet.PARENT_ID, ConstraintSet.END);
+                constraintSet.connect(commentsCountTextView.getId(), ConstraintSet.START, saveButton.getId(), ConstraintSet.END);
+                constraintSet.connect(commentsCountTextView.getId(), ConstraintSet.END, upvoteButton.getId(), ConstraintSet.START);
+                constraintSet.connect(saveButton.getId(), ConstraintSet.START, shareButton.getId(), ConstraintSet.END);
+                constraintSet.connect(shareButton.getId(), ConstraintSet.START, ConstraintSet.PARENT_ID, ConstraintSet.START);
+                constraintSet.setHorizontalBias(commentsCountTextView.getId(), 0);
+                constraintSet.applyTo(bottomConstraintLayout);
+            }
+
+            if (((ViewGroup) itemView).getLayoutTransition() != null) {
+                ((ViewGroup) itemView).getLayoutTransition().setAnimateParentHierarchy(false);
+            }
+
+            if (mActivity.typeface != null) {
+                nameTextView.setTypeface(mActivity.typeface);
+                postTimeTextView.setTypeface(mActivity.typeface);
+                typeTextView.setTypeface(mActivity.typeface);
+                spoilerTextView.setTypeface(mActivity.typeface);
+                nsfwTextView.setTypeface(mActivity.typeface);
+                flairTextView.setTypeface(mActivity.typeface);
+                awardsTextView.setTypeface(mActivity.typeface);
+                linkTextView.setTypeface(mActivity.typeface);
+                scoreTextView.setTypeface(mActivity.typeface);
+                commentsCountTextView.setTypeface(mActivity.typeface);
+            }
+            if (mActivity.titleTypeface != null) {
+                titleTextView.setTypeface(mActivity.titleTypeface);
+            }
+
+            itemView.setBackgroundColor(mCardViewBackgroundColor);
+            postTimeTextView.setTextColor(mSecondaryTextColor);
+            titleTextView.setTextColor(mPostTitleColor);
+            stickiedPostImageView.setColorFilter(mStickiedPostIconTint, PorterDuff.Mode.SRC_IN);
+            typeTextView.setBackgroundColor(mPostTypeBackgroundColor);
+            typeTextView.setBorderColor(mPostTypeBackgroundColor);
+            typeTextView.setTextColor(mPostTypeTextColor);
+            spoilerTextView.setBackgroundColor(mSpoilerBackgroundColor);
+            spoilerTextView.setBorderColor(mSpoilerBackgroundColor);
+            spoilerTextView.setTextColor(mSpoilerTextColor);
+            nsfwTextView.setBackgroundColor(mNSFWBackgroundColor);
+            nsfwTextView.setBorderColor(mNSFWBackgroundColor);
+            nsfwTextView.setTextColor(mNSFWTextColor);
+            flairTextView.setBackgroundColor(mFlairBackgroundColor);
+            flairTextView.setBorderColor(mFlairBackgroundColor);
+            flairTextView.setTextColor(mFlairTextColor);
+            awardsTextView.setBackgroundColor(mAwardsBackgroundColor);
+            awardsTextView.setBorderColor(mAwardsBackgroundColor);
+            awardsTextView.setTextColor(mAwardsTextColor);
+            archivedImageView.setColorFilter(mArchivedIconTint, PorterDuff.Mode.SRC_IN);
+            lockedImageView.setColorFilter(mLockedIconTint, PorterDuff.Mode.SRC_IN);
+            crosspostImageView.setColorFilter(mCrosspostIconTint, PorterDuff.Mode.SRC_IN);
+            linkTextView.setTextColor(mSecondaryTextColor);
+            playButtonImageView.setColorFilter(mMediaIndicatorIconTint, PorterDuff.Mode.SRC_IN);
+            playButtonImageView.setBackgroundTintList(ColorStateList.valueOf(mMediaIndicatorBackgroundColor));
+            progressBar.setIndeterminateTintList(ColorStateList.valueOf(mColorAccent));
+            noPreviewLinkImageView.setBackgroundColor(mNoPreviewPostTypeBackgroundColor);
+            noPreviewLinkImageView.setColorFilter(mNoPreviewPostTypeIconTint, android.graphics.PorterDuff.Mode.SRC_IN);
+            upvoteButton.setColorFilter(mPostIconAndInfoColor, android.graphics.PorterDuff.Mode.SRC_IN);
+            scoreTextView.setTextColor(mPostIconAndInfoColor);
+            downvoteButton.setColorFilter(mPostIconAndInfoColor, android.graphics.PorterDuff.Mode.SRC_IN);
+            commentsCountTextView.setTextColor(mPostIconAndInfoColor);
+            commentsCountTextView.setCompoundDrawablesWithIntrinsicBounds(mCommentIcon, null, null, null);
+            saveButton.setColorFilter(mPostIconAndInfoColor, android.graphics.PorterDuff.Mode.SRC_IN);
+            shareButton.setColorFilter(mPostIconAndInfoColor, android.graphics.PorterDuff.Mode.SRC_IN);
+            divider.setBackgroundColor(mDividerColor);
+
+            imageView.setClipToOutline(true);
+            noPreviewLinkImageFrameLayout.setClipToOutline(true);
+
+            itemView.setOnClickListener(view -> {
+                int position = getBindingAdapterPosition();
+                if (position < 0) {
+                    return;
+                }
+                Post post = getItem(position);
+                if (post != null && canStartActivity) {
+                    openViewPostDetailActivity(post, getBindingAdapterPosition());
+                }
+            });
+
+            itemView.setOnLongClickListener(view -> {
+                if (mLongPressToHideToolbarInCompactLayout) {
+                    if (bottomConstraintLayout.getLayoutParams().height == 0) {
+                        ViewGroup.LayoutParams params = bottomConstraintLayout.getLayoutParams();
+                        params.height = LinearLayout.LayoutParams.WRAP_CONTENT;
+                        bottomConstraintLayout.setLayoutParams(params);
+                        mCallback.delayTransition();
+                    } else {
+                        mCallback.delayTransition();
+                        ViewGroup.LayoutParams params = bottomConstraintLayout.getLayoutParams();
+                        params.height = 0;
+                        bottomConstraintLayout.setLayoutParams(params);
+                    }
+                }
+                return true;
+            });
+
+            itemView.setOnTouchListener((v, event) -> {
+                if (event.getActionMasked() == MotionEvent.ACTION_UP || event.getActionMasked() == MotionEvent.ACTION_CANCEL) {
+                    if (mFragment.isRecyclerViewItemSwipeable(PostCompactBaseViewHolder.this)) {
+                        mActivity.unlockSwipeRightToGoBack();
+                    }
+                } else {
+                    if (mFragment.isRecyclerViewItemSwipeable(PostCompactBaseViewHolder.this)) {
+                        mActivity.lockSwipeRightToGoBack();
+                    }
+                }
+                return false;
+            });
+
+            nameTextView.setOnClickListener(view -> {
+                int position = getBindingAdapterPosition();
+                if (position < 0) {
+                    return;
+                }
+                Post post = getItem(position);
+                if (post != null && canStartActivity) {
+                    canStartActivity = false;
+                    if (mDisplaySubredditName) {
+                        Intent intent = new Intent(mActivity, ViewSubredditDetailActivity.class);
+                        intent.putExtra(ViewSubredditDetailActivity.EXTRA_SUBREDDIT_NAME_KEY,
+                                post.getSubredditName());
+                        mActivity.startActivity(intent);
+                    } else if (!post.isAuthorDeleted()) {
+                        Intent intent = new Intent(mActivity, ViewUserDetailActivity.class);
+                        intent.putExtra(ViewUserDetailActivity.EXTRA_USER_NAME_KEY, post.getAuthor());
+                        mActivity.startActivity(intent);
+                    }
+                }
+            });
+
+            iconGifImageView.setOnClickListener(view -> nameTextView.performClick());
+
+            nsfwTextView.setOnClickListener(view -> {
+                int position = getBindingAdapterPosition();
+                if (position < 0) {
+                    return;
+                }
+                Post post = getItem(position);
+                if (post != null && !(mActivity instanceof FilteredPostsActivity)) {
+                    mCallback.nsfwChipClicked();
+                }
+            });
+
+            typeTextView.setOnClickListener(view -> {
+                int position = getBindingAdapterPosition();
+                if (position < 0) {
+                    return;
+                }
+                Post post = getItem(position);
+                if (post != null && !(mActivity instanceof FilteredPostsActivity)) {
+                    mCallback.typeChipClicked(post.getPostType());
+                }
+            });
+
+            flairTextView.setOnClickListener(view -> {
+                int position = getBindingAdapterPosition();
+                if (position < 0) {
+                    return;
+                }
+                Post post = getItem(position);
+                if (post != null && !(mActivity instanceof FilteredPostsActivity)) {
+                    mCallback.flairChipClicked(post.getFlair());
+                }
+            });
+
+            imageView.setOnClickListener(view -> {
+                int position = getBindingAdapterPosition();
+                if (position < 0) {
+                    return;
+                }
+                Post post = getItem(position);
+                if (post != null) {
+                    openMedia(post);
+                }
+            });
+
+            noPreviewLinkImageFrameLayout.setOnClickListener(view -> {
+                imageView.performClick();
+            });
+
+            upvoteButton.setOnClickListener(view -> {
+                if (mAccessToken == null) {
+                    Toast.makeText(mActivity, R.string.login_first, Toast.LENGTH_SHORT).show();
+                    return;
+                }
+
+                int position = getBindingAdapterPosition();
+                if (position < 0) {
+                    return;
+                }
+                Post post = getItem(position);
+                if (post != null) {
+                    if (post.isArchived()) {
+                        Toast.makeText(mActivity, R.string.archived_post_vote_unavailable, Toast.LENGTH_SHORT).show();
+                        return;
+                    }
+
+                    ColorFilter previousUpvoteButtonColorFilter = upvoteButton.getColorFilter();
+                    ColorFilter previousDownvoteButtonColorFilter = downvoteButton.getColorFilter();
+                    int previousScoreTextViewColor = scoreTextView.getCurrentTextColor();
+
+                    int previousVoteType = post.getVoteType();
+                    String newVoteType;
+
+                    downvoteButton.setColorFilter(mPostIconAndInfoColor, android.graphics.PorterDuff.Mode.SRC_IN);
+
+                    if (previousVoteType != 1) {
+                        //Not upvoted before
+                        post.setVoteType(1);
+                        newVoteType = APIUtils.DIR_UPVOTE;
+                        upvoteButton
+                                .setColorFilter(mUpvotedColor, android.graphics.PorterDuff.Mode.SRC_IN);
+                        scoreTextView.setTextColor(mUpvotedColor);
+                    } else {
+                        //Upvoted before
+                        post.setVoteType(0);
+                        newVoteType = APIUtils.DIR_UNVOTE;
+                        upvoteButton.setColorFilter(mPostIconAndInfoColor, android.graphics.PorterDuff.Mode.SRC_IN);
+                        scoreTextView.setTextColor(mPostIconAndInfoColor);
+                    }
+
+                    if (!mHideTheNumberOfVotes) {
+                        scoreTextView.setText(Utils.getNVotes(mShowAbsoluteNumberOfVotes, post.getScore() + post.getVoteType()));
+                    }
+
+                    VoteThing.voteThing(mActivity, mOauthRetrofit, mAccessToken, new VoteThing.VoteThingListener() {
+                        @Override
+                        public void onVoteThingSuccess(int position1) {
+                            int currentPosition = getBindingAdapterPosition();
+                            if (newVoteType.equals(APIUtils.DIR_UPVOTE)) {
+                                post.setVoteType(1);
+                                if (currentPosition == position) {
+                                    upvoteButton.setColorFilter(mUpvotedColor, android.graphics.PorterDuff.Mode.SRC_IN);
+                                    scoreTextView.setTextColor(mUpvotedColor);
+                                }
+                            } else {
+                                post.setVoteType(0);
+                                if (currentPosition == position) {
+                                    upvoteButton.setColorFilter(mPostIconAndInfoColor, android.graphics.PorterDuff.Mode.SRC_IN);
+                                    scoreTextView.setTextColor(mPostIconAndInfoColor);
+                                }
+                            }
+
+                            if (currentPosition == position) {
+                                downvoteButton.setColorFilter(mPostIconAndInfoColor, android.graphics.PorterDuff.Mode.SRC_IN);
+                                if (!mHideTheNumberOfVotes) {
+                                    scoreTextView.setText(Utils.getNVotes(mShowAbsoluteNumberOfVotes, post.getScore() + post.getVoteType()));
+                                }
+                            }
+
+                            EventBus.getDefault().post(new PostUpdateEventToPostDetailFragment(post));
+                        }
+
+                        @Override
+                        public void onVoteThingFail(int position1) {
+                            Toast.makeText(mActivity, R.string.vote_failed, Toast.LENGTH_SHORT).show();
+                            post.setVoteType(previousVoteType);
+                            if (getBindingAdapterPosition() == position) {
+                                if (!mHideTheNumberOfVotes) {
+                                    scoreTextView.setText(Utils.getNVotes(mShowAbsoluteNumberOfVotes, post.getScore() + previousVoteType));
+                                }
+                                upvoteButton.setColorFilter(previousUpvoteButtonColorFilter);
+                                downvoteButton.setColorFilter(previousDownvoteButtonColorFilter);
+                                scoreTextView.setTextColor(previousScoreTextViewColor);
+                            }
+
+                            EventBus.getDefault().post(new PostUpdateEventToPostDetailFragment(post));
+                        }
+                    }, post.getFullName(), newVoteType, getBindingAdapterPosition());
+                }
+            });
+
+            downvoteButton.setOnClickListener(view -> {
+                if (mAccessToken == null) {
+                    Toast.makeText(mActivity, R.string.login_first, Toast.LENGTH_SHORT).show();
+                    return;
+                }
+
+                int position = getBindingAdapterPosition();
+                if (position < 0) {
+                    return;
+                }
+                Post post = getItem(position);
+                if (post != null) {
+                    if (post.isArchived()) {
+                        Toast.makeText(mActivity, R.string.archived_post_vote_unavailable, Toast.LENGTH_SHORT).show();
+                        return;
+                    }
+
+                    ColorFilter previousUpvoteButtonColorFilter = upvoteButton.getColorFilter();
+                    ColorFilter previousDownvoteButtonColorFilter = downvoteButton.getColorFilter();
+                    int previousScoreTextViewColor = scoreTextView.getCurrentTextColor();
+
+                    int previousVoteType = post.getVoteType();
+                    String newVoteType;
+
+                    upvoteButton.setColorFilter(mPostIconAndInfoColor, android.graphics.PorterDuff.Mode.SRC_IN);
+
+                    if (previousVoteType != -1) {
+                        //Not downvoted before
+                        post.setVoteType(-1);
+                        newVoteType = APIUtils.DIR_DOWNVOTE;
+                        downvoteButton
+                                .setColorFilter(mDownvotedColor, android.graphics.PorterDuff.Mode.SRC_IN);
+                        scoreTextView.setTextColor(mDownvotedColor);
+                    } else {
+                        //Downvoted before
+                        post.setVoteType(0);
+                        newVoteType = APIUtils.DIR_UNVOTE;
+                        downvoteButton.setColorFilter(mPostIconAndInfoColor, android.graphics.PorterDuff.Mode.SRC_IN);
+                        scoreTextView.setTextColor(mPostIconAndInfoColor);
+                    }
+
+                    if (!mHideTheNumberOfVotes) {
+                        scoreTextView.setText(Utils.getNVotes(mShowAbsoluteNumberOfVotes, post.getScore() + post.getVoteType()));
+                    }
+
+                    VoteThing.voteThing(mActivity, mOauthRetrofit, mAccessToken, new VoteThing.VoteThingListener() {
+                        @Override
+                        public void onVoteThingSuccess(int position1) {
+                            int currentPosition = getBindingAdapterPosition();
+                            if (newVoteType.equals(APIUtils.DIR_DOWNVOTE)) {
+                                post.setVoteType(-1);
+                                if (currentPosition == position) {
+                                    downvoteButton.setColorFilter(mDownvotedColor, android.graphics.PorterDuff.Mode.SRC_IN);
+                                    scoreTextView.setTextColor(mDownvotedColor);
+                                }
+
+                            } else {
+                                post.setVoteType(0);
+                                if (currentPosition == position) {
+                                    downvoteButton.setColorFilter(mPostIconAndInfoColor, android.graphics.PorterDuff.Mode.SRC_IN);
+                                    scoreTextView.setTextColor(mPostIconAndInfoColor);
+                                }
+                            }
+
+                            if (currentPosition == position) {
+                                upvoteButton.setColorFilter(mPostIconAndInfoColor, android.graphics.PorterDuff.Mode.SRC_IN);
+                                if (!mHideTheNumberOfVotes) {
+                                    scoreTextView.setText(Utils.getNVotes(mShowAbsoluteNumberOfVotes, post.getScore() + post.getVoteType()));
+                                }
+                            }
+
+                            EventBus.getDefault().post(new PostUpdateEventToPostDetailFragment(post));
+                        }
+
+                        @Override
+                        public void onVoteThingFail(int position1) {
+                            Toast.makeText(mActivity, R.string.vote_failed, Toast.LENGTH_SHORT).show();
+                            post.setVoteType(previousVoteType);
+                            if (getBindingAdapterPosition() == position) {
+                                if (!mHideTheNumberOfVotes) {
+                                    scoreTextView.setText(Utils.getNVotes(mShowAbsoluteNumberOfVotes, post.getScore() + previousVoteType));
+                                }
+                                upvoteButton.setColorFilter(previousUpvoteButtonColorFilter);
+                                downvoteButton.setColorFilter(previousDownvoteButtonColorFilter);
+                                scoreTextView.setTextColor(previousScoreTextViewColor);
+                            }
+
+                            EventBus.getDefault().post(new PostUpdateEventToPostDetailFragment(post));
+                        }
+                    }, post.getFullName(), newVoteType, getBindingAdapterPosition());
+                }
+            });
+
+            saveButton.setOnClickListener(view -> {
+                if (mAccessToken == null) {
+                    Toast.makeText(mActivity, R.string.login_first, Toast.LENGTH_SHORT).show();
+                    return;
+                }
+
+                int position = getBindingAdapterPosition();
+                if (position < 0) {
+                    return;
+                }
+                Post post = getItem(position);
+                if (post != null) {
+                    if (post.isSaved()) {
+                        saveButton.setImageResource(R.drawable.ic_bookmark_border_grey_24dp);
+                        SaveThing.unsaveThing(mOauthRetrofit, mAccessToken, post.getFullName(),
+                                new SaveThing.SaveThingListener() {
+                                    @Override
+                                    public void success() {
+                                        post.setSaved(false);
+                                        if (getBindingAdapterPosition() == position) {
+                                            saveButton.setImageResource(R.drawable.ic_bookmark_border_grey_24dp);
+                                        }
+                                        Toast.makeText(mActivity, R.string.post_unsaved_success, Toast.LENGTH_SHORT).show();
+                                        EventBus.getDefault().post(new PostUpdateEventToPostDetailFragment(post));
+                                    }
+
+                                    @Override
+                                    public void failed() {
+                                        post.setSaved(true);
+                                        if (getBindingAdapterPosition() == position) {
+                                            saveButton.setImageResource(R.drawable.ic_bookmark_grey_24dp);
+                                        }
+                                        Toast.makeText(mActivity, R.string.post_unsaved_failed, Toast.LENGTH_SHORT).show();
+                                        EventBus.getDefault().post(new PostUpdateEventToPostDetailFragment(post));
+                                    }
+                                });
+                    } else {
+                        saveButton.setImageResource(R.drawable.ic_bookmark_grey_24dp);
+                        SaveThing.saveThing(mOauthRetrofit, mAccessToken, post.getFullName(),
+                                new SaveThing.SaveThingListener() {
+                                    @Override
+                                    public void success() {
+                                        post.setSaved(true);
+                                        if (getBindingAdapterPosition() == position) {
+                                            saveButton.setImageResource(R.drawable.ic_bookmark_grey_24dp);
+                                        }
+                                        Toast.makeText(mActivity, R.string.post_saved_success, Toast.LENGTH_SHORT).show();
+                                        EventBus.getDefault().post(new PostUpdateEventToPostDetailFragment(post));
+                                    }
+
+                                    @Override
+                                    public void failed() {
+                                        post.setSaved(false);
+                                        if (getBindingAdapterPosition() == position) {
+                                            saveButton.setImageResource(R.drawable.ic_bookmark_border_grey_24dp);
+                                        }
+                                        Toast.makeText(mActivity, R.string.post_saved_failed, Toast.LENGTH_SHORT).show();
+                                        EventBus.getDefault().post(new PostUpdateEventToPostDetailFragment(post));
+                                    }
+                                });
+                    }
+                }
+            });
+
+            saveButton.setOnLongClickListener(view ->
+            {
+                int position = getBindingAdapterPosition();
+                if (position < 0) {
+                    return false;
+                }
+                Post post = getItem(position);
+                if (post != null) {
+                    LocalSave.RemovePost(post.getPermalink());
+                    return true;
+                }
+                return false;
+            });
+
+            shareButton.setOnClickListener(view -> {
+                int position = getBindingAdapterPosition();
+                if (position < 0) {
+                    return;
+                }
+                Post post = getItem(position);
+                if (post != null) {
+                    shareLink(post);
+                }
+            });
+
+            shareButton.setOnLongClickListener(view -> {
+                int position = getBindingAdapterPosition();
+                if (position < 0) {
+                    return false;
+                }
+                Post post = getItem(position);
+                if (post != null) {
+                    mActivity.copyLink(post.getPermalink());
+                    return true;
+                }
+                return false;
+            });
+
+            requestListener = new RequestListener<>() {
+                @Override
+                public boolean onLoadFailed(@Nullable GlideException e, Object model, Target<Drawable> target, boolean isFirstResource) {
+                    progressBar.setVisibility(View.GONE);
+                    return false;
+                }
+
+                @Override
+                public boolean onResourceReady(Drawable resource, Object model, Target<Drawable> target, DataSource dataSource, boolean isFirstResource) {
+                    progressBar.setVisibility(View.GONE);
+                    return false;
+                }
+            };
+        }
+    }
+
+    class PostCompactLeftThumbnailViewHolder extends PostCompactBaseViewHolder {
+        @BindView(R.id.icon_gif_image_view_item_post_compact)
+        AspectRatioGifImageView iconGifImageView;
+        @BindView(R.id.name_text_view_item_post_compact)
+        TextView nameTextView;
+        @BindView(R.id.stickied_post_image_view_item_post_compact)
+        ImageView stickiedPostImageView;
+        @BindView(R.id.post_time_text_view_item_post_compact)
+        TextView postTimeTextView;
+        @BindView(R.id.title_and_image_constraint_layout)
+        ConstraintLayout titleAndImageConstraintLayout;
+        @BindView(R.id.title_text_view_item_post_compact)
+        TextView titleTextView;
+        @BindView(R.id.type_text_view_item_post_compact)
+        CustomTextView typeTextView;
+        @BindView(R.id.archived_image_view_item_post_compact)
+        ImageView archivedImageView;
+        @BindView(R.id.locked_image_view_item_post_compact)
+        ImageView lockedImageView;
+        @BindView(R.id.crosspost_image_view_item_post_compact)
+        ImageView crosspostImageView;
+        @BindView(R.id.nsfw_text_view_item_post_compact)
+        CustomTextView nsfwTextView;
+        @BindView(R.id.spoiler_custom_text_view_item_post_compact)
+        CustomTextView spoilerTextView;
+        @BindView(R.id.flair_custom_text_view_item_post_compact)
+        CustomTextView flairTextView;
+        @BindView(R.id.awards_text_view_item_post_compact)
+        CustomTextView awardsTextView;
+        @BindView(R.id.link_text_view_item_post_compact)
+        TextView linkTextView;
+        @BindView(R.id.image_view_wrapper_item_post_compact)
+        RelativeLayout relativeLayout;
+        @BindView(R.id.progress_bar_item_post_compact)
+        ProgressBar progressBar;
+        @BindView(R.id.image_view_item_post_compact)
+        ImageView imageView;
+        @BindView(R.id.play_button_image_view_item_post_compact)
+        ImageView playButtonImageView;
+        @BindView(R.id.frame_layout_image_view_no_preview_link_item_post_compact)
+        FrameLayout noPreviewLinkImageFrameLayout;
+        @BindView(R.id.image_view_no_preview_link_item_post_compact)
+        ImageView noPreviewLinkImageView;
+        @BindView(R.id.barrier2)
+        Barrier imageBarrier;
+        @BindView(R.id.bottom_constraint_layout_item_post_compact)
+        ConstraintLayout bottomConstraintLayout;
+        @BindView(R.id.plus_button_item_post_compact)
+        ImageView upvoteButton;
+        @BindView(R.id.score_text_view_item_post_compact)
+        TextView scoreTextView;
+        @BindView(R.id.minus_button_item_post_compact)
+        ImageView downvoteButton;
+        @BindView(R.id.comments_count_item_post_compact)
+        TextView commentsCountTextView;
+        @BindView(R.id.save_button_item_post_compact)
+        ImageView saveButton;
+        @BindView(R.id.share_button_item_post_compact)
+        ImageView shareButton;
+        @BindView(R.id.divider_item_post_compact)
+        View divider;
+
+        PostCompactLeftThumbnailViewHolder(View itemView) {
+            super(itemView);
+            ButterKnife.bind(this, itemView);
+
+            setBaseView(iconGifImageView, nameTextView, stickiedPostImageView, postTimeTextView,
+                    titleAndImageConstraintLayout, titleTextView, typeTextView, archivedImageView,
+                    lockedImageView, crosspostImageView, nsfwTextView, spoilerTextView,
+                    flairTextView, awardsTextView, linkTextView, relativeLayout, progressBar, imageView,
+                    playButtonImageView, noPreviewLinkImageFrameLayout, noPreviewLinkImageView,
+                    imageBarrier, bottomConstraintLayout, upvoteButton, scoreTextView, downvoteButton,
+                    commentsCountTextView, saveButton, shareButton, divider);
+        }
+    }
+
+    class PostCompactRightThumbnailViewHolder extends PostCompactBaseViewHolder {
+        @BindView(R.id.icon_gif_image_view_item_post_compact_right_thumbnail)
+        AspectRatioGifImageView iconGifImageView;
+        @BindView(R.id.name_text_view_item_post_compact_right_thumbnail)
+        TextView nameTextView;
+        @BindView(R.id.stickied_post_image_view_item_post_compact_right_thumbnail)
+        ImageView stickiedPostImageView;
+        @BindView(R.id.post_time_text_view_item_post_compact_right_thumbnail)
+        TextView postTimeTextView;
+        @BindView(R.id.title_and_image_constraint_layout)
+        ConstraintLayout titleAndImageConstraintLayout;
+        @BindView(R.id.title_text_view_item_post_compact_right_thumbnail)
+        TextView titleTextView;
+        @BindView(R.id.type_text_view_item_post_compact_right_thumbnail)
+        CustomTextView typeTextView;
+        @BindView(R.id.archived_image_view_item_post_compact_right_thumbnail)
+        ImageView archivedImageView;
+        @BindView(R.id.locked_image_view_item_post_compact_right_thumbnail)
+        ImageView lockedImageView;
+        @BindView(R.id.crosspost_image_view_item_post_compact_right_thumbnail)
+        ImageView crosspostImageView;
+        @BindView(R.id.nsfw_text_view_item_post_compact_right_thumbnail)
+        CustomTextView nsfwTextView;
+        @BindView(R.id.spoiler_custom_text_view_item_post_compact_right_thumbnail)
+        CustomTextView spoilerTextView;
+        @BindView(R.id.flair_custom_text_view_item_post_compact_right_thumbnail)
+        CustomTextView flairTextView;
+        @BindView(R.id.awards_text_view_item_post_compact_right_thumbnail)
+        CustomTextView awardsTextView;
+        @BindView(R.id.link_text_view_item_post_compact_right_thumbnail)
+        TextView linkTextView;
+        @BindView(R.id.image_view_wrapper_item_post_compact_right_thumbnail)
+        RelativeLayout relativeLayout;
+        @BindView(R.id.progress_bar_item_post_compact_right_thumbnail)
+        ProgressBar progressBar;
+        @BindView(R.id.image_view_item_post_compact_right_thumbnail)
+        ImageView imageView;
+        @BindView(R.id.play_button_image_view_item_post_compact_right_thumbnail)
+        ImageView playButtonImageView;
+        @BindView(R.id.frame_layout_image_view_no_preview_link_item_post_compact_right_thumbnail)
+        FrameLayout noPreviewLinkImageFrameLayout;
+        @BindView(R.id.image_view_no_preview_link_item_post_compact_right_thumbnail)
+        ImageView noPreviewLinkImageView;
+        @BindView(R.id.barrier2)
+        Barrier imageBarrier;
+        @BindView(R.id.bottom_constraint_layout_item_post_compact_right_thumbnail)
+        ConstraintLayout bottomConstraintLayout;
+        @BindView(R.id.plus_button_item_post_compact_right_thumbnail)
+        ImageView upvoteButton;
+        @BindView(R.id.score_text_view_item_post_compact_right_thumbnail)
+        TextView scoreTextView;
+        @BindView(R.id.minus_button_item_post_compact_right_thumbnail)
+        ImageView downvoteButton;
+        @BindView(R.id.comments_count_item_post_compact_right_thumbnail)
+        TextView commentsCountTextView;
+        @BindView(R.id.save_button_item_post_compact_right_thumbnail)
+        ImageView saveButton;
+        @BindView(R.id.share_button_item_post_compact_right_thumbnail)
+        ImageView shareButton;
+        @BindView(R.id.divider_item_post_compact_right_thumbnail)
+        View divider;
+
+        PostCompactRightThumbnailViewHolder(View itemView) {
+            super(itemView);
+            ButterKnife.bind(this, itemView);
+
+            setBaseView(iconGifImageView, nameTextView, stickiedPostImageView, postTimeTextView,
+                    titleAndImageConstraintLayout, titleTextView, typeTextView, archivedImageView,
+                    lockedImageView, crosspostImageView, nsfwTextView, spoilerTextView,
+                    flairTextView, awardsTextView, linkTextView, relativeLayout, progressBar, imageView,
+                    playButtonImageView, noPreviewLinkImageFrameLayout, noPreviewLinkImageView,
+                    imageBarrier, bottomConstraintLayout, upvoteButton, scoreTextView, downvoteButton,
+                    commentsCountTextView, saveButton, shareButton, divider);
+        }
+    }
+
+    class PostGalleryViewHolder extends RecyclerView.ViewHolder {
+        @BindView(R.id.progress_bar_item_post_gallery)
+        ProgressBar progressBar;
+        @BindView(R.id.video_or_gif_indicator_image_view_item_post_gallery)
+        ImageView videoOrGifIndicatorImageView;
+        @BindView(R.id.image_view_item_post_gallery)
+        AspectRatioGifImageView imageView;
+        @BindView(R.id.load_image_error_text_view_item_gallery)
+        TextView errorTextView;
+        @BindView(R.id.image_view_no_preview_item_post_gallery)
+        ImageView noPreviewImageView;
+        @BindView(R.id.title_text_view_item_post_gallery)
+        TextView titleTextView;
+        RequestListener<Drawable> requestListener;
+        Post post;
+        Post.Preview preview;
+
+        public PostGalleryViewHolder(@NonNull View itemView) {
+            super(itemView);
+            ButterKnife.bind(this, itemView);
+
+            if (mActivity.typeface != null) {
+                errorTextView.setTypeface(mActivity.typeface);
+            }
+            if (mActivity.titleTypeface != null) {
+                titleTextView.setTypeface(mActivity.titleTypeface);
+            }
+            itemView.setBackgroundTintList(ColorStateList.valueOf(mCardViewBackgroundColor));
+            titleTextView.setTextColor(mPostTitleColor);
+            progressBar.setIndeterminateTintList(ColorStateList.valueOf(mColorAccent));
+            noPreviewImageView.setBackgroundColor(mNoPreviewPostTypeBackgroundColor);
+            noPreviewImageView.setColorFilter(mNoPreviewPostTypeIconTint, android.graphics.PorterDuff.Mode.SRC_IN);
+            videoOrGifIndicatorImageView.setColorFilter(mMediaIndicatorIconTint, PorterDuff.Mode.SRC_IN);
+            videoOrGifIndicatorImageView.setBackgroundTintList(ColorStateList.valueOf(mMediaIndicatorBackgroundColor));
+            errorTextView.setTextColor(mPrimaryTextColor);
+
+            itemView.setOnClickListener(view -> {
+                int position = getBindingAdapterPosition();
+                if (position >= 0 && canStartActivity) {
+                    Post post = getItem(position);
+                    if (post != null) {
+                        if (post.getPostType() == Post.TEXT_TYPE || !mSharedPreferences.getBoolean(SharedPreferencesUtils.CLICK_TO_SHOW_MEDIA_IN_GALLERY_LAYOUT, false)) {
+                            openViewPostDetailActivity(post, getBindingAdapterPosition());
+                        } else {
+                            openMedia(post);
+                        }
+                    }
+                }
+            });
+
+            itemView.setOnLongClickListener(view -> {
+                int position = getBindingAdapterPosition();
+                if (position >= 0 && canStartActivity) {
+                    Post post = getItem(position);
+                    if (post != null) {
+                        if (post.getPostType() == Post.TEXT_TYPE || mSharedPreferences.getBoolean(SharedPreferencesUtils.CLICK_TO_SHOW_MEDIA_IN_GALLERY_LAYOUT, false)) {
+                            openViewPostDetailActivity(post, getBindingAdapterPosition());
+                        } else {
+                            openMedia(post);
+                        }
+                    }
+                }
+
+                return true;
+            });
+
+            errorTextView.setOnClickListener(view -> {
+                progressBar.setVisibility(View.VISIBLE);
+                errorTextView.setVisibility(View.GONE);
+                loadImage(this);
+            });
+
+            noPreviewImageView.setOnClickListener(view -> {
+                itemView.performClick();
+            });
+
+            requestListener = new RequestListener<>() {
+                @Override
+                public boolean onLoadFailed(@Nullable GlideException e, Object model, Target<Drawable> target, boolean isFirstResource) {
+                    progressBar.setVisibility(View.GONE);
+                    errorTextView.setVisibility(View.VISIBLE);
+                    return false;
+                }
+
+                @Override
+                public boolean onResourceReady(Drawable resource, Object model, Target<Drawable> target, DataSource dataSource, boolean isFirstResource) {
+                    errorTextView.setVisibility(View.GONE);
+                    progressBar.setVisibility(View.GONE);
+                    return false;
+                }
+            };
+        }
+    }
+
+    class PostGalleryBaseGalleryTypeViewHolder extends RecyclerView.ViewHolder {
+
+        FrameLayout frameLayout;
+        RecyclerView recyclerView;
+        CustomTextView imageIndexTextView;
+        ImageView noPreviewImageView;
+
+        PostGalleryTypeImageRecyclerViewAdapter adapter;
+        private LinearLayoutManagerBugFixed layoutManager;
+
+        Post post;
+        Post.Preview preview;
+
+        int currentPosition;
+
+        public PostGalleryBaseGalleryTypeViewHolder(@NonNull View itemView,
+                                                    FrameLayout frameLayout,
+                                                    RecyclerView recyclerView,
+                                                    CustomTextView imageIndexTextView,
+                                                    ImageView noPreviewImageView) {
+            super(itemView);
+
+            this.frameLayout = frameLayout;
+            this.recyclerView = recyclerView;
+            this.imageIndexTextView = imageIndexTextView;
+            this.noPreviewImageView = noPreviewImageView;
+
+            if (mActivity.typeface != null) {
+                imageIndexTextView.setTypeface(mActivity.typeface);
+            }
+
+            itemView.setBackgroundTintList(ColorStateList.valueOf(mCardViewBackgroundColor));
+            noPreviewImageView.setBackgroundColor(mNoPreviewPostTypeBackgroundColor);
+            noPreviewImageView.setColorFilter(mNoPreviewPostTypeIconTint, android.graphics.PorterDuff.Mode.SRC_IN);
+
+            imageIndexTextView.setTextColor(mMediaIndicatorIconTint);
+            imageIndexTextView.setBackgroundColor(mMediaIndicatorBackgroundColor);
+            imageIndexTextView.setBorderColor(mMediaIndicatorBackgroundColor);
+
+            adapter = new PostGalleryTypeImageRecyclerViewAdapter(mGlide, mActivity.typeface,
+                    mSaveMemoryCenterInsideDownsampleStrategy, mColorAccent, mPrimaryTextColor, mScale);
+            recyclerView.setOnTouchListener((v, motionEvent) -> {
+                if (motionEvent.getActionMasked() == MotionEvent.ACTION_UP || motionEvent.getActionMasked() == MotionEvent.ACTION_CANCEL) {
+                    if (mActivity.mSliderPanel != null) {
+                        mActivity.mSliderPanel.requestDisallowInterceptTouchEvent(false);
+                    }
+                    if (mActivity.mViewPager2 != null) {
+                        mActivity.mViewPager2.setUserInputEnabled(true);
+                    }
+                    mActivity.unlockSwipeRightToGoBack();
+                } else {
+                    if (mActivity.mSliderPanel != null) {
+                        mActivity.mSliderPanel.requestDisallowInterceptTouchEvent(true);
+                    }
+                    if (mActivity.mViewPager2 != null) {
+                        mActivity.mViewPager2.setUserInputEnabled(false);
+                    }
+                    mActivity.lockSwipeRightToGoBack();
+                }
+
+                return false;
+            });
+            recyclerView.setAdapter(adapter);
+            new PagerSnapHelper().attachToRecyclerView(recyclerView);
+            recyclerView.setRecycledViewPool(mGalleryRecycledViewPool);
+            layoutManager = new LinearLayoutManagerBugFixed(mActivity, RecyclerView.HORIZONTAL, false);
+            recyclerView.setLayoutManager(layoutManager);
+            recyclerView.addOnScrollListener(new RecyclerView.OnScrollListener() {
+                @Override
+                public void onScrollStateChanged(@NonNull RecyclerView recyclerView, int newState) {
+                    super.onScrollStateChanged(recyclerView, newState);
+                }
+
+                @Override
+                public void onScrolled(@NonNull RecyclerView recyclerView, int dx, int dy) {
+                    super.onScrolled(recyclerView, dx, dy);
+                    imageIndexTextView.setText(mActivity.getString(R.string.image_index_in_gallery, layoutManager.findFirstVisibleItemPosition() + 1, post.getGallery().size()));
+                }
+            });
+            recyclerView.addOnItemTouchListener(new RecyclerView.OnItemTouchListener() {
+                private float downX;
+                private float downY;
+                private boolean dragged;
+                private long downTime;
+                private final int minTouchSlop = ViewConfiguration.get(mActivity).getScaledTouchSlop();
+                private final int longClickThreshold = ViewConfiguration.getLongPressTimeout();
+
+                @Override
+                public boolean onInterceptTouchEvent(@NonNull RecyclerView rv, @NonNull MotionEvent e) {
+                    int action = e.getAction();
+                    switch (action) {
+                        case MotionEvent.ACTION_DOWN:
+                            downX = e.getRawX();
+                            downY = e.getRawY();
+                            downTime = System.currentTimeMillis();
+                            break;
+                        case MotionEvent.ACTION_MOVE:
+                            if(Math.abs(e.getRawX() - downX) > minTouchSlop || Math.abs(e.getRawY() - downY) > minTouchSlop) {
+                                dragged = true;
+                            }
+                            if (!dragged) {
+                                if (System.currentTimeMillis() - downTime >= longClickThreshold) {
+                                    onLongClick();
+                                }
+                            }
+                            break;
+                        case MotionEvent.ACTION_UP:
+                            if (!dragged) {
+                                if (System.currentTimeMillis() - downTime < longClickThreshold) {
+                                    onClick();
+                                }
+                            }
+                        case MotionEvent.ACTION_CANCEL:
+                            downX = 0;
+                            downY = 0;
+                            dragged = false;
+
+                    }
+                    return false;
+                }
+
+                @Override
+                public void onTouchEvent(@NonNull RecyclerView rv, @NonNull MotionEvent e) {
+
+                }
+
+                @Override
+                public void onRequestDisallowInterceptTouchEvent(boolean disallowIntercept) {
+
+                }
+            });
+
+            noPreviewImageView.setOnClickListener(view -> {
+                onClick();
+            });
+
+            noPreviewImageView.setOnLongClickListener(view -> onLongClick());
+        }
+
+        void onClick() {
+            int position = getBindingAdapterPosition();
+            if (position >= 0 && canStartActivity) {
+                Post post = getItem(position);
+                if (post != null) {
+                    if (post.getPostType() == Post.TEXT_TYPE || !mSharedPreferences.getBoolean(SharedPreferencesUtils.CLICK_TO_SHOW_MEDIA_IN_GALLERY_LAYOUT, false)) {
+                        openViewPostDetailActivity(post, getBindingAdapterPosition());
+                    } else {
+                        openMedia(post, layoutManager.findFirstVisibleItemPosition());
+                    }
+                }
+            }
+        }
+
+        boolean onLongClick() {
+            int position = getBindingAdapterPosition();
+            if (position >= 0 && canStartActivity) {
+                Post post = getItem(position);
+                if (post != null) {
+                    if (post.getPostType() == Post.TEXT_TYPE || mSharedPreferences.getBoolean(SharedPreferencesUtils.CLICK_TO_SHOW_MEDIA_IN_GALLERY_LAYOUT, false)) {
+                        openViewPostDetailActivity(post, getBindingAdapterPosition());
+                    } else {
+                        openMedia(post, layoutManager.findFirstVisibleItemPosition());
+                    }
+                }
+            }
+
+            return true;
+        }
+    }
+
+    class PostGalleryGalleryTypeViewHolder extends PostGalleryBaseGalleryTypeViewHolder {
+
+        public PostGalleryGalleryTypeViewHolder(@NonNull ItemPostGalleryGalleryTypeBinding binding) {
+            super(binding.getRoot(), binding.galleryFrameLayoutItemPostGalleryGalleryType,
+                    binding.galleryRecyclerViewItemPostGalleryGalleryType, binding.imageIndexTextViewItemPostGalleryGalleryType,
+                    binding.imageViewNoPreviewItemPostGalleryGalleryType);
+        }
+    }
+
+    class PostCard2VideoAutoplayViewHolder extends PostBaseViewHolder implements ToroPlayer {
+        @BindView(R.id.icon_gif_image_view_item_post_card_2_video_autoplay)
+        AspectRatioGifImageView iconGifImageView;
+        @BindView(R.id.subreddit_name_text_view_item_post_card_2_video_autoplay)
+        TextView subredditTextView;
+        @BindView(R.id.user_text_view_item_post_card_2_video_autoplay)
+        TextView userTextView;
+        @BindView(R.id.stickied_post_image_view_item_post_card_2_video_autoplay)
+        ImageView stickiedPostImageView;
+        @BindView(R.id.post_time_text_view_item_post_card_2_video_autoplay)
+        TextView postTimeTextView;
+        @BindView(R.id.title_text_view_item_post_card_2_video_autoplay)
+        TextView titleTextView;
+        @BindView(R.id.type_text_view_item_post_card_2_video_autoplay)
+        CustomTextView typeTextView;
+        @BindView(R.id.archived_image_view_item_post_card_2_video_autoplay)
+        ImageView archivedImageView;
+        @BindView(R.id.locked_image_view_item_post_card_2_video_autoplay)
+        ImageView lockedImageView;
+        @BindView(R.id.crosspost_image_view_item_post_card_2_video_autoplay)
+        ImageView crosspostImageView;
+        @BindView(R.id.nsfw_text_view_item_post_card_2_video_autoplay)
+        CustomTextView nsfwTextView;
+        @BindView(R.id.spoiler_custom_text_view_item_post_card_2_video_autoplay)
+        CustomTextView spoilerTextView;
+        @BindView(R.id.flair_custom_text_view_item_post_card_2_video_autoplay)
+        CustomTextView flairTextView;
+        @BindView(R.id.awards_text_view_item_post_card_2_video_autoplay)
+        CustomTextView awardsTextView;
+        @BindView(R.id.aspect_ratio_frame_layout_item_post_card_2_video_autoplay)
+        AspectRatioFrameLayout aspectRatioFrameLayout;
+        @BindView(R.id.preview_image_view_item_post_card_2_video_autoplay)
+        GifImageView previewImageView;
+        @BindView(R.id.error_loading_gfycat_image_view_item_post_card_2_video_autoplay)
+        ImageView errorLoadingGfycatImageView;
+        @BindView(R.id.player_view_item_post_card_2_video_autoplay)
+        PlayerView videoPlayer;
+        @BindView(R.id.mute_exo_playback_control_view)
+        ImageView muteButton;
+        @BindView(R.id.fullscreen_exo_playback_control_view)
+        ImageView fullscreenButton;
+        @BindView(R.id.exo_pause)
+        ImageView pauseButton;
+        @BindView(R.id.exo_play)
+        ImageView playButton;
+        @BindView(R.id.exo_progress)
+        DefaultTimeBar progressBar;
+        @BindView(R.id.bottom_constraint_layout_item_post_card_2_video_autoplay)
+        ConstraintLayout bottomConstraintLayout;
+        @BindView(R.id.plus_button_item_post_card_2_video_autoplay)
+        ImageView upvoteButton;
+        @BindView(R.id.score_text_view_item_post_card_2_video_autoplay)
+        TextView scoreTextView;
+        @BindView(R.id.minus_button_item_post_card_2_video_autoplay)
+        ImageView downvoteButton;
+        @BindView(R.id.comments_count_item_post_card_2_video_autoplay)
+        TextView commentsCountTextView;
+        @BindView(R.id.save_button_item_post_card_2_video_autoplay)
+        ImageView saveButton;
+        @BindView(R.id.share_button_item_post_card_2_video_autoplay)
+        ImageView shareButton;
+        @BindView(R.id.divider_item_post_card_2_video_autoplay)
+        View divider;
+
+        @Nullable
+        Container container;
+        @Nullable
+        ExoPlayerViewHelper helper;
+        private Uri mediaUri;
+        private float volume;
+        public Call<String> fetchGfycatOrStreamableVideoCall;
+        private boolean isManuallyPaused;
+
+        PostCard2VideoAutoplayViewHolder(View itemView) {
+            super(itemView);
+            ButterKnife.bind(this, itemView);
+            setBaseView(
+                    iconGifImageView,
+                    subredditTextView,
+                    userTextView,
+                    stickiedPostImageView,
+                    postTimeTextView,
+                    titleTextView,
+                    typeTextView,
+                    archivedImageView,
+                    lockedImageView,
+                    crosspostImageView,
+                    nsfwTextView,
+                    spoilerTextView,
+                    flairTextView,
+                    awardsTextView,
+                    bottomConstraintLayout,
+                    upvoteButton,
+                    scoreTextView,
+                    downvoteButton,
+                    commentsCountTextView,
+                    saveButton,
+                    shareButton,
+                    true);
+
+            divider.setBackgroundColor(mDividerColor);
+
+            aspectRatioFrameLayout.setOnClickListener(null);
+
+            muteButton.setOnClickListener(view -> {
+                if (helper != null) {
+                    if (helper.getVolume() != 0) {
+                        muteButton.setImageDrawable(ContextCompat.getDrawable(mActivity, R.drawable.ic_mute_white_rounded_24dp));
+                        helper.setVolume(0f);
+                        volume = 0f;
+                        mFragment.videoAutoplayChangeMutingOption(true);
+                    } else {
+                        muteButton.setImageDrawable(ContextCompat.getDrawable(mActivity, R.drawable.ic_unmute_white_rounded_24dp));
+                        helper.setVolume(1f);
+                        volume = 1f;
+                        mFragment.videoAutoplayChangeMutingOption(false);
+                    }
+                }
+            });
+
+            pauseButton.setOnClickListener(view -> {
+                pause();
+                isManuallyPaused = true;
+                savePlaybackInfo(getPlayerOrder(), getCurrentPlaybackInfo());
+            });
+
+            playButton.setOnClickListener(view -> {
+                isManuallyPaused = false;
+                play();
+            });
+
+            progressBar.addListener(new TimeBar.OnScrubListener() {
+                @Override
+                public void onScrubStart(TimeBar timeBar, long position) {
+
+                }
+
+                @Override
+                public void onScrubMove(TimeBar timeBar, long position) {
+
+                }
+
+                @Override
+                public void onScrubStop(TimeBar timeBar, long position, boolean canceled) {
+                    if (!canceled) {
+                        savePlaybackInfo(getPlayerOrder(), getCurrentPlaybackInfo());
+                    }
+                }
+            });
+
+            fullscreenButton.setOnClickListener(view -> {
+                int position = getBindingAdapterPosition();
+                if (position < 0) {
+                    return;
+                }
+                Post post = getItem(position);
+                if (post != null) {
+                    Intent intent = new Intent(mActivity, ViewVideoActivity.class);
+                    if (post.isImgur()) {
+                        intent.setData(Uri.parse(post.getVideoUrl()));
+                        intent.putExtra(ViewVideoActivity.EXTRA_VIDEO_TYPE, ViewVideoActivity.VIDEO_TYPE_IMGUR);
+                    } else if (post.isGfycat()) {
+                        intent.putExtra(ViewVideoActivity.EXTRA_VIDEO_TYPE, ViewVideoActivity.VIDEO_TYPE_GFYCAT);
+                        intent.putExtra(ViewVideoActivity.EXTRA_GFYCAT_ID, post.getGfycatId());
+                        if (post.isLoadGfycatOrStreamableVideoSuccess()) {
+                            intent.setData(Uri.parse(post.getVideoUrl()));
+                            intent.putExtra(ViewVideoActivity.EXTRA_VIDEO_DOWNLOAD_URL, post.getVideoDownloadUrl());
+                        }
+                    } else if (post.isRedgifs()) {
+                        intent.putExtra(ViewVideoActivity.EXTRA_VIDEO_TYPE, ViewVideoActivity.VIDEO_TYPE_REDGIFS);
+                        intent.putExtra(ViewVideoActivity.EXTRA_GFYCAT_ID, post.getGfycatId());
+                        if (post.isLoadGfycatOrStreamableVideoSuccess()) {
+                            intent.setData(Uri.parse(post.getVideoUrl()));
+                            intent.putExtra(ViewVideoActivity.EXTRA_VIDEO_DOWNLOAD_URL, post.getVideoDownloadUrl());
+                        }
+                    } else if (post.isStreamable()) {
+                        intent.putExtra(ViewVideoActivity.EXTRA_VIDEO_TYPE, ViewVideoActivity.VIDEO_TYPE_STREAMABLE);
+                        intent.putExtra(ViewVideoActivity.EXTRA_STREAMABLE_SHORT_CODE, post.getStreamableShortCode());
+                    } else {
+                        intent.setData(Uri.parse(post.getVideoUrl()));
+                        intent.putExtra(ViewVideoActivity.EXTRA_VIDEO_DOWNLOAD_URL, post.getVideoDownloadUrl());
+                        intent.putExtra(ViewVideoActivity.EXTRA_SUBREDDIT, post.getSubredditName());
+                        intent.putExtra(ViewVideoActivity.EXTRA_ID, post.getId());
+                    }
+                    intent.putExtra(ViewVideoActivity.EXTRA_POST_TITLE, post.getTitle());
+                    if (helper != null) {
+                        intent.putExtra(ViewVideoActivity.EXTRA_PROGRESS_SECONDS, helper.getLatestPlaybackInfo().getResumePosition());
+                    }
+                    intent.putExtra(ViewVideoActivity.EXTRA_IS_NSFW, post.isNSFW());
+                    mActivity.startActivity(intent);
+                }
+            });
+
+            previewImageView.setOnClickListener(view -> fullscreenButton.performClick());
+
+            videoPlayer.setOnClickListener(view -> {
+                if (mEasierToWatchInFullScreen && videoPlayer.isControllerVisible()) {
+                    fullscreenButton.performClick();
+                }
+            });
+        }
+
+        void bindVideoUri(Uri videoUri) {
+            mediaUri = videoUri;
+        }
+
+        void setVolume(float volume) {
+            this.volume = volume;
+        }
+
+        void resetVolume() {
+            volume = 0f;
+        }
+
+        private void savePlaybackInfo(int order, @Nullable PlaybackInfo playbackInfo) {
+            if (container != null) container.savePlaybackInfo(order, playbackInfo);
+        }
+
+        @NonNull
+        @Override
+        public View getPlayerView() {
+            return videoPlayer;
+        }
+
+        @NonNull
+        @Override
+        public PlaybackInfo getCurrentPlaybackInfo() {
+            return helper != null && mediaUri != null ? helper.getLatestPlaybackInfo() : new PlaybackInfo();
+        }
+
+        @Override
+        public void initialize(@NonNull Container container, @NonNull PlaybackInfo playbackInfo) {
+            if (mediaUri == null) {
+                return;
+            }
+            if (this.container == null) {
+                this.container = container;
+            }
+            if (helper == null) {
+                helper = new ExoPlayerViewHelper(this, mediaUri, null, mExoCreator);
+                helper.addEventListener(new Playable.DefaultEventListener() {
+                    @Override
+                    public void onTracksChanged(@NonNull Tracks tracks) {
+                        ImmutableList<Tracks.Group> trackGroups = tracks.getGroups();
+                        if (!trackGroups.isEmpty()) {
+                            for (int i = 0; i < trackGroups.size(); i++) {
+                                String mimeType = trackGroups.get(i).getTrackFormat(0).sampleMimeType;
+                                if (mimeType != null && mimeType.contains("audio")) {
+                                    if (mFragment.getMasterMutingOption() != null) {
+                                        volume = mFragment.getMasterMutingOption() ? 0f : 1f;
+                                    }
+                                    helper.setVolume(volume);
+                                    muteButton.setVisibility(View.VISIBLE);
+                                    if (volume != 0f) {
+                                        muteButton.setImageDrawable(ContextCompat.getDrawable(mActivity, R.drawable.ic_unmute_white_rounded_24dp));
+                                    } else {
+                                        muteButton.setImageDrawable(ContextCompat.getDrawable(mActivity, R.drawable.ic_mute_white_rounded_24dp));
+                                    }
+                                    break;
+                                }
+                            }
+                        } else {
+                            muteButton.setVisibility(View.GONE);
+                        }
+                    }
+
+                    @Override
+                    public void onRenderedFirstFrame() {
+                        mGlide.clear(previewImageView);
+                        previewImageView.setVisibility(View.GONE);
+                    }
+                });
+            }
+            helper.initialize(container, playbackInfo);
+        }
+
+        @Override
+        public void play() {
+            if (helper != null && mediaUri != null) {
+                if (!isPlaying() && isManuallyPaused) {
+                    helper.play();
+                    pause();
+                    helper.setVolume(volume);
+                } else {
+                    helper.play();
+                }
+            }
+        }
+
+        @Override
+        public void pause() {
+            if (helper != null) helper.pause();
+        }
+
+        @Override
+        public boolean isPlaying() {
+            return helper != null && helper.isPlaying();
+        }
+
+        @Override
+        public void release() {
+            if (helper != null) {
+                helper.release();
+                helper = null;
+            }
+            isManuallyPaused = false;
+            container = null;
+        }
+
+        @Override
+        public boolean wantsToPlay() {
+            return canPlayVideo && mediaUri != null && ToroUtil.visibleAreaOffset(this, itemView.getParent()) >= mStartAutoplayVisibleAreaOffset;
+        }
+
+        @Override
+        public int getPlayerOrder() {
+            return getBindingAdapterPosition();
+        }
+    }
+
+    class PostCard2WithPreviewViewHolder extends PostBaseViewHolder {
+        @BindView(R.id.icon_gif_image_view_item_post_card_2_with_preview)
+        AspectRatioGifImageView iconGifImageView;
+        @BindView(R.id.subreddit_name_text_view_item_post_card_2_with_preview)
+        TextView subredditTextView;
+        @BindView(R.id.user_text_view_item_post_card_2_with_preview)
+        TextView userTextView;
+        @BindView(R.id.stickied_post_image_view_item_post_card_2_with_preview)
+        ImageView stickiedPostImageView;
+        @BindView(R.id.post_time_text_view_item_post_card_2_with_preview)
+        TextView postTimeTextView;
+        @BindView(R.id.title_text_view_item_post_card_2_with_preview)
+        TextView titleTextView;
+        @BindView(R.id.type_text_view_item_post_card_2_with_preview)
+        CustomTextView typeTextView;
+        @BindView(R.id.archived_image_view_item_post_card_2_with_preview)
+        ImageView archivedImageView;
+        @BindView(R.id.locked_image_view_item_post_card_2_with_preview)
+        ImageView lockedImageView;
+        @BindView(R.id.crosspost_image_view_item_post_card_2_with_preview)
+        ImageView crosspostImageView;
+        @BindView(R.id.nsfw_text_view_item_post_card_2_with_preview)
+        CustomTextView nsfwTextView;
+        @BindView(R.id.spoiler_custom_text_view_item_post_card_2_with_preview)
+        CustomTextView spoilerTextView;
+        @BindView(R.id.flair_custom_text_view_item_post_card_2_with_preview)
+        CustomTextView flairTextView;
+        @BindView(R.id.awards_text_view_item_post_card_2_with_preview)
+        CustomTextView awardsTextView;
+        @BindView(R.id.link_text_view_item_post_card_2_with_preview)
+        TextView linkTextView;
+        @BindView(R.id.video_or_gif_indicator_image_view_item_post_card_2_with_preview)
+        ImageView videoOrGifIndicatorImageView;
+        @BindView(R.id.progress_bar_item_post_card_2_with_preview)
+        ProgressBar progressBar;
+        @BindView(R.id.image_view_item_post_card_2_with_preview)
+        AspectRatioGifImageView imageView;
+        @BindView(R.id.load_image_error_text_view_item_post_card_2_with_preview)
+        TextView errorTextView;
+        @BindView(R.id.image_view_no_preview_gallery_item_post_card_2_with_preview)
+        ImageView noPreviewImageView;
+        @BindView(R.id.bottom_constraint_layout_item_post_card_2_with_preview)
+        ConstraintLayout bottomConstraintLayout;
+        @BindView(R.id.plus_button_item_post_card_2_with_preview)
+        ImageView upvoteButton;
+        @BindView(R.id.score_text_view_item_post_card_2_with_preview)
+        TextView scoreTextView;
+        @BindView(R.id.minus_button_item_post_card_2_with_preview)
+        ImageView downvoteButton;
+        @BindView(R.id.comments_count_item_post_card_2_with_preview)
+        TextView commentsCountTextView;
+        @BindView(R.id.save_button_item_post_card_2_with_preview)
+        ImageView saveButton;
+        @BindView(R.id.share_button_item_post_card_2_with_preview)
+        ImageView shareButton;
+        @BindView(R.id.divider_item_post_card_2_with_preview)
+        View divider;
+        RequestListener<Drawable> requestListener;
+
+        PostCard2WithPreviewViewHolder(@NonNull View itemView) {
+            super(itemView);
+            ButterKnife.bind(this, itemView);
+            setBaseView(
+                    iconGifImageView,
+                    subredditTextView,
+                    userTextView,
+                    stickiedPostImageView,
+                    postTimeTextView,
+                    titleTextView,
+                    typeTextView,
+                    archivedImageView,
+                    lockedImageView,
+                    crosspostImageView,
+                    nsfwTextView,
+                    spoilerTextView,
+                    flairTextView,
+                    awardsTextView,
+                    bottomConstraintLayout,
+                    upvoteButton,
+                    scoreTextView,
+                    downvoteButton,
+                    commentsCountTextView,
+                    saveButton,
+                    shareButton,
+                    true);
+
+            if (mActivity.typeface != null) {
+                linkTextView.setTypeface(mActivity.typeface);
+                errorTextView.setTypeface(mActivity.typeface);
+            }
+            linkTextView.setTextColor(mSecondaryTextColor);
+            noPreviewImageView.setBackgroundColor(mNoPreviewPostTypeBackgroundColor);
+            noPreviewImageView.setColorFilter(mNoPreviewPostTypeIconTint, android.graphics.PorterDuff.Mode.SRC_IN);
+            progressBar.setIndeterminateTintList(ColorStateList.valueOf(mColorAccent));
+            videoOrGifIndicatorImageView.setColorFilter(mMediaIndicatorIconTint, PorterDuff.Mode.SRC_IN);
+            videoOrGifIndicatorImageView.setBackgroundTintList(ColorStateList.valueOf(mMediaIndicatorBackgroundColor));
+            errorTextView.setTextColor(mPrimaryTextColor);
+            divider.setBackgroundColor(mDividerColor);
+
+            imageView.setOnClickListener(view -> {
+                int position = getBindingAdapterPosition();
+                if (position < 0) {
+                    return;
+                }
+                Post post = getItem(position);
+                if (post != null) {
+                    openMedia(post);
+                }
+            });
+
+            errorTextView.setOnClickListener(view -> {
+                progressBar.setVisibility(View.VISIBLE);
+                errorTextView.setVisibility(View.GONE);
+                loadImage(this);
+            });
+
+            noPreviewImageView.setOnClickListener(view -> {
+                imageView.performClick();
+            });
+
+            requestListener = new RequestListener<>() {
+                @Override
+                public boolean onLoadFailed(@Nullable GlideException e, Object model, Target<Drawable> target, boolean isFirstResource) {
+                    progressBar.setVisibility(View.GONE);
+                    errorTextView.setVisibility(View.VISIBLE);
+                    return false;
+                }
+
+                @Override
+                public boolean onResourceReady(Drawable resource, Object model, Target<Drawable> target, DataSource dataSource, boolean isFirstResource) {
+                    errorTextView.setVisibility(View.GONE);
+                    progressBar.setVisibility(View.GONE);
+                    return false;
+                }
+            };
+        }
+    }
+
+    public class PostCard2GalleryTypeViewHolder extends PostBaseGalleryTypeViewHolder {
+
+        PostCard2GalleryTypeViewHolder(ItemPostCard2GalleryTypeBinding binding) {
+            super(binding.getRoot(),
+                    binding.iconGifImageViewItemPostCard2GalleryType,
+                    binding.subredditNameTextViewItemPostCard2GalleryType,
+                    binding.userTextViewItemPostCard2GalleryType,
+                    binding.stickiedPostImageViewItemPostCard2GalleryType,
+                    binding.postTimeTextViewItemPostCard2GalleryType,
+                    binding.titleTextViewItemPostCard2GalleryType,
+                    binding.typeTextViewItemPostCard2GalleryType,
+                    binding.archivedImageViewItemPostCard2GalleryType,
+                    binding.lockedImageViewItemPostCard2GalleryType,
+                    binding.crosspostImageViewItemPostCard2GalleryType,
+                    binding.nsfwTextViewItemPostCard2GalleryType,
+                    binding.spoilerCustomTextViewItemPostCard2GalleryType,
+                    binding.flairCustomTextViewItemPostCard2GalleryType,
+                    binding.awardsTextViewItemPostCard2GalleryType,
+                    binding.galleryFrameLayoutItemPostCard2GalleryType,
+                    binding.galleryRecyclerViewItemPostCard2GalleryType,
+                    binding.imageIndexTextViewItemPostCard2GalleryType,
+                    binding.noPreviewImageViewItemPostCard2GalleryType,
+                    binding.bottomConstraintLayoutItemPostCard2GalleryType,
+                    binding.upvoteButtonItemPostCard2GalleryType,
+                    binding.scoreTextViewItemPostCard2GalleryType,
+                    binding.downvoteButtonItemPostCard2GalleryType,
+                    binding.commentsCountTextViewItemPostCard2GalleryType,
+                    binding.saveButtonItemPostCard2GalleryType,
+                    binding.shareButtonItemPostCard2GalleryType,
+                    true);
+
+            binding.dividerItemPostCard2GalleryType.setBackgroundColor(mDividerColor);
+        }
+    }
+
+    class PostCard2TextTypeViewHolder extends PostBaseViewHolder {
+        @BindView(R.id.icon_gif_image_view_item_post_card_2_text)
+        AspectRatioGifImageView iconGifImageView;
+        @BindView(R.id.subreddit_name_text_view_item_post_card_2_text)
+        TextView subredditTextView;
+        @BindView(R.id.user_text_view_item_post_card_2_text)
+        TextView userTextView;
+        @BindView(R.id.stickied_post_image_view_item_post_card_2_text)
+        ImageView stickiedPostImageView;
+        @BindView(R.id.post_time_text_view_item_post_card_2_text)
+        TextView postTimeTextView;
+        @BindView(R.id.title_text_view_item_post_card_2_text)
+        TextView titleTextView;
+        @BindView(R.id.content_text_view_item_post_card_2_text)
+        TextView contentTextView;
+        @BindView(R.id.type_text_view_item_post_card_2_text)
+        CustomTextView typeTextView;
+        @BindView(R.id.archived_image_view_item_post_card_2_text)
+        ImageView archivedImageView;
+        @BindView(R.id.locked_image_view_item_post_card_2_text)
+        ImageView lockedImageView;
+        @BindView(R.id.crosspost_image_view_item_post_card_2_text)
+        ImageView crosspostImageView;
+        @BindView(R.id.nsfw_text_view_item_post_card_2_text)
+        CustomTextView nsfwTextView;
+        @BindView(R.id.spoiler_custom_text_view_item_post_card_2_text)
+        CustomTextView spoilerTextView;
+        @BindView(R.id.flair_custom_text_view_item_post_card_2_text)
+        CustomTextView flairTextView;
+        @BindView(R.id.awards_text_view_item_post_card_2_text)
+        CustomTextView awardsTextView;
+        @BindView(R.id.bottom_constraint_layout_item_post_card_2_text)
+        ConstraintLayout bottomConstraintLayout;
+        @BindView(R.id.plus_button_item_post_card_2_text)
+        ImageView upvoteButton;
+        @BindView(R.id.score_text_view_item_post_card_2_text)
+        TextView scoreTextView;
+        @BindView(R.id.minus_button_item_post_card_2_text)
+        ImageView downvoteButton;
+        @BindView(R.id.comments_count_item_post_card_2_text)
+        TextView commentsCountTextView;
+        @BindView(R.id.save_button_item_post_card_2_text)
+        ImageView saveButton;
+        @BindView(R.id.share_button_item_post_card_2_text)
+        ImageView shareButton;
+        @BindView(R.id.divider_item_post_card_2_text)
+        View divider;
+
+        PostCard2TextTypeViewHolder(@NonNull View itemView) {
+            super(itemView);
+            ButterKnife.bind(this, itemView);
+            setBaseView(
+                    iconGifImageView,
+                    subredditTextView,
+                    userTextView,
+                    stickiedPostImageView,
+                    postTimeTextView,
+                    titleTextView,
+                    typeTextView,
+                    archivedImageView,
+                    lockedImageView,
+                    crosspostImageView,
+                    nsfwTextView,
+                    spoilerTextView,
+                    flairTextView,
+                    awardsTextView,
+                    bottomConstraintLayout,
+                    upvoteButton,
+                    scoreTextView,
+                    downvoteButton,
+                    commentsCountTextView,
+                    saveButton,
+                    shareButton,
+                    true);
+
+            if (mActivity.contentTypeface != null) {
+                contentTextView.setTypeface(mActivity.contentTypeface);
+            }
+            contentTextView.setTextColor(mPostContentColor);
+            divider.setBackgroundColor(mDividerColor);
+        }
+    }
+}

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/PostDetailRecyclerViewAdapter.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/PostDetailRecyclerViewAdapter.java
@@ -70,6 +70,7 @@ import jp.wasabeef.glide.transformations.RoundedCornersTransformation;
 import me.saket.bettermovementmethod.BetterLinkMovementMethod;
 import ml.docilealligator.infinityforreddit.FetchGfycatOrRedgifsVideoLinks;
 import ml.docilealligator.infinityforreddit.FetchStreamableVideo;
+import ml.docilealligator.infinityforreddit.LocalSave;
 import ml.docilealligator.infinityforreddit.R;
 import ml.docilealligator.infinityforreddit.RedditDataRoomDatabase;
 import ml.docilealligator.infinityforreddit.SaveMemoryCenterInisdeDownsampleStrategy;
@@ -1428,9 +1429,20 @@ public class PostDetailRecyclerViewAdapter extends RecyclerView.Adapter<Recycler
                 }
             });
 
+            mSaveButton.setOnLongClickListener(view ->
+            {
+                LocalSave.AddPost(mPost.getId(), mPost.getTitle(), mPost.getSubredditName(), mPost.getFlair(), mPost.getPostTimeMillis());
+                return true;
+            });
+
             mShareButton.setOnClickListener(view -> {
                 Bundle bundle = new Bundle();
                 bundle.putString(ShareLinkBottomSheetFragment.EXTRA_POST_LINK, mPost.getPermalink());
+                bundle.putString(ShareLinkBottomSheetFragment.EXTRA_POST_ID, mPost.getId());
+                bundle.putString(ShareLinkBottomSheetFragment.EXTRA_POST_TITLE, mPost.getTitle());
+                bundle.putString(ShareLinkBottomSheetFragment.EXTRA_POST_SUBREDDIT, mPost.getSubredditName());
+                bundle.putString(ShareLinkBottomSheetFragment.EXTRA_POST_FLAIR, mPost.getFlair());
+                bundle.putLong(ShareLinkBottomSheetFragment.EXTRA_POST_TIME, mPost.getPostTimeMillis());
                 if (mPost.getPostType() != Post.TEXT_TYPE) {
                     bundle.putInt(ShareLinkBottomSheetFragment.EXTRA_MEDIA_TYPE, mPost.getPostType());
                     switch (mPost.getPostType()) {

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/PostRecyclerViewAdapter.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/PostRecyclerViewAdapter.java
@@ -68,6 +68,7 @@ import jp.wasabeef.glide.transformations.BlurTransformation;
 import jp.wasabeef.glide.transformations.RoundedCornersTransformation;
 import ml.docilealligator.infinityforreddit.FetchGfycatOrRedgifsVideoLinks;
 import ml.docilealligator.infinityforreddit.FetchStreamableVideo;
+import ml.docilealligator.infinityforreddit.LocalSave;
 import ml.docilealligator.infinityforreddit.MarkPostAsReadInterface;
 import ml.docilealligator.infinityforreddit.R;
 import ml.docilealligator.infinityforreddit.SaveMemoryCenterInisdeDownsampleStrategy;
@@ -1723,6 +1724,11 @@ public class PostRecyclerViewAdapter extends PagingDataAdapter<Post, RecyclerVie
     private void shareLink(Post post) {
         Bundle bundle = new Bundle();
         bundle.putString(ShareLinkBottomSheetFragment.EXTRA_POST_LINK, post.getPermalink());
+        bundle.putString(ShareLinkBottomSheetFragment.EXTRA_POST_ID, post.getId());
+        bundle.putString(ShareLinkBottomSheetFragment.EXTRA_POST_TITLE, post.getTitle());
+        bundle.putString(ShareLinkBottomSheetFragment.EXTRA_POST_SUBREDDIT, post.getSubredditName());
+        bundle.putString(ShareLinkBottomSheetFragment.EXTRA_POST_FLAIR, post.getFlair());
+        bundle.putLong(ShareLinkBottomSheetFragment.EXTRA_POST_TIME, post.getPostTimeMillis());
         if (post.getPostType() != Post.TEXT_TYPE) {
             bundle.putInt(ShareLinkBottomSheetFragment.EXTRA_MEDIA_TYPE, post.getPostType());
             switch (post.getPostType()) {
@@ -2692,6 +2698,20 @@ public class PostRecyclerViewAdapter extends PagingDataAdapter<Post, RecyclerVie
                                 });
                     }
                 }
+            });
+
+            saveButton.setOnLongClickListener(view ->
+            {
+                int position = getBindingAdapterPosition();
+                if (position < 0) {
+                    return false;
+                }
+                Post post = getItem(position);
+                if (post != null) {
+                    LocalSave.AddPost(post.getId(), post.getTitle(), post.getSubredditName(), post.getFlair(), post.getPostTimeMillis());
+                    return true;
+                }
+                return false;
             });
 
             shareButton.setOnClickListener(view -> {
@@ -4059,6 +4079,20 @@ public class PostRecyclerViewAdapter extends PagingDataAdapter<Post, RecyclerVie
                                 });
                     }
                 }
+            });
+
+            saveButton.setOnLongClickListener(view ->
+            {
+                int position = getBindingAdapterPosition();
+                if (position < 0) {
+                    return false;
+                }
+                Post post = getItem(position);
+                if (post != null) {
+                    LocalSave.AddPost(post.getId(), post.getTitle(), post.getSubredditName(), post.getFlair(), post.getPostTimeMillis());
+                    return true;
+                }
+                return false;
             });
 
             shareButton.setOnClickListener(view -> {

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/navigationdrawer/AccountSectionRecyclerViewAdapter.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/navigationdrawer/AccountSectionRecyclerViewAdapter.java
@@ -25,7 +25,7 @@ public class AccountSectionRecyclerViewAdapter extends RecyclerView.Adapter<Recy
 
     private static final int VIEW_TYPE_MENU_GROUP_TITLE = 1;
     private static final int VIEW_TYPE_MENU_ITEM = 2;
-    private static final int ACCOUNT_SECTION_ITEMS = 5;
+    private static final int ACCOUNT_SECTION_ITEMS = 6;
     private static final int ANONYMOUS_ACCOUNT_SECTION_ITEMS = 3;
 
     private BaseActivity baseActivity;
@@ -117,6 +117,10 @@ public class AccountSectionRecyclerViewAdapter extends RecyclerView.Adapter<Recy
                             Intent intent = new Intent(baseActivity, InboxActivity.class);
                             baseActivity.startActivity(intent);
                         });
+                        break;
+                    case 5:
+                        stringId = R.string.local_posts;
+                        drawableId = R.drawable.ic_import_day_night_24dp;
                         break;
                     default:
                         stringId = R.string.history;

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/bottomsheetfragments/ShareLinkBottomSheetFragment.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/bottomsheetfragments/ShareLinkBottomSheetFragment.java
@@ -35,6 +35,7 @@ public class ShareLinkBottomSheetFragment extends LandscapeExpandedRoundedBottom
     public static final String EXTRA_POST_ID = "EPID";
     public static final String EXTRA_POST_SUBREDDIT = "EPS";
     public static final String EXTRA_POST_TITLE = "EPT";
+    public static final String EXTRA_POST_TIME = "EPTI";
     public static final String EXTRA_POST_FLAIR = "EPF";
     public static final String EXTRA_POST_LINK = "EPL";
     public static final String EXTRA_MEDIA_LINK = "EML";
@@ -107,6 +108,7 @@ public class ShareLinkBottomSheetFragment extends LandscapeExpandedRoundedBottom
         String postTitle = getArguments().getString(EXTRA_POST_TITLE);
         String postSubName = getArguments().getString(EXTRA_POST_SUBREDDIT);
         String postFlair = getArguments().getString(EXTRA_POST_FLAIR);
+        long postTime = getArguments().getLong(EXTRA_POST_TIME);
 
         postLinkTextView.setText(postLink);
 
@@ -158,7 +160,7 @@ public class ShareLinkBottomSheetFragment extends LandscapeExpandedRoundedBottom
             ShowTags(postID);
         });
         addLocalTextView.setOnClickListener(view -> {
-            LocalSave.AddPost(postID, postTitle, postSubName, postFlair, 0);
+            LocalSave.AddPost(postID, postTitle, postSubName, postFlair, postTime);
             dismiss();
         });
         removeLocalTextView.setOnClickListener(view -> {

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/bottomsheetfragments/ShareLinkBottomSheetFragment.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/bottomsheetfragments/ShareLinkBottomSheetFragment.java
@@ -1,21 +1,27 @@
 package ml.docilealligator.infinityforreddit.bottomsheetfragments;
 
 
+import android.app.AlertDialog;
 import android.content.ActivityNotFoundException;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.EditText;
 import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+
 import butterknife.BindView;
 import butterknife.ButterKnife;
+import ml.docilealligator.infinityforreddit.LocalSave;
 import ml.docilealligator.infinityforreddit.R;
 import ml.docilealligator.infinityforreddit.activities.BaseActivity;
 import ml.docilealligator.infinityforreddit.customviews.LandscapeExpandedRoundedBottomSheetDialogFragment;
@@ -26,9 +32,23 @@ import ml.docilealligator.infinityforreddit.utils.Utils;
  * A simple {@link Fragment} subclass.
  */
 public class ShareLinkBottomSheetFragment extends LandscapeExpandedRoundedBottomSheetDialogFragment {
+    public static final String EXTRA_POST_ID = "EPID";
+    public static final String EXTRA_POST_SUBREDDIT = "EPS";
+    public static final String EXTRA_POST_TITLE = "EPT";
+    public static final String EXTRA_POST_FLAIR = "EPF";
     public static final String EXTRA_POST_LINK = "EPL";
     public static final String EXTRA_MEDIA_LINK = "EML";
     public static final String EXTRA_MEDIA_TYPE = "EMT";
+
+
+    @BindView(R.id.manage_tags)
+    TextView manageTagsTextView;
+
+    @BindView(R.id.remove_local_post)
+    TextView removeLocalTextView;
+    @BindView(R.id.add_local_post)
+    TextView addLocalTextView;
+
 
     @BindView(R.id.post_link_text_view_share_link_bottom_sheet_fragment)
     TextView postLinkTextView;
@@ -49,6 +69,29 @@ public class ShareLinkBottomSheetFragment extends LandscapeExpandedRoundedBottom
         // Required empty public constructor
     }
 
+    private void ShowTags(String postID)
+    {
+        MaterialAlertDialogBuilder alert = new MaterialAlertDialogBuilder(activity, R.style.MaterialAlertDialogTheme).setTitle("Tags");
+
+        LocalSave.SavedPost post = LocalSave.GetPost(postID);
+        if(post == null)
+        {
+            alert.setMessage("Post is not saved");
+            alert.setPositiveButton("OK", (dialogInterface, i) -> dialogInterface.dismiss());
+            alert.show();
+            return;
+        }
+
+        final EditText input = new EditText(activity);
+        input.setText(post.getTags());
+
+        alert.setView(input);
+
+        alert.setPositiveButton("Save", (dialogInterface, i) -> post.setTags(input.getText().toString()));
+        alert.setNegativeButton("Cancel", (dialogInterface, i) -> dialogInterface.dismiss());
+
+        alert.show();
+    }
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
@@ -60,6 +103,10 @@ public class ShareLinkBottomSheetFragment extends LandscapeExpandedRoundedBottom
 
         String postLink = getArguments().getString(EXTRA_POST_LINK);
         String mediaLink = getArguments().containsKey(EXTRA_MEDIA_LINK) ? getArguments().getString(EXTRA_MEDIA_LINK) : null;
+        String postID = getArguments().getString(EXTRA_POST_ID);
+        String postTitle = getArguments().getString(EXTRA_POST_TITLE);
+        String postSubName = getArguments().getString(EXTRA_POST_SUBREDDIT);
+        String postFlair = getArguments().getString(EXTRA_POST_FLAIR);
 
         postLinkTextView.setText(postLink);
 
@@ -106,6 +153,18 @@ public class ShareLinkBottomSheetFragment extends LandscapeExpandedRoundedBottom
                 dismiss();
             });
         }
+
+        manageTagsTextView.setOnClickListener(view -> {
+            ShowTags(postID);
+        });
+        addLocalTextView.setOnClickListener(view -> {
+            LocalSave.AddPost(postID, postTitle, postSubName, postFlair, 0);
+            dismiss();
+        });
+        removeLocalTextView.setOnClickListener(view -> {
+            LocalSave.RemovePost(postID);
+            dismiss();
+        });
 
         sharePostLinkTextView.setOnClickListener(view -> {
             shareLink(postLink);

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/fragments/LocalPostFragment.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/fragments/LocalPostFragment.java
@@ -379,7 +379,7 @@ public class LocalPostFragment extends Fragment implements FragmentCommunicator 
 
         if (localType == LOCALPOST_TYPE_READ_POSTS) {
             postLayout = mPostLayoutSharedPreferences.getInt(SharedPreferencesUtils.LOCAL_POST_LAYOUT, defaultPostLayout);
-            LocalSave.sortType = mPostLayoutSharedPreferences.getInt(SharedPreferencesUtils.LOCAL_POST_SORTING, LocalSave.SORT_NEWEST);
+            LocalSave.sortType = mPostLayoutSharedPreferences.getInt(SharedPreferencesUtils.LOCAL_POST_SORTING, LocalSave.SORT_NEWEST_ADDED);
             LocalSave.cacheSaved = mPostLayoutSharedPreferences.getBoolean(SharedPreferencesUtils.LOCAL_POST_CACHE_SAVED, true);
             LocalSave.cacheHistory = mPostLayoutSharedPreferences.getBoolean(SharedPreferencesUtils.LOCAL_POST_CACHE_HISTORY, false);
 
@@ -657,15 +657,9 @@ public class LocalPostFragment extends Fragment implements FragmentCommunicator 
     }
 
     private void initializeAndBindPostViewModel(String accessToken) {
-        if (postType == LocalPostPagingSource.TYPE_READ_POSTS) {
-            mLocalPostViewModel = new ViewModelProvider(LocalPostFragment.this, new LocalPostViewModel.Factory(mExecutor,
-                    accessToken == null ? mRetrofit : mOauthRetrofit, mRedditDataRoomDatabase, accessToken,
-                    accountName, mSharedPreferences, LocalPostPagingSource.TYPE_READ_POSTS, postFilter)).get(LocalPostViewModel.class);
-        } else {
-            mLocalPostViewModel = new ViewModelProvider(LocalPostFragment.this, new LocalPostViewModel.Factory(mExecutor,
-                    accessToken == null ? mRetrofit : mOauthRetrofit, mRedditDataRoomDatabase, accessToken,
-                    accountName, mSharedPreferences, LocalPostPagingSource.TYPE_READ_POSTS, postFilter)).get(LocalPostViewModel.class);
-        }
+        mLocalPostViewModel = new ViewModelProvider(LocalPostFragment.this, new LocalPostViewModel.Factory(mExecutor,
+                accessToken == null ? mRetrofit : mOauthRetrofit, mRedditDataRoomDatabase, accessToken,
+                accountName, mSharedPreferences, LocalPostPagingSource.TYPE_READ_POSTS, postFilter)).get(LocalPostViewModel.class);
 
         bindPostViewModel();
     }

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/fragments/LocalPostFragment.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/fragments/LocalPostFragment.java
@@ -1,0 +1,1450 @@
+package ml.docilealligator.infinityforreddit.fragments;
+
+import static ml.docilealligator.infinityforreddit.videoautoplay.media.PlaybackInfo.INDEX_UNSET;
+import static ml.docilealligator.infinityforreddit.videoautoplay.media.PlaybackInfo.TIME_UNSET;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.content.res.Configuration;
+import android.content.res.Resources;
+import android.graphics.Canvas;
+import android.graphics.Rect;
+import android.graphics.drawable.ColorDrawable;
+import android.graphics.drawable.Drawable;
+import android.os.Build;
+import android.os.Bundle;
+import android.os.CountDownTimer;
+import android.os.Handler;
+import android.view.HapticFeedbackConstants;
+import android.view.KeyEvent;
+import android.view.LayoutInflater;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.Window;
+import android.view.WindowManager;
+import android.widget.ImageView;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.annotation.DimenRes;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.content.res.ResourcesCompat;
+import androidx.fragment.app.Fragment;
+import androidx.lifecycle.ViewModelProvider;
+import androidx.paging.ItemSnapshotList;
+import androidx.paging.LoadState;
+import androidx.recyclerview.widget.ItemTouchHelper;
+import androidx.recyclerview.widget.LinearSmoothScroller;
+import androidx.recyclerview.widget.RecyclerView;
+import androidx.recyclerview.widget.StaggeredGridLayoutManager;
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
+import androidx.transition.AutoTransition;
+import androidx.transition.TransitionManager;
+
+import com.bumptech.glide.Glide;
+import com.bumptech.glide.RequestManager;
+
+import org.greenrobot.eventbus.EventBus;
+import org.greenrobot.eventbus.Subscribe;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.Executor;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Provider;
+
+import butterknife.BindView;
+import butterknife.ButterKnife;
+import butterknife.Unbinder;
+import ml.docilealligator.infinityforreddit.FetchPostFilterReadPostsAndConcatenatedSubredditNames;
+import ml.docilealligator.infinityforreddit.FragmentCommunicator;
+import ml.docilealligator.infinityforreddit.Infinity;
+import ml.docilealligator.infinityforreddit.R;
+import ml.docilealligator.infinityforreddit.RecyclerViewContentScrollingInterface;
+import ml.docilealligator.infinityforreddit.RedditDataRoomDatabase;
+import ml.docilealligator.infinityforreddit.activities.BaseActivity;
+import ml.docilealligator.infinityforreddit.adapters.LocalPostRecyclerViewAdapter;
+import ml.docilealligator.infinityforreddit.adapters.Paging3LoadingStateAdapter;
+import ml.docilealligator.infinityforreddit.apis.StreamableAPI;
+import ml.docilealligator.infinityforreddit.asynctasks.LoadSubredditIcon;
+import ml.docilealligator.infinityforreddit.asynctasks.LoadUserData;
+import ml.docilealligator.infinityforreddit.customtheme.CustomThemeWrapper;
+import ml.docilealligator.infinityforreddit.customviews.CustomToroContainer;
+import ml.docilealligator.infinityforreddit.customviews.LinearLayoutManagerBugFixed;
+import ml.docilealligator.infinityforreddit.events.ChangeAutoplayNsfwVideosEvent;
+import ml.docilealligator.infinityforreddit.events.ChangeCompactLayoutToolbarHiddenByDefaultEvent;
+import ml.docilealligator.infinityforreddit.events.ChangeDataSavingModeEvent;
+import ml.docilealligator.infinityforreddit.events.ChangeDefaultLinkPostLayoutEvent;
+import ml.docilealligator.infinityforreddit.events.ChangeDefaultPostLayoutEvent;
+import ml.docilealligator.infinityforreddit.events.ChangeDisableImagePreviewEvent;
+import ml.docilealligator.infinityforreddit.events.ChangeEasierToWatchInFullScreenEvent;
+import ml.docilealligator.infinityforreddit.events.ChangeEnableSwipeActionSwitchEvent;
+import ml.docilealligator.infinityforreddit.events.ChangeFixedHeightPreviewInCardEvent;
+import ml.docilealligator.infinityforreddit.events.ChangeHidePostFlairEvent;
+import ml.docilealligator.infinityforreddit.events.ChangeHidePostTypeEvent;
+import ml.docilealligator.infinityforreddit.events.ChangeHideSubredditAndUserPrefixEvent;
+import ml.docilealligator.infinityforreddit.events.ChangeHideTextPostContent;
+import ml.docilealligator.infinityforreddit.events.ChangeHideTheNumberOfAwardsEvent;
+import ml.docilealligator.infinityforreddit.events.ChangeHideTheNumberOfCommentsEvent;
+import ml.docilealligator.infinityforreddit.events.ChangeHideTheNumberOfVotesEvent;
+import ml.docilealligator.infinityforreddit.events.ChangeLongPressToHideToolbarInCompactLayoutEvent;
+import ml.docilealligator.infinityforreddit.events.ChangeMuteAutoplayingVideosEvent;
+import ml.docilealligator.infinityforreddit.events.ChangeMuteNSFWVideoEvent;
+import ml.docilealligator.infinityforreddit.events.ChangeNSFWBlurEvent;
+import ml.docilealligator.infinityforreddit.events.ChangeNetworkStatusEvent;
+import ml.docilealligator.infinityforreddit.events.ChangeOnlyDisablePreviewInVideoAndGifPostsEvent;
+import ml.docilealligator.infinityforreddit.events.ChangePostFeedMaxResolutionEvent;
+import ml.docilealligator.infinityforreddit.events.ChangePostLayoutEvent;
+import ml.docilealligator.infinityforreddit.events.ChangePullToRefreshEvent;
+import ml.docilealligator.infinityforreddit.events.ChangeRememberMutingOptionInPostFeedEvent;
+import ml.docilealligator.infinityforreddit.events.ChangeShowAbsoluteNumberOfVotesEvent;
+import ml.docilealligator.infinityforreddit.events.ChangeShowElapsedTimeEvent;
+import ml.docilealligator.infinityforreddit.events.ChangeSpoilerBlurEvent;
+import ml.docilealligator.infinityforreddit.events.ChangeStartAutoplayVisibleAreaOffsetEvent;
+import ml.docilealligator.infinityforreddit.events.ChangeSwipeActionEvent;
+import ml.docilealligator.infinityforreddit.events.ChangeSwipeActionThresholdEvent;
+import ml.docilealligator.infinityforreddit.events.ChangeTimeFormatEvent;
+import ml.docilealligator.infinityforreddit.events.ChangeVibrateWhenActionTriggeredEvent;
+import ml.docilealligator.infinityforreddit.events.ChangeVideoAutoplayEvent;
+import ml.docilealligator.infinityforreddit.events.ChangeVoteButtonsPositionEvent;
+import ml.docilealligator.infinityforreddit.events.NeedForPostListFromPostFragmentEvent;
+import ml.docilealligator.infinityforreddit.events.PostUpdateEventToPostList;
+import ml.docilealligator.infinityforreddit.events.ProvidePostListToViewPostDetailActivityEvent;
+import ml.docilealligator.infinityforreddit.events.ShowDividerInCompactLayoutPreferenceEvent;
+import ml.docilealligator.infinityforreddit.events.ShowThumbnailOnTheRightInCompactLayoutEvent;
+import ml.docilealligator.infinityforreddit.post.LocalPostPagingSource;
+import ml.docilealligator.infinityforreddit.post.LocalPostViewModel;
+import ml.docilealligator.infinityforreddit.post.Post;
+import ml.docilealligator.infinityforreddit.postfilter.PostFilter;
+import ml.docilealligator.infinityforreddit.postfilter.PostFilterUsage;
+import ml.docilealligator.infinityforreddit.utils.SharedPreferencesUtils;
+import ml.docilealligator.infinityforreddit.utils.Utils;
+import ml.docilealligator.infinityforreddit.videoautoplay.ExoCreator;
+import ml.docilealligator.infinityforreddit.videoautoplay.media.PlaybackInfo;
+import ml.docilealligator.infinityforreddit.videoautoplay.media.VolumeInfo;
+import retrofit2.Retrofit;
+
+public class LocalPostFragment extends Fragment implements FragmentCommunicator {
+
+    public static final String EXTRA_ACCESS_TOKEN = "EAT";
+    public static final String EXTRA_ACCOUNT_NAME = "EAN";
+    public static final String EXTRA_LOCALPOST_TYPE = "EHT";
+    public static final String EXTRA_FILTER = "EF";
+    public static final int LOCALPOST_TYPE_READ_POSTS = 1;
+
+    private static final String IS_IN_LAZY_MODE_STATE = "IILMS";
+    private static final String RECYCLER_VIEW_POSITION_STATE = "RVPS";
+    private static final String READ_POST_LIST_STATE = "RPLS";
+    private static final String POST_FILTER_STATE = "PFS";
+    private static final String POST_FRAGMENT_ID_STATE = "PFIS";
+
+    @BindView(R.id.swipe_refresh_layout_local_post_fragment)
+    SwipeRefreshLayout mSwipeRefreshLayout;
+    @BindView(R.id.recycler_view_local_post_fragment)
+    CustomToroContainer mPostRecyclerView;
+    @BindView(R.id.fetch_post_info_linear_layout_local_post_fragment)
+    LinearLayout mFetchPostInfoLinearLayout;
+    @BindView(R.id.fetch_post_info_image_view_local_post_fragment)
+    ImageView mFetchPostInfoImageView;
+    @BindView(R.id.fetch_post_info_text_view_local_post_fragment)
+    TextView mFetchPostInfoTextView;
+    LocalPostViewModel mLocalPostViewModel;
+    @Inject
+    @Named("no_oauth")
+    Retrofit mRetrofit;
+    @Inject
+    @Named("oauth")
+    Retrofit mOauthRetrofit;
+    @Inject
+    @Named("gfycat")
+    Retrofit mGfycatRetrofit;
+    @Inject
+    @Named("redgifs")
+    Retrofit mRedgifsRetrofit;
+    @Inject
+    Provider<StreamableAPI> mStreamableApiProvider;
+    @Inject
+    RedditDataRoomDatabase mRedditDataRoomDatabase;
+    @Inject
+    @Named("default")
+    SharedPreferences mSharedPreferences;
+    @Inject
+    @Named("current_account")
+    SharedPreferences mCurrentAccountSharedPreferences;
+    @Inject
+    @Named("post_layout")
+    SharedPreferences mPostLayoutSharedPreferences;
+    @Inject
+    @Named("nsfw_and_spoiler")
+    SharedPreferences mNsfwAndSpoilerSharedPreferences;
+    @Inject
+    @Named("post_local")
+    SharedPreferences mPostLocalSharedPreferences;
+    @Inject
+    @Named("post_feed_scrolled_position_cache")
+    SharedPreferences mPostFeedScrolledPositionSharedPreferences;
+    @Inject
+    CustomThemeWrapper mCustomThemeWrapper;
+    @Inject
+    ExoCreator mExoCreator;
+    @Inject
+    Executor mExecutor;
+    private RequestManager mGlide;
+    private BaseActivity activity;
+    private LinearLayoutManagerBugFixed mLinearLayoutManager;
+    private StaggeredGridLayoutManager mStaggeredGridLayoutManager;
+    private MenuItem lazyModeItem;
+    private long localPostFragmentId;
+    private int postType;
+    private boolean isInLazyMode = false;
+    private boolean isLazyModePaused = false;
+    private boolean hasPost = false;
+    private boolean rememberMutingOptionInPostFeed;
+    private boolean swipeActionEnabled;
+    private Boolean masterMutingOption;
+    private LocalPostRecyclerViewAdapter mAdapter;
+    private RecyclerView.SmoothScroller smoothScroller;
+    private Window window;
+    private Handler lazyModeHandler;
+    private LazyModeRunnable lazyModeRunnable;
+    private CountDownTimer resumeLazyModeCountDownTimer;
+    private float lazyModeInterval;
+    private String accountName;
+    private int maxPosition = -1;
+    private int postLayout;
+    private PostFilter postFilter;
+    private ColorDrawable backgroundSwipeRight;
+    private ColorDrawable backgroundSwipeLeft;
+    private Drawable drawableSwipeRight;
+    private Drawable drawableSwipeLeft;
+    private int swipeLeftAction;
+    private int swipeRightAction;
+    private boolean vibrateWhenActionTriggered;
+    private float swipeActionThreshold;
+    private ItemTouchHelper touchHelper;
+    private ArrayList<String> readPosts;
+    private Unbinder unbinder;
+    private Map<String, String> subredditOrUserIcons = new HashMap<>();
+    private String accessToken;
+    private int localType;
+
+    public LocalPostFragment() {
+        // Required empty public constructor
+    }
+
+    public static LocalPostFragment newInstance() {
+        LocalPostFragment fragment = new LocalPostFragment();
+        Bundle args = new Bundle();
+        fragment.setArguments(args);
+        return fragment;
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        // Inflate the layout for this fragment
+        View rootView = inflater.inflate(R.layout.fragment_local_post, container, false);
+
+        ((Infinity) activity.getApplication()).getAppComponent().inject(this);
+
+        unbinder = ButterKnife.bind(this, rootView);
+
+        setHasOptionsMenu(true);
+
+        EventBus.getDefault().register(this);
+
+        applyTheme();
+
+        mPostRecyclerView.addOnWindowFocusChangedListener(this::onWindowFocusChanged);
+
+        lazyModeHandler = new Handler();
+
+        lazyModeInterval = Float.parseFloat(mSharedPreferences.getString(SharedPreferencesUtils.LAZY_MODE_INTERVAL_KEY, "2.5"));
+
+        smoothScroller = new LinearSmoothScroller(activity) {
+            @Override
+            protected int getVerticalSnapPreference() {
+                return LinearSmoothScroller.SNAP_TO_START;
+            }
+        };
+
+        window = activity.getWindow();
+
+        Resources resources = getResources();
+
+        if ((activity != null && activity.isImmersiveInterface())) {
+            mPostRecyclerView.setPadding(0, 0, 0, ((BaseActivity) activity).getNavBarHeight());
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O
+                && mSharedPreferences.getBoolean(SharedPreferencesUtils.IMMERSIVE_INTERFACE_KEY, true)) {
+            int navBarResourceId = resources.getIdentifier("navigation_bar_height", "dimen", "android");
+            if (navBarResourceId > 0) {
+                mPostRecyclerView.setPadding(0, 0, 0, resources.getDimensionPixelSize(navBarResourceId));
+            }
+        }
+
+        mGlide = Glide.with(activity);
+
+        lazyModeRunnable = new LazyModeRunnable() {
+
+            @Override
+            public void run() {
+                if (isInLazyMode && !isLazyModePaused && mAdapter != null) {
+                    int nPosts = mAdapter.getItemCount();
+                    if (getCurrentPosition() == -1) {
+                        if (mLinearLayoutManager != null) {
+                            setCurrentPosition(mLinearLayoutManager.findFirstVisibleItemPosition());
+                        } else {
+                            int[] into = new int[2];
+                            setCurrentPosition(mStaggeredGridLayoutManager.findFirstVisibleItemPositions(into)[1]);
+                        }
+                    }
+
+                    if (getCurrentPosition() != RecyclerView.NO_POSITION && nPosts > getCurrentPosition()) {
+                        incrementCurrentPosition();
+                        smoothScroller.setTargetPosition(getCurrentPosition());
+                        if (mLinearLayoutManager != null) {
+                            mLinearLayoutManager.startSmoothScroll(smoothScroller);
+                        } else {
+                            mStaggeredGridLayoutManager.startSmoothScroll(smoothScroller);
+                        }
+                    }
+                }
+                lazyModeHandler.postDelayed(this, (long) (lazyModeInterval * 1000));
+            }
+        };
+
+        resumeLazyModeCountDownTimer = new CountDownTimer((long) (lazyModeInterval * 1000), (long) (lazyModeInterval * 1000)) {
+            @Override
+            public void onTick(long l) {
+
+            }
+
+            @Override
+            public void onFinish() {
+                resumeLazyMode(true);
+            }
+        };
+
+        mSwipeRefreshLayout.setEnabled(mSharedPreferences.getBoolean(SharedPreferencesUtils.PULL_TO_REFRESH, true));
+        mSwipeRefreshLayout.setOnRefreshListener(this::refresh);
+
+        int recyclerViewPosition = 0;
+        if (savedInstanceState != null) {
+            recyclerViewPosition = savedInstanceState.getInt(RECYCLER_VIEW_POSITION_STATE);
+
+            isInLazyMode = savedInstanceState.getBoolean(IS_IN_LAZY_MODE_STATE);
+            readPosts = savedInstanceState.getStringArrayList(READ_POST_LIST_STATE);
+            postFilter = savedInstanceState.getParcelable(POST_FILTER_STATE);
+            localPostFragmentId = savedInstanceState.getLong(POST_FRAGMENT_ID_STATE);
+        } else {
+            postFilter = getArguments().getParcelable(EXTRA_FILTER);
+            localPostFragmentId = System.currentTimeMillis() + new Random().nextInt(1000);
+        }
+
+        mPostRecyclerView.setOnTouchListener((view, motionEvent) -> {
+            if (isInLazyMode) {
+                pauseLazyMode(true);
+            }
+            return false;
+        });
+
+        if (activity instanceof RecyclerViewContentScrollingInterface) {
+            mPostRecyclerView.addOnScrollListener(new RecyclerView.OnScrollListener() {
+                @Override
+                public void onScrolled(@NonNull RecyclerView recyclerView, int dx, int dy) {
+                    if (dy > 0) {
+                        ((RecyclerViewContentScrollingInterface) activity).contentScrollDown();
+                    } else if (dy < 0) {
+                        ((RecyclerViewContentScrollingInterface) activity).contentScrollUp();
+                    }
+                }
+            });
+        }
+
+        accessToken = getArguments().getString(EXTRA_ACCESS_TOKEN);
+        accountName = getArguments().getString(EXTRA_ACCOUNT_NAME);
+        localType = getArguments().getInt(EXTRA_LOCALPOST_TYPE, LOCALPOST_TYPE_READ_POSTS);
+        int defaultPostLayout = Integer.parseInt(mSharedPreferences.getString(SharedPreferencesUtils.DEFAULT_POST_LAYOUT_KEY, "0"));
+        rememberMutingOptionInPostFeed = mSharedPreferences.getBoolean(SharedPreferencesUtils.REMEMBER_MUTING_OPTION_IN_POST_FEED, false);
+        Locale locale = getResources().getConfiguration().locale;
+
+        if (localType == LOCALPOST_TYPE_READ_POSTS) {
+            postLayout = mPostLayoutSharedPreferences.getInt(SharedPreferencesUtils.LOCAL_POST_LAYOUT, defaultPostLayout);
+
+            mAdapter = new LocalPostRecyclerViewAdapter(activity, this, mExecutor, mOauthRetrofit, mGfycatRetrofit,
+                    mRedgifsRetrofit, mStreamableApiProvider, mCustomThemeWrapper, locale,
+                    accessToken, accountName, postType, postLayout, true,
+                    mSharedPreferences, mCurrentAccountSharedPreferences, mNsfwAndSpoilerSharedPreferences,
+                    mExoCreator, new LocalPostRecyclerViewAdapter.Callback() {
+                @Override
+                public void typeChipClicked(int filter) {
+                    /*Intent intent = new Intent(activity, FilteredPostsActivity.class);
+                    intent.putExtra(FilteredPostsActivity.EXTRA_NAME, username);
+                    intent.putExtra(FilteredPostsActivity.EXTRA_POST_TYPE, postType);
+                    intent.putExtra(FilteredPostsActivity.EXTRA_USER_WHERE, where);
+                    intent.putExtra(FilteredPostsActivity.EXTRA_FILTER, filter);
+                    startActivity(intent);*/
+                }
+
+                @Override
+                public void flairChipClicked(String flair) {
+                    /*Intent intent = new Intent(activity, FilteredPostsActivity.class);
+                    intent.putExtra(FilteredPostsActivity.EXTRA_NAME, username);
+                    intent.putExtra(FilteredPostsActivity.EXTRA_POST_TYPE, postType);
+                    intent.putExtra(FilteredPostsActivity.EXTRA_USER_WHERE, where);
+                    intent.putExtra(FilteredPostsActivity.EXTRA_CONTAIN_FLAIR, flair);
+                    startActivity(intent);*/
+                }
+
+                @Override
+                public void nsfwChipClicked() {
+                    /*Intent intent = new Intent(activity, FilteredPostsActivity.class);
+                    intent.putExtra(FilteredPostsActivity.EXTRA_NAME, username);
+                    intent.putExtra(FilteredPostsActivity.EXTRA_POST_TYPE, postType);
+                    intent.putExtra(FilteredPostsActivity.EXTRA_USER_WHERE, where);
+                    intent.putExtra(FilteredPostsActivity.EXTRA_FILTER, Post.NSFW_TYPE);
+                    startActivity(intent);*/
+                }
+
+                @Override
+                public void currentlyBindItem(int position) {
+                    if (maxPosition < position) {
+                        maxPosition = position;
+                    }
+                }
+
+                @Override
+                public void delayTransition() {
+                    TransitionManager.beginDelayedTransition(mPostRecyclerView, new AutoTransition());
+                }
+            });
+        }
+
+        int nColumns = getNColumns(resources);
+        if (nColumns == 1) {
+            mLinearLayoutManager = new LinearLayoutManagerBugFixed(activity);
+            mPostRecyclerView.setLayoutManager(mLinearLayoutManager);
+        } else {
+            mStaggeredGridLayoutManager = new StaggeredGridLayoutManager(nColumns, StaggeredGridLayoutManager.VERTICAL);
+            mPostRecyclerView.setLayoutManager(mStaggeredGridLayoutManager);
+            StaggeredGridLayoutManagerItemOffsetDecoration itemDecoration =
+                    new StaggeredGridLayoutManagerItemOffsetDecoration(activity, R.dimen.staggeredLayoutManagerItemOffset, nColumns);
+            mPostRecyclerView.addItemDecoration(itemDecoration);
+        }
+
+        if (recyclerViewPosition > 0) {
+            mPostRecyclerView.scrollToPosition(recyclerViewPosition);
+        }
+
+        if (postFilter == null) {
+            FetchPostFilterReadPostsAndConcatenatedSubredditNames.fetchPostFilterAndReadPosts(mRedditDataRoomDatabase, mExecutor,
+                    new Handler(), null, PostFilterUsage.HISTORY_TYPE, PostFilterUsage.NO_USAGE, (postFilter, readPostList) -> {
+                        if (activity != null && !activity.isFinishing() && !activity.isDestroyed() && !isDetached()) {
+                            this.postFilter = postFilter;
+                            postFilter.allowNSFW = !mSharedPreferences.getBoolean(SharedPreferencesUtils.DISABLE_NSFW_FOREVER, false) && mNsfwAndSpoilerSharedPreferences.getBoolean(accountName + SharedPreferencesUtils.NSFW_BASE, false);
+                            initializeAndBindPostViewModel(accessToken);
+                        }
+                    });
+        } else {
+            initializeAndBindPostViewModel(accessToken);
+        }
+
+        vibrateWhenActionTriggered = mSharedPreferences.getBoolean(SharedPreferencesUtils.VIBRATE_WHEN_ACTION_TRIGGERED, true);
+        swipeActionThreshold = Float.parseFloat(mSharedPreferences.getString(SharedPreferencesUtils.SWIPE_ACTION_THRESHOLD, "0.3"));
+        swipeRightAction = Integer.parseInt(mSharedPreferences.getString(SharedPreferencesUtils.SWIPE_RIGHT_ACTION, "1"));
+        swipeLeftAction = Integer.parseInt(mSharedPreferences.getString(SharedPreferencesUtils.SWIPE_LEFT_ACTION, "0"));
+        initializeSwipeActionDrawable();
+
+        touchHelper = new ItemTouchHelper(new ItemTouchHelper.Callback() {
+            boolean exceedThreshold = false;
+
+            @Override
+            public int getMovementFlags(@NonNull RecyclerView recyclerView, @NonNull RecyclerView.ViewHolder viewHolder) {
+                if (!(viewHolder instanceof LocalPostRecyclerViewAdapter.PostBaseViewHolder) &&
+                        !(viewHolder instanceof LocalPostRecyclerViewAdapter.PostCompactBaseViewHolder)) {
+                    return makeMovementFlags(0, 0);
+                } else if (viewHolder instanceof LocalPostRecyclerViewAdapter.PostBaseGalleryTypeViewHolder) {
+                    if (((LocalPostRecyclerViewAdapter.PostBaseGalleryTypeViewHolder) viewHolder).isSwipeLocked()) {
+                        return makeMovementFlags(0, 0);
+                    }
+                }
+                int swipeFlags = ItemTouchHelper.START | ItemTouchHelper.END;
+                return makeMovementFlags(0, swipeFlags);
+            }
+
+            @Override
+            public boolean onMove(@NonNull RecyclerView recyclerView, @NonNull RecyclerView.ViewHolder viewHolder, @NonNull RecyclerView.ViewHolder target) {
+                return false;
+            }
+
+            @Override
+            public boolean isItemViewSwipeEnabled() {
+                return true;
+            }
+
+            @Override
+            public void onSwiped(@NonNull RecyclerView.ViewHolder viewHolder, int direction) {
+                if (touchHelper != null) {
+                    exceedThreshold = false;
+                    touchHelper.attachToRecyclerView(null);
+                    touchHelper.attachToRecyclerView(mPostRecyclerView);
+                }
+            }
+
+            @Override
+            public void onChildDraw(@NonNull Canvas c, @NonNull RecyclerView recyclerView, @NonNull RecyclerView.ViewHolder viewHolder, float dX, float dY, int actionState, boolean isCurrentlyActive) {
+                super.onChildDraw(c, recyclerView, viewHolder, dX, dY, actionState, isCurrentlyActive);
+
+                if (isCurrentlyActive) {
+                    View itemView = viewHolder.itemView;
+                    int horizontalOffset = (int) Utils.convertDpToPixel(16, activity);
+                    if (dX > 0) {
+                        if (dX > (itemView.getRight() - itemView.getLeft()) * swipeActionThreshold) {
+                            if (!exceedThreshold) {
+                                exceedThreshold = true;
+                                if (vibrateWhenActionTriggered) {
+                                    viewHolder.itemView.setHapticFeedbackEnabled(true);
+                                    viewHolder.itemView.performHapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY, HapticFeedbackConstants.FLAG_IGNORE_GLOBAL_SETTING);
+                                }
+                            }
+                            backgroundSwipeRight.setBounds(0, itemView.getTop(), itemView.getRight(), itemView.getBottom());
+                        } else {
+                            exceedThreshold = false;
+                            backgroundSwipeRight.setBounds(0, 0, 0, 0);
+                        }
+
+                        drawableSwipeRight.setBounds(itemView.getLeft() + ((int) dX) - horizontalOffset - drawableSwipeRight.getIntrinsicWidth(),
+                                (itemView.getBottom() + itemView.getTop() - drawableSwipeRight.getIntrinsicHeight()) / 2,
+                                itemView.getLeft() + ((int) dX) - horizontalOffset,
+                                (itemView.getBottom() + itemView.getTop() + drawableSwipeRight.getIntrinsicHeight()) / 2);
+                        backgroundSwipeRight.draw(c);
+                        drawableSwipeRight.draw(c);
+                    } else if (dX < 0) {
+                        if (-dX > (itemView.getRight() - itemView.getLeft()) * swipeActionThreshold) {
+                            if (!exceedThreshold) {
+                                exceedThreshold = true;
+                                if (vibrateWhenActionTriggered) {
+                                    viewHolder.itemView.setHapticFeedbackEnabled(true);
+                                    viewHolder.itemView.performHapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY, HapticFeedbackConstants.FLAG_IGNORE_GLOBAL_SETTING);
+                                }
+                            }
+                            backgroundSwipeLeft.setBounds(0, itemView.getTop(), itemView.getRight(), itemView.getBottom());
+                        } else {
+                            exceedThreshold = false;
+                            backgroundSwipeLeft.setBounds(0, 0, 0, 0);
+                        }
+                        drawableSwipeLeft.setBounds(itemView.getRight() + ((int) dX) + horizontalOffset,
+                                (itemView.getBottom() + itemView.getTop() - drawableSwipeLeft.getIntrinsicHeight()) / 2,
+                                itemView.getRight() + ((int) dX) + horizontalOffset + drawableSwipeLeft.getIntrinsicWidth(),
+                                (itemView.getBottom() + itemView.getTop() + drawableSwipeLeft.getIntrinsicHeight()) / 2);
+                        backgroundSwipeLeft.draw(c);
+                        drawableSwipeLeft.draw(c);
+                    }
+                } else {
+                    if (exceedThreshold) {
+                        mAdapter.onItemSwipe(viewHolder, dX > 0 ? ItemTouchHelper.END : ItemTouchHelper.START, swipeLeftAction, swipeRightAction);
+                        exceedThreshold = false;
+                    }
+                }
+            }
+
+            @Override
+            public float getSwipeThreshold(@NonNull RecyclerView.ViewHolder viewHolder) {
+                return 1;
+            }
+        });
+
+        if (nColumns == 1 && mSharedPreferences.getBoolean(SharedPreferencesUtils.ENABLE_SWIPE_ACTION, false)) {
+            swipeActionEnabled = true;
+            touchHelper.attachToRecyclerView(mPostRecyclerView);
+        }
+        mPostRecyclerView.setAdapter(mAdapter);
+        mPostRecyclerView.setCacheManager(mAdapter);
+        mPostRecyclerView.setPlayerInitializer(order -> {
+            VolumeInfo volumeInfo = new VolumeInfo(true, 0f);
+            return new PlaybackInfo(INDEX_UNSET, TIME_UNSET, volumeInfo);
+        });
+
+        return rootView;
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        if (mAdapter != null) {
+            mAdapter.setCanStartActivity(true);
+        }
+        if (isInLazyMode) {
+            resumeLazyMode(false);
+        }
+        if (mAdapter != null && mPostRecyclerView != null) {
+            mPostRecyclerView.onWindowVisibilityChanged(View.VISIBLE);
+        }
+    }
+
+    private boolean scrollPostsByCount(int count) {
+        if (mLinearLayoutManager != null) {
+            int pos = mLinearLayoutManager.findFirstVisibleItemPosition();
+            int targetPosition = pos + count;
+            mLinearLayoutManager.scrollToPositionWithOffset(targetPosition, 0);
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public boolean handleKeyDown(int keyCode) {
+        boolean volumeKeysNavigatePosts = mSharedPreferences.getBoolean(SharedPreferencesUtils.VOLUME_KEYS_NAVIGATE_POSTS, false);
+        if (volumeKeysNavigatePosts) {
+            switch (keyCode) {
+                case KeyEvent.KEYCODE_VOLUME_UP:
+                    return scrollPostsByCount(-1);
+                case KeyEvent.KEYCODE_VOLUME_DOWN:
+                    return scrollPostsByCount(1);
+            }
+        }
+        return false;
+    }
+
+    private int getNColumns(Resources resources) {
+        final boolean foldEnabled = mSharedPreferences.getBoolean(SharedPreferencesUtils.ENABLE_FOLD_SUPPORT, false);
+        if (resources.getConfiguration().orientation == Configuration.ORIENTATION_PORTRAIT) {
+            switch (postLayout) {
+                case SharedPreferencesUtils.POST_LAYOUT_CARD_2:
+                    return Integer.parseInt(mSharedPreferences.getString(SharedPreferencesUtils.NUMBER_OF_COLUMNS_IN_POST_FEED_PORTRAIT_CARD_LAYOUT_2, "1"));
+                case SharedPreferencesUtils.POST_LAYOUT_COMPACT:
+                    return Integer.parseInt(mSharedPreferences.getString(SharedPreferencesUtils.NUMBER_OF_COLUMNS_IN_POST_FEED_PORTRAIT_COMPACT_LAYOUT, "1"));
+                case SharedPreferencesUtils.POST_LAYOUT_GALLERY:
+                    return Integer.parseInt(mSharedPreferences.getString(SharedPreferencesUtils.NUMBER_OF_COLUMNS_IN_POST_FEED_PORTRAIT_GALLERY_LAYOUT, "2"));
+                default:
+                    if (getResources().getBoolean(R.bool.isTablet)) {
+                        if (foldEnabled) {
+                            return Integer.parseInt(mSharedPreferences.getString(SharedPreferencesUtils.NUMBER_OF_COLUMNS_IN_POST_FEED_PORTRAIT_UNFOLDED, "2"));
+                        } else {
+                            return Integer.parseInt(mSharedPreferences.getString(SharedPreferencesUtils.NUMBER_OF_COLUMNS_IN_POST_FEED_PORTRAIT, "2"));
+                        }
+                    }
+                    return Integer.parseInt(mSharedPreferences.getString(SharedPreferencesUtils.NUMBER_OF_COLUMNS_IN_POST_FEED_PORTRAIT, "1"));
+            }
+        } else {
+            switch (postLayout) {
+                case SharedPreferencesUtils.POST_LAYOUT_CARD_2:
+                    return Integer.parseInt(mSharedPreferences.getString(SharedPreferencesUtils.NUMBER_OF_COLUMNS_IN_POST_FEED_LANDSCAPE_CARD_LAYOUT_2, "2"));
+                case SharedPreferencesUtils.POST_LAYOUT_COMPACT:
+                    return Integer.parseInt(mSharedPreferences.getString(SharedPreferencesUtils.NUMBER_OF_COLUMNS_IN_POST_FEED_LANDSCAPE_COMPACT_LAYOUT, "2"));
+                case SharedPreferencesUtils.POST_LAYOUT_GALLERY:
+                    return Integer.parseInt(mSharedPreferences.getString(SharedPreferencesUtils.NUMBER_OF_COLUMNS_IN_POST_FEED_LANDSCAPE_GALLERY_LAYOUT, "2"));
+                default:
+                    if (getResources().getBoolean(R.bool.isTablet) && foldEnabled) {
+                        return Integer.parseInt(mSharedPreferences.getString(SharedPreferencesUtils.NUMBER_OF_COLUMNS_IN_POST_FEED_LANDSCAPE_UNFOLDED, "2"));
+                    }
+                    return Integer.parseInt(mSharedPreferences.getString(SharedPreferencesUtils.NUMBER_OF_COLUMNS_IN_POST_FEED_LANDSCAPE, "2"));
+            }
+        }
+    }
+
+    private void initializeAndBindPostViewModel(String accessToken) {
+        if (postType == LocalPostPagingSource.TYPE_READ_POSTS) {
+            mLocalPostViewModel = new ViewModelProvider(LocalPostFragment.this, new LocalPostViewModel.Factory(mExecutor,
+                    accessToken == null ? mRetrofit : mOauthRetrofit, mRedditDataRoomDatabase, accessToken,
+                    accountName, mSharedPreferences, LocalPostPagingSource.TYPE_READ_POSTS, postFilter)).get(LocalPostViewModel.class);
+        } else {
+            mLocalPostViewModel = new ViewModelProvider(LocalPostFragment.this, new LocalPostViewModel.Factory(mExecutor,
+                    accessToken == null ? mRetrofit : mOauthRetrofit, mRedditDataRoomDatabase, accessToken,
+                    accountName, mSharedPreferences, LocalPostPagingSource.TYPE_READ_POSTS, postFilter)).get(LocalPostViewModel.class);
+        }
+
+        bindPostViewModel();
+    }
+
+    private void bindPostViewModel() {
+        mLocalPostViewModel.getPosts().observe(getViewLifecycleOwner(), posts -> mAdapter.submitData(getViewLifecycleOwner().getLifecycle(), posts));
+
+        mAdapter.addLoadStateListener(combinedLoadStates -> {
+            LoadState refreshLoadState = combinedLoadStates.getRefresh();
+            LoadState appendLoadState = combinedLoadStates.getAppend();
+
+            mSwipeRefreshLayout.setRefreshing(refreshLoadState instanceof LoadState.Loading);
+            if (refreshLoadState instanceof LoadState.NotLoading) {
+                if (refreshLoadState.getEndOfPaginationReached() && mAdapter.getItemCount() < 1) {
+                    noPostFound();
+                } else {
+                    hasPost = true;
+                }
+            } else if (refreshLoadState instanceof LoadState.Error) {
+                mFetchPostInfoLinearLayout.setOnClickListener(view -> refresh());
+                showErrorView(R.string.load_posts_error);
+            }
+            if (!(refreshLoadState instanceof LoadState.Loading) && appendLoadState instanceof LoadState.NotLoading) {
+                if (appendLoadState.getEndOfPaginationReached() && mAdapter.getItemCount() < 1) {
+                    noPostFound();
+                }
+            }
+            return null;
+        });
+
+        mPostRecyclerView.setAdapter(mAdapter.withLoadStateFooter(new Paging3LoadingStateAdapter(activity, mCustomThemeWrapper, R.string.load_more_posts_error,
+                view -> mAdapter.retry())));
+    }
+
+    private void noPostFound() {
+        hasPost = false;
+        if (isInLazyMode) {
+            stopLazyMode();
+        }
+
+        mFetchPostInfoLinearLayout.setOnClickListener(null);
+        showErrorView(R.string.no_posts);
+    }
+
+    private void initializeSwipeActionDrawable() {
+        if (swipeRightAction == SharedPreferencesUtils.SWIPE_ACITON_DOWNVOTE) {
+            backgroundSwipeRight = new ColorDrawable(mCustomThemeWrapper.getDownvoted());
+            drawableSwipeRight = ResourcesCompat.getDrawable(activity.getResources(), R.drawable.ic_arrow_downward_black_24dp, null);
+        } else {
+            backgroundSwipeRight = new ColorDrawable(mCustomThemeWrapper.getUpvoted());
+            drawableSwipeRight = ResourcesCompat.getDrawable(activity.getResources(), R.drawable.ic_arrow_upward_black_24dp, null);
+        }
+
+        if (swipeLeftAction == SharedPreferencesUtils.SWIPE_ACITON_UPVOTE) {
+            backgroundSwipeLeft = new ColorDrawable(mCustomThemeWrapper.getUpvoted());
+            drawableSwipeLeft = ResourcesCompat.getDrawable(activity.getResources(), R.drawable.ic_arrow_upward_black_24dp, null);
+        } else {
+            backgroundSwipeLeft = new ColorDrawable(mCustomThemeWrapper.getDownvoted());
+            drawableSwipeLeft = ResourcesCompat.getDrawable(activity.getResources(), R.drawable.ic_arrow_downward_black_24dp, null);
+        }
+    }
+
+    public long getLocalPostFragmentId() {
+        return localPostFragmentId;
+    }
+
+    @Override
+    public void onAttach(@NonNull Context context) {
+        super.onAttach(context);
+        this.activity = (BaseActivity) context;
+    }
+
+    @Override
+    public void onSaveInstanceState(@NonNull Bundle outState) {
+        super.onSaveInstanceState(outState);
+        outState.putBoolean(IS_IN_LAZY_MODE_STATE, isInLazyMode);
+        outState.putStringArrayList(READ_POST_LIST_STATE, readPosts);
+        if (mLinearLayoutManager != null) {
+            outState.putInt(RECYCLER_VIEW_POSITION_STATE, mLinearLayoutManager.findFirstVisibleItemPosition());
+        } else if (mStaggeredGridLayoutManager != null) {
+            int[] into = new int[mStaggeredGridLayoutManager.getSpanCount()];
+            outState.putInt(RECYCLER_VIEW_POSITION_STATE,
+                    mStaggeredGridLayoutManager.findFirstVisibleItemPositions(into)[0]);
+        }
+        outState.putParcelable(POST_FILTER_STATE, postFilter);
+        outState.putLong(POST_FRAGMENT_ID_STATE, localPostFragmentId);
+    }
+
+    @Override
+    public void refresh() {
+        mFetchPostInfoLinearLayout.setVisibility(View.GONE);
+        hasPost = false;
+        if (isInLazyMode) {
+            stopLazyMode();
+        }
+        mAdapter.refresh();
+        goBackToTop();
+    }
+
+    private void showErrorView(int stringResId) {
+        if (activity != null && isAdded()) {
+            mSwipeRefreshLayout.setRefreshing(false);
+            mFetchPostInfoLinearLayout.setVisibility(View.VISIBLE);
+            mFetchPostInfoTextView.setText(stringResId);
+            mGlide.load(R.drawable.error_image).into(mFetchPostInfoImageView);
+        }
+    }
+
+    @Override
+    public boolean startLazyMode() {
+        if (!hasPost) {
+            Toast.makeText(activity, R.string.no_posts_no_lazy_mode, Toast.LENGTH_SHORT).show();
+            return false;
+        }
+
+        Utils.setTitleWithCustomFontToMenuItem(activity.typeface, lazyModeItem, getString(R.string.action_stop_lazy_mode));
+
+        if (mAdapter != null && mAdapter.isAutoplay()) {
+            mAdapter.setAutoplay(false);
+            refreshAdapter();
+        }
+
+        isInLazyMode = true;
+        isLazyModePaused = false;
+
+        lazyModeInterval = Float.parseFloat(mSharedPreferences.getString(SharedPreferencesUtils.LAZY_MODE_INTERVAL_KEY, "2.5"));
+        lazyModeHandler.postDelayed(lazyModeRunnable, (long) (lazyModeInterval * 1000));
+        window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+        Toast.makeText(activity, getString(R.string.lazy_mode_start, lazyModeInterval),
+                Toast.LENGTH_SHORT).show();
+
+        return true;
+    }
+
+    @Override
+    public void stopLazyMode() {
+        Utils.setTitleWithCustomFontToMenuItem(activity.typeface, lazyModeItem, getString(R.string.action_start_lazy_mode));
+        if (mAdapter != null) {
+            String autoplayString = mSharedPreferences.getString(SharedPreferencesUtils.VIDEO_AUTOPLAY, SharedPreferencesUtils.VIDEO_AUTOPLAY_VALUE_NEVER);
+            if (autoplayString.equals(SharedPreferencesUtils.VIDEO_AUTOPLAY_VALUE_ALWAYS_ON) ||
+                    (autoplayString.equals(SharedPreferencesUtils.VIDEO_AUTOPLAY_VALUE_ON_WIFI) && Utils.isConnectedToWifi(activity))) {
+                mAdapter.setAutoplay(true);
+                refreshAdapter();
+            }
+        }
+        isInLazyMode = false;
+        isLazyModePaused = false;
+        lazyModeRunnable.resetOldPosition();
+        lazyModeHandler.removeCallbacks(lazyModeRunnable);
+        resumeLazyModeCountDownTimer.cancel();
+        window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+        Toast.makeText(activity, getString(R.string.lazy_mode_stop), Toast.LENGTH_SHORT).show();
+    }
+
+    @Override
+    public void resumeLazyMode(boolean resumeNow) {
+        if (isInLazyMode) {
+            if (mAdapter != null && mAdapter.isAutoplay()) {
+                mAdapter.setAutoplay(false);
+                refreshAdapter();
+            }
+            isLazyModePaused = false;
+            window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+
+            lazyModeRunnable.resetOldPosition();
+
+            if (resumeNow) {
+                lazyModeHandler.post(lazyModeRunnable);
+            } else {
+                lazyModeHandler.postDelayed(lazyModeRunnable, (long) (lazyModeInterval * 1000));
+            }
+        }
+    }
+
+    @Override
+    public void pauseLazyMode(boolean startTimer) {
+        resumeLazyModeCountDownTimer.cancel();
+        isInLazyMode = true;
+        isLazyModePaused = true;
+        lazyModeHandler.removeCallbacks(lazyModeRunnable);
+        window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+
+        if (startTimer) {
+            resumeLazyModeCountDownTimer.start();
+        }
+    }
+
+    @Override
+    public boolean isInLazyMode() {
+        return isInLazyMode;
+    }
+
+    @Override
+    public void changePostLayout(int postLayout) {
+        changePostLayout(postLayout, false);
+    }
+
+    public void changePostLayout(int postLayout, boolean temporary) {
+        this.postLayout = postLayout;
+        if (!temporary) {
+            switch (postType) {
+                case LocalPostPagingSource.TYPE_READ_POSTS:
+                    mPostLayoutSharedPreferences.edit().putInt(SharedPreferencesUtils.LOCAL_POST_LAYOUT, postLayout).apply();
+            }
+        }
+
+        int previousPosition = -1;
+        if (mLinearLayoutManager != null) {
+            previousPosition = mLinearLayoutManager.findFirstVisibleItemPosition();
+        } else if (mStaggeredGridLayoutManager != null) {
+            int[] into = new int[mStaggeredGridLayoutManager.getSpanCount()];
+            previousPosition = mStaggeredGridLayoutManager.findFirstVisibleItemPositions(into)[0];
+        }
+        int nColumns = getNColumns(getResources());
+        if (nColumns == 1) {
+            mLinearLayoutManager = new LinearLayoutManagerBugFixed(activity);
+            if (mPostRecyclerView.getItemDecorationCount() > 0) {
+                mPostRecyclerView.removeItemDecorationAt(0);
+            }
+            mPostRecyclerView.setLayoutManager(mLinearLayoutManager);
+            mStaggeredGridLayoutManager = null;
+        } else {
+            mStaggeredGridLayoutManager = new StaggeredGridLayoutManager(nColumns, StaggeredGridLayoutManager.VERTICAL);
+            if (mPostRecyclerView.getItemDecorationCount() > 0) {
+                mPostRecyclerView.removeItemDecorationAt(0);
+            }
+            mPostRecyclerView.setLayoutManager(mStaggeredGridLayoutManager);
+            StaggeredGridLayoutManagerItemOffsetDecoration itemDecoration =
+                    new StaggeredGridLayoutManagerItemOffsetDecoration(activity, R.dimen.staggeredLayoutManagerItemOffset, nColumns);
+            mPostRecyclerView.addItemDecoration(itemDecoration);
+            mLinearLayoutManager = null;
+        }
+
+        if (previousPosition > 0) {
+            mPostRecyclerView.scrollToPosition(previousPosition);
+        }
+
+        if (mAdapter != null) {
+            mAdapter.setPostLayout(postLayout);
+            refreshAdapter();
+        }
+    }
+
+    @Override
+    public void applyTheme() {
+        mSwipeRefreshLayout.setProgressBackgroundColorSchemeColor(mCustomThemeWrapper.getCircularProgressBarBackground());
+        mSwipeRefreshLayout.setColorSchemeColors(mCustomThemeWrapper.getColorAccent());
+        mFetchPostInfoTextView.setTextColor(mCustomThemeWrapper.getSecondaryTextColor());
+        if (activity.typeface != null) {
+            mFetchPostInfoTextView.setTypeface(activity.typeface);
+        }
+    }
+
+    @Nullable
+    public Boolean getMasterMutingOption() {
+        return masterMutingOption;
+    }
+
+    public void videoAutoplayChangeMutingOption(boolean isMute) {
+        if (rememberMutingOptionInPostFeed) {
+            masterMutingOption = isMute;
+        }
+    }
+
+    public void loadIcon(String subredditOrUserName, boolean isSubreddit, PostFragment.LoadIconListener loadIconListener) {
+        if (subredditOrUserIcons.containsKey(subredditOrUserName)) {
+            loadIconListener.loadIconSuccess(subredditOrUserName, subredditOrUserIcons.get(subredditOrUserName));
+        } else {
+            if (isSubreddit) {
+                LoadSubredditIcon.loadSubredditIcon(mExecutor, new Handler(), mRedditDataRoomDatabase,
+                        subredditOrUserName, accessToken, mOauthRetrofit, mRetrofit,
+                        iconImageUrl -> {
+                            subredditOrUserIcons.put(subredditOrUserName, iconImageUrl);
+                            loadIconListener.loadIconSuccess(subredditOrUserName, iconImageUrl);
+                        });
+            } else {
+                LoadUserData.loadUserData(mExecutor, new Handler(), mRedditDataRoomDatabase, subredditOrUserName,
+                        mRetrofit, iconImageUrl -> {
+                            subredditOrUserIcons.put(subredditOrUserName, iconImageUrl);
+                            loadIconListener.loadIconSuccess(subredditOrUserName, iconImageUrl);
+                        });
+            }
+        }
+    }
+
+    private void refreshAdapter() {
+        int previousPosition = -1;
+        if (mLinearLayoutManager != null) {
+            previousPosition = mLinearLayoutManager.findFirstVisibleItemPosition();
+        } else if (mStaggeredGridLayoutManager != null) {
+            int[] into = new int[mStaggeredGridLayoutManager.getSpanCount()];
+            previousPosition = mStaggeredGridLayoutManager.findFirstVisibleItemPositions(into)[0];
+        }
+
+        RecyclerView.LayoutManager layoutManager = mPostRecyclerView.getLayoutManager();
+        mPostRecyclerView.setAdapter(null);
+        mPostRecyclerView.setLayoutManager(null);
+        mPostRecyclerView.setAdapter(mAdapter);
+        mPostRecyclerView.setLayoutManager(layoutManager);
+        if (previousPosition > 0) {
+            mPostRecyclerView.scrollToPosition(previousPosition);
+        }
+    }
+
+    public void goBackToTop() {
+        if (mLinearLayoutManager != null) {
+            mLinearLayoutManager.scrollToPositionWithOffset(0, 0);
+            if (isInLazyMode) {
+                lazyModeRunnable.resetOldPosition();
+            }
+        } else if (mStaggeredGridLayoutManager != null) {
+            mStaggeredGridLayoutManager.scrollToPositionWithOffset(0, 0);
+            if (isInLazyMode) {
+                lazyModeRunnable.resetOldPosition();
+            }
+        }
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        if (isInLazyMode) {
+            pauseLazyMode(false);
+        }
+        if (mAdapter != null && mPostRecyclerView != null) {
+            mPostRecyclerView.onWindowVisibilityChanged(View.GONE);
+        }
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        unbinder.unbind();
+    }
+
+    @Override
+    public void onDestroy() {
+        EventBus.getDefault().unregister(this);
+        if (mPostRecyclerView != null) {
+            mPostRecyclerView.addOnWindowFocusChangedListener(null);
+        }
+        super.onDestroy();
+    }
+
+    private void onWindowFocusChanged(boolean hasWindowsFocus) {
+        if (mAdapter != null) {
+            mAdapter.setCanPlayVideo(hasWindowsFocus);
+        }
+    }
+
+    public boolean isRecyclerViewItemSwipeable(RecyclerView.ViewHolder viewHolder) {
+        if (swipeActionEnabled) {
+            if (viewHolder instanceof LocalPostRecyclerViewAdapter.PostBaseGalleryTypeViewHolder) {
+                return !((LocalPostRecyclerViewAdapter.PostBaseGalleryTypeViewHolder) viewHolder).isSwipeLocked();
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    @Subscribe
+    public void onPostUpdateEvent(PostUpdateEventToPostList event) {
+        ItemSnapshotList<Post> posts = mAdapter.snapshot();
+        if (event.positionInList >= 0 && event.positionInList < posts.size()) {
+            Post post = posts.get(event.positionInList);
+            if (post != null && post.getFullName().equals(event.post.getFullName())) {
+                post.setTitle(event.post.getTitle());
+                post.setVoteType(event.post.getVoteType());
+                post.setScore(event.post.getScore());
+                post.setNComments(event.post.getNComments());
+                post.setNSFW(event.post.isNSFW());
+                post.setHidden(event.post.isHidden());
+                post.setSpoiler(event.post.isSpoiler());
+                post.setFlair(event.post.getFlair());
+                post.setSaved(event.post.isSaved());
+                if (event.post.isRead()) {
+                    post.markAsRead();
+                }
+                mAdapter.notifyItemChanged(event.positionInList);
+            }
+        }
+    }
+
+    @Subscribe
+    public void onChangeShowElapsedTimeEvent(ChangeShowElapsedTimeEvent event) {
+        if (mAdapter != null) {
+            mAdapter.setShowElapsedTime(event.showElapsedTime);
+            refreshAdapter();
+        }
+    }
+
+    @Subscribe
+    public void onChangeTimeFormatEvent(ChangeTimeFormatEvent changeTimeFormatEvent) {
+        if (mAdapter != null) {
+            mAdapter.setTimeFormat(changeTimeFormatEvent.timeFormat);
+            refreshAdapter();
+        }
+    }
+
+    @Subscribe
+    public void onChangeVoteButtonsPositionEvent(ChangeVoteButtonsPositionEvent event) {
+        if (mAdapter != null) {
+            mAdapter.setVoteButtonsPosition(event.voteButtonsOnTheRight);
+            refreshAdapter();
+        }
+    }
+
+    @Subscribe
+    public void onChangeNSFWBlurEvent(ChangeNSFWBlurEvent event) {
+        if (mAdapter != null) {
+            mAdapter.setBlurNsfwAndDoNotBlurNsfwInNsfwSubreddits(event.needBlurNSFW);
+            refreshAdapter();
+        }
+    }
+
+    @Subscribe
+    public void onChangeSpoilerBlurEvent(ChangeSpoilerBlurEvent event) {
+        if (mAdapter != null) {
+            mAdapter.setBlurSpoiler(event.needBlurSpoiler);
+            refreshAdapter();
+        }
+    }
+
+    @Subscribe
+    public void onChangePostLayoutEvent(ChangePostLayoutEvent event) {
+        changePostLayout(event.postLayout);
+    }
+
+    @Subscribe
+    public void onShowDividerInCompactLayoutPreferenceEvent(ShowDividerInCompactLayoutPreferenceEvent event) {
+        if (mAdapter != null) {
+            mAdapter.setShowDividerInCompactLayout(event.showDividerInCompactLayout);
+            refreshAdapter();
+        }
+    }
+
+    @Subscribe
+    public void onChangeDefaultPostLayoutEvent(ChangeDefaultPostLayoutEvent changeDefaultPostLayoutEvent) {
+        Bundle bundle = getArguments();
+        if (bundle != null) {
+            switch (postType) {
+                case LocalPostPagingSource.TYPE_READ_POSTS:
+                    if (mPostLayoutSharedPreferences.contains(SharedPreferencesUtils.LOCAL_POST_LAYOUT)) {
+                        changePostLayout(changeDefaultPostLayoutEvent.defaultPostLayout, true);
+                    }
+                    break;
+            }
+        }
+    }
+
+    @Subscribe
+    public void onChangeDefaultLinkPostLayoutEvent(ChangeDefaultLinkPostLayoutEvent event) {
+        if (mAdapter != null) {
+            mAdapter.setDefaultLinkPostLayout(event.defaultLinkPostLayout);
+            refreshAdapter();
+        }
+    }
+
+    @Subscribe
+    public void onChangeShowAbsoluteNumberOfVotesEvent(ChangeShowAbsoluteNumberOfVotesEvent changeShowAbsoluteNumberOfVotesEvent) {
+        if (mAdapter != null) {
+            mAdapter.setShowAbsoluteNumberOfVotes(changeShowAbsoluteNumberOfVotesEvent.showAbsoluteNumberOfVotes);
+            refreshAdapter();
+        }
+    }
+
+    @Subscribe
+    public void onChangeVideoAutoplayEvent(ChangeVideoAutoplayEvent changeVideoAutoplayEvent) {
+        if (mAdapter != null) {
+            boolean autoplay = false;
+            if (changeVideoAutoplayEvent.autoplay.equals(SharedPreferencesUtils.VIDEO_AUTOPLAY_VALUE_ALWAYS_ON)) {
+                autoplay = true;
+            } else if (changeVideoAutoplayEvent.autoplay.equals(SharedPreferencesUtils.VIDEO_AUTOPLAY_VALUE_ON_WIFI)) {
+                autoplay = Utils.isConnectedToWifi(activity);
+            }
+            mAdapter.setAutoplay(autoplay);
+            refreshAdapter();
+        }
+    }
+
+    @Subscribe
+    public void onChangeAutoplayNsfwVideosEvent(ChangeAutoplayNsfwVideosEvent changeAutoplayNsfwVideosEvent) {
+        if (mAdapter != null) {
+            mAdapter.setAutoplayNsfwVideos(changeAutoplayNsfwVideosEvent.autoplayNsfwVideos);
+            refreshAdapter();
+        }
+    }
+
+    @Subscribe
+    public void onChangeMuteAutoplayingVideosEvent(ChangeMuteAutoplayingVideosEvent changeMuteAutoplayingVideosEvent) {
+        if (mAdapter != null) {
+            mAdapter.setMuteAutoplayingVideos(changeMuteAutoplayingVideosEvent.muteAutoplayingVideos);
+            refreshAdapter();
+        }
+    }
+
+    @Subscribe
+    public void onChangeNetworkStatusEvent(ChangeNetworkStatusEvent changeNetworkStatusEvent) {
+        if (mAdapter != null) {
+            String autoplay = mSharedPreferences.getString(SharedPreferencesUtils.VIDEO_AUTOPLAY, SharedPreferencesUtils.VIDEO_AUTOPLAY_VALUE_NEVER);
+            String dataSavingMode = mSharedPreferences.getString(SharedPreferencesUtils.DATA_SAVING_MODE, SharedPreferencesUtils.DATA_SAVING_MODE_OFF);
+            boolean stateChanged = false;
+            if (autoplay.equals(SharedPreferencesUtils.VIDEO_AUTOPLAY_VALUE_ON_WIFI)) {
+                mAdapter.setAutoplay(changeNetworkStatusEvent.connectedNetwork == Utils.NETWORK_TYPE_WIFI);
+                stateChanged = true;
+            }
+            if (dataSavingMode.equals(SharedPreferencesUtils.DATA_SAVING_MODE_ONLY_ON_CELLULAR_DATA)) {
+                mAdapter.setDataSavingMode(changeNetworkStatusEvent.connectedNetwork == Utils.NETWORK_TYPE_CELLULAR);
+                stateChanged = true;
+            }
+
+            if (stateChanged) {
+                refreshAdapter();
+            }
+        }
+    }
+
+    @Subscribe
+    public void onShowThumbnailOnTheRightInCompactLayoutEvent(ShowThumbnailOnTheRightInCompactLayoutEvent showThumbnailOnTheRightInCompactLayoutEvent) {
+        if (mAdapter != null) {
+            mAdapter.setShowThumbnailOnTheRightInCompactLayout(showThumbnailOnTheRightInCompactLayoutEvent.showThumbnailOnTheRightInCompactLayout);
+            refreshAdapter();
+        }
+    }
+
+    @Subscribe
+    public void onChangeStartAutoplayVisibleAreaOffsetEvent(ChangeStartAutoplayVisibleAreaOffsetEvent changeStartAutoplayVisibleAreaOffsetEvent) {
+        if (mAdapter != null) {
+            mAdapter.setStartAutoplayVisibleAreaOffset(changeStartAutoplayVisibleAreaOffsetEvent.startAutoplayVisibleAreaOffset);
+            refreshAdapter();
+        }
+    }
+
+    @Subscribe
+    public void onChangeMuteNSFWVideoEvent(ChangeMuteNSFWVideoEvent changeMuteNSFWVideoEvent) {
+        if (mAdapter != null) {
+            mAdapter.setMuteNSFWVideo(changeMuteNSFWVideoEvent.muteNSFWVideo);
+            refreshAdapter();
+        }
+    }
+
+    @Subscribe
+    public void onChangeVibrateWhenActionTriggeredEvent(ChangeVibrateWhenActionTriggeredEvent changeVibrateWhenActionTriggeredEvent) {
+        vibrateWhenActionTriggered = changeVibrateWhenActionTriggeredEvent.vibrateWhenActionTriggered;
+    }
+
+    @Subscribe
+    public void onChangeEnableSwipeActionSwitchEvent(ChangeEnableSwipeActionSwitchEvent changeEnableSwipeActionSwitchEvent) {
+        if (getNColumns(getResources()) == 1 && touchHelper != null) {
+            swipeActionEnabled = changeEnableSwipeActionSwitchEvent.enableSwipeAction;
+            if (changeEnableSwipeActionSwitchEvent.enableSwipeAction) {
+                touchHelper.attachToRecyclerView(mPostRecyclerView);
+            } else {
+                touchHelper.attachToRecyclerView(null);
+            }
+        }
+    }
+
+    @Subscribe
+    public void onChangePullToRefreshEvent(ChangePullToRefreshEvent changePullToRefreshEvent) {
+        mSwipeRefreshLayout.setEnabled(changePullToRefreshEvent.pullToRefresh);
+    }
+
+    @Subscribe
+    public void onChangeLongPressToHideToolbarInCompactLayoutEvent(ChangeLongPressToHideToolbarInCompactLayoutEvent changeLongPressToHideToolbarInCompactLayoutEvent) {
+        if (mAdapter != null) {
+            mAdapter.setLongPressToHideToolbarInCompactLayout(changeLongPressToHideToolbarInCompactLayoutEvent.longPressToHideToolbarInCompactLayout);
+            refreshAdapter();
+        }
+    }
+
+    @Subscribe
+    public void onChangeCompactLayoutToolbarHiddenByDefaultEvent(ChangeCompactLayoutToolbarHiddenByDefaultEvent changeCompactLayoutToolbarHiddenByDefaultEvent) {
+        if (mAdapter != null) {
+            mAdapter.setCompactLayoutToolbarHiddenByDefault(changeCompactLayoutToolbarHiddenByDefaultEvent.compactLayoutToolbarHiddenByDefault);
+            refreshAdapter();
+        }
+    }
+
+    @Subscribe
+    public void onChangeSwipeActionThresholdEvent(ChangeSwipeActionThresholdEvent changeSwipeActionThresholdEvent) {
+        swipeActionThreshold = changeSwipeActionThresholdEvent.swipeActionThreshold;
+    }
+
+    @Subscribe
+    public void onChangeDataSavingModeEvent(ChangeDataSavingModeEvent changeDataSavingModeEvent) {
+        if (mAdapter != null) {
+            boolean dataSavingMode = false;
+            if (changeDataSavingModeEvent.dataSavingMode.equals(SharedPreferencesUtils.DATA_SAVING_MODE_ONLY_ON_CELLULAR_DATA)) {
+                dataSavingMode = Utils.isConnectedToCellularData(activity);
+            } else if (changeDataSavingModeEvent.dataSavingMode.equals(SharedPreferencesUtils.DATA_SAVING_MODE_ALWAYS)) {
+                dataSavingMode = true;
+            }
+            mAdapter.setDataSavingMode(dataSavingMode);
+            refreshAdapter();
+        }
+    }
+
+    @Subscribe
+    public void onChangeDisableImagePreviewEvent(ChangeDisableImagePreviewEvent changeDisableImagePreviewEvent) {
+        if (mAdapter != null) {
+            mAdapter.setDisableImagePreview(changeDisableImagePreviewEvent.disableImagePreview);
+            refreshAdapter();
+        }
+    }
+
+    @Subscribe
+    public void onChangeOnlyDisablePreviewInVideoAndGifPostsEvent(ChangeOnlyDisablePreviewInVideoAndGifPostsEvent changeOnlyDisablePreviewInVideoAndGifPostsEvent) {
+        if (mAdapter != null) {
+            mAdapter.setOnlyDisablePreviewInVideoPosts(changeOnlyDisablePreviewInVideoAndGifPostsEvent.onlyDisablePreviewInVideoAndGifPosts);
+            refreshAdapter();
+        }
+    }
+
+    @Subscribe
+    public void onChangeSwipeActionEvent(ChangeSwipeActionEvent changeSwipeActionEvent) {
+        swipeRightAction = changeSwipeActionEvent.swipeRightAction == -1 ? swipeRightAction : changeSwipeActionEvent.swipeRightAction;
+        swipeLeftAction = changeSwipeActionEvent.swipeLeftAction == -1 ? swipeLeftAction : changeSwipeActionEvent.swipeLeftAction;
+        initializeSwipeActionDrawable();
+    }
+
+    @Subscribe
+    public void onNeedForPostListFromPostRecyclerViewAdapterEvent(NeedForPostListFromPostFragmentEvent event) {
+        if (localPostFragmentId == event.postFragmentTimeId && mAdapter != null) {
+            EventBus.getDefault().post(new ProvidePostListToViewPostDetailActivityEvent(localPostFragmentId,
+                    new ArrayList<>(mAdapter.snapshot()), LocalPostPagingSource.TYPE_READ_POSTS, null, null, null,
+                    null, null, null, postFilter, null, null));
+        }
+    }
+
+    @Subscribe
+    public void onChangeHidePostTypeEvent(ChangeHidePostTypeEvent event) {
+        if (mAdapter != null) {
+            mAdapter.setHidePostType(event.hidePostType);
+            refreshAdapter();
+        }
+    }
+
+    @Subscribe
+    public void onChangeHidePostFlairEvent(ChangeHidePostFlairEvent event) {
+        if (mAdapter != null) {
+            mAdapter.setHidePostFlair(event.hidePostFlair);
+            refreshAdapter();
+        }
+    }
+
+    @Subscribe
+    public void onChangeHideTheNumberOfAwardsEvent(ChangeHideTheNumberOfAwardsEvent event) {
+        if (mAdapter != null) {
+            mAdapter.setHideTheNumberOfAwards(event.hideTheNumberOfAwards);
+            refreshAdapter();
+        }
+    }
+
+    @Subscribe
+    public void onChangeHideSubredditAndUserEvent(ChangeHideSubredditAndUserPrefixEvent event) {
+        if (mAdapter != null) {
+            mAdapter.setHideSubredditAndUserPrefix(event.hideSubredditAndUserPrefix);
+            refreshAdapter();
+        }
+    }
+
+    @Subscribe
+    public void onChangeHideTheNumberOfVotesEvent(ChangeHideTheNumberOfVotesEvent event) {
+        if (mAdapter != null) {
+            mAdapter.setHideTheNumberOfVotes(event.hideTheNumberOfVotes);
+            refreshAdapter();
+        }
+    }
+
+    @Subscribe
+    public void onChangeHideTheNumberOfCommentsEvent(ChangeHideTheNumberOfCommentsEvent event) {
+        if (mAdapter != null) {
+            mAdapter.setHideTheNumberOfComments(event.hideTheNumberOfComments);
+            refreshAdapter();
+        }
+    }
+
+    @Subscribe
+    public void onChangeRememberMutingOptionInPostFeedEvent(ChangeRememberMutingOptionInPostFeedEvent event) {
+        rememberMutingOptionInPostFeed = event.rememberMutingOptionInPostFeedEvent;
+        if (!event.rememberMutingOptionInPostFeedEvent) {
+            masterMutingOption = null;
+        }
+    }
+
+    @Subscribe
+    public void onChangeFixedHeightPreviewCardEvent(ChangeFixedHeightPreviewInCardEvent event) {
+        if (mAdapter != null) {
+            mAdapter.setFixedHeightPreviewInCard(event.fixedHeightPreviewInCard);
+            refreshAdapter();
+        }
+    }
+
+    @Subscribe
+    public void onChangeHideTextPostContentEvent(ChangeHideTextPostContent event) {
+        if (mAdapter != null) {
+            mAdapter.setHideTextPostContent(event.hideTextPostContent);
+            refreshAdapter();
+        }
+    }
+
+    @Subscribe
+    public void onChangePostFeedMaxResolutionEvent(ChangePostFeedMaxResolutionEvent event) {
+        if (mAdapter != null) {
+            mAdapter.setPostFeedMaxResolution(event.postFeedMaxResolution);
+            refreshAdapter();
+        }
+    }
+
+    @Subscribe
+    public void onChangeEasierToWatchInFullScreenEvent(ChangeEasierToWatchInFullScreenEvent event) {
+        if (mAdapter != null) {
+            mAdapter.setEasierToWatchInFullScreen(event.easierToWatchInFullScreen);
+        }
+    }
+
+    private static abstract class LazyModeRunnable implements Runnable {
+        private int currentPosition = -1;
+
+        int getCurrentPosition() {
+            return currentPosition;
+        }
+
+        void setCurrentPosition(int currentPosition) {
+            this.currentPosition = currentPosition;
+        }
+
+        void incrementCurrentPosition() {
+            currentPosition++;
+        }
+
+        void resetOldPosition() {
+            currentPosition = -1;
+        }
+    }
+
+    private static class StaggeredGridLayoutManagerItemOffsetDecoration extends RecyclerView.ItemDecoration {
+
+        private int mItemOffset;
+        private int mNColumns;
+
+        StaggeredGridLayoutManagerItemOffsetDecoration(int itemOffset, int nColumns) {
+            mItemOffset = itemOffset;
+            mNColumns = nColumns;
+        }
+
+        StaggeredGridLayoutManagerItemOffsetDecoration(@NonNull Context context, @DimenRes int itemOffsetId, int nColumns) {
+            this(context.getResources().getDimensionPixelSize(itemOffsetId), nColumns);
+        }
+
+        @Override
+        public void getItemOffsets(@NonNull Rect outRect, @NonNull View view, @NonNull RecyclerView parent,
+                                   @NonNull RecyclerView.State state) {
+            super.getItemOffsets(outRect, view, parent, state);
+
+            StaggeredGridLayoutManager.LayoutParams layoutParams = (StaggeredGridLayoutManager.LayoutParams) view.getLayoutParams();
+
+            int spanIndex = layoutParams.getSpanIndex();
+
+            int halfOffset = mItemOffset / 2;
+
+            if (mNColumns == 2) {
+                if (spanIndex == 0) {
+                    outRect.set(halfOffset, 0, halfOffset / 2, 0);
+                } else {
+                    outRect.set(halfOffset / 2, 0, halfOffset, 0);
+                }
+            } else if (mNColumns == 3) {
+                if (spanIndex == 0) {
+                    outRect.set(halfOffset, 0, halfOffset / 2, 0);
+                } else if (spanIndex == 1) {
+                    outRect.set(halfOffset / 2, 0, halfOffset / 2, 0);
+                } else {
+                    outRect.set(halfOffset / 2, 0, halfOffset, 0);
+                }
+            }
+        }
+    }
+
+    public interface LoadIconListener {
+        void loadIconSuccess(String subredditOrUserName, String iconUrl);
+    }
+}

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/fragments/LocalPostFragment.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/fragments/LocalPostFragment.java
@@ -67,6 +67,7 @@ import butterknife.Unbinder;
 import ml.docilealligator.infinityforreddit.FetchPostFilterReadPostsAndConcatenatedSubredditNames;
 import ml.docilealligator.infinityforreddit.FragmentCommunicator;
 import ml.docilealligator.infinityforreddit.Infinity;
+import ml.docilealligator.infinityforreddit.LocalSave;
 import ml.docilealligator.infinityforreddit.R;
 import ml.docilealligator.infinityforreddit.RecyclerViewContentScrollingInterface;
 import ml.docilealligator.infinityforreddit.RedditDataRoomDatabase;
@@ -378,6 +379,9 @@ public class LocalPostFragment extends Fragment implements FragmentCommunicator 
 
         if (localType == LOCALPOST_TYPE_READ_POSTS) {
             postLayout = mPostLayoutSharedPreferences.getInt(SharedPreferencesUtils.LOCAL_POST_LAYOUT, defaultPostLayout);
+            LocalSave.sortType = mPostLayoutSharedPreferences.getInt(SharedPreferencesUtils.LOCAL_POST_SORTING, LocalSave.SORT_NEWEST);
+            LocalSave.cacheSaved = mPostLayoutSharedPreferences.getBoolean(SharedPreferencesUtils.LOCAL_POST_CACHE_SAVED, true);
+            LocalSave.cacheHistory = mPostLayoutSharedPreferences.getBoolean(SharedPreferencesUtils.LOCAL_POST_CACHE_HISTORY, false);
 
             mAdapter = new LocalPostRecyclerViewAdapter(activity, this, mExecutor, mOauthRetrofit, mGfycatRetrofit,
                     mRedgifsRetrofit, mStreamableApiProvider, mCustomThemeWrapper, locale,

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/post/HistoryPostPagingSource.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/post/HistoryPostPagingSource.java
@@ -17,6 +17,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.concurrent.Executor;
 
+import ml.docilealligator.infinityforreddit.LocalSave;
 import ml.docilealligator.infinityforreddit.RedditDataRoomDatabase;
 import ml.docilealligator.infinityforreddit.apis.RedditAPI;
 import ml.docilealligator.infinityforreddit.postfilter.PostFilter;
@@ -96,6 +97,12 @@ public class HistoryPostPagingSource extends ListenableFuturePagingSource<String
                 if (newPosts == null) {
                     return new LoadResult.Error<>(new Exception("Error parsing posts"));
                 } else {
+
+                    if(LocalSave.cacheHistory)
+                    {
+                        LocalSave.CachePosts(newPosts);
+                    }
+
                     if (newPosts.size() < 25) {
                         return new LoadResult.Page<>(new ArrayList<>(newPosts), null, null);
                     }

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/post/LocalPostPagingSource.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/post/LocalPostPagingSource.java
@@ -1,0 +1,137 @@
+package ml.docilealligator.infinityforreddit.post;
+
+import android.content.SharedPreferences;
+import android.os.Build;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.RequiresApi;
+import androidx.paging.ListenableFuturePagingSource;
+import androidx.paging.PagingState;
+
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+
+import org.jetbrains.annotations.Nullable;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.concurrent.Executor;
+
+import ml.docilealligator.infinityforreddit.LocalSave;
+import ml.docilealligator.infinityforreddit.RedditDataRoomDatabase;
+import ml.docilealligator.infinityforreddit.apis.RedditAPI;
+import ml.docilealligator.infinityforreddit.postfilter.PostFilter;
+import ml.docilealligator.infinityforreddit.readpost.ReadPost;
+import ml.docilealligator.infinityforreddit.utils.APIUtils;
+import retrofit2.Call;
+import retrofit2.HttpException;
+import retrofit2.Response;
+import retrofit2.Retrofit;
+
+public class LocalPostPagingSource extends ListenableFuturePagingSource<String, Post> {
+    public static final int TYPE_READ_POSTS = 100;
+
+    private Retrofit retrofit;
+    private Executor executor;
+    private RedditDataRoomDatabase redditDataRoomDatabase;
+    private String accessToken;
+    private String accountName;
+    private SharedPreferences sharedPreferences;
+    private String username;
+    private int postType;
+    private PostFilter postFilter;
+
+    public LocalPostPagingSource(Retrofit retrofit, Executor executor, RedditDataRoomDatabase redditDataRoomDatabase,
+                                 String accessToken, String accountName, SharedPreferences sharedPreferences,
+                                 String username, int postType, PostFilter postFilter) {
+        this.retrofit = retrofit;
+        this.executor = executor;
+        this.redditDataRoomDatabase = redditDataRoomDatabase;
+        this.accessToken = accessToken;
+        this.accountName = accountName;
+        this.sharedPreferences = sharedPreferences;
+        this.username = username;
+        this.postType = postType;
+        this.postFilter = postFilter;
+    }
+
+    @Nullable
+    @Override
+    public String getRefreshKey(@NonNull PagingState<String, Post> pagingState) {
+        return null;
+    }
+
+    @Override
+    public boolean getKeyReuseSupported() { return true; }
+
+    @NonNull
+    @Override
+    public ListenableFuture<LoadResult<String, Post>> loadFuture(@NonNull LoadParams<String> loadParams) {
+        if (postType == TYPE_READ_POSTS) {
+            return loadHomePosts(loadParams, redditDataRoomDatabase);
+        } else {
+            return loadHomePosts(loadParams, redditDataRoomDatabase);
+        }
+    }
+
+    public LoadResult<String, Post> transformData(List<ReadPost> readPosts) {
+        StringBuilder ids = new StringBuilder();
+        long lastItem = 0;
+
+        for(LocalSave.SavedPost post : LocalSave.GetPosts())
+        {
+            ids.append("t3_").append(post.getId()).append(",");
+            lastItem = post.getTime();
+        }
+        if (ids.length() > 0) {
+            ids.deleteCharAt(ids.length() - 1);
+        }
+
+        Call<String> historyPosts;
+        if (accessToken != null && !accessToken.isEmpty()) {
+            historyPosts = retrofit.create(RedditAPI.class).getInfoOauth(ids.toString(), APIUtils.getOAuthHeader(accessToken));
+        } else {
+            historyPosts = retrofit.create(RedditAPI.class).getInfo(ids.toString());
+        }
+
+        try {
+            Response<String> response = historyPosts.execute();
+            if (response.isSuccessful()) {
+                String responseString = response.body();
+                LinkedHashSet<Post> newPosts = ParsePost.parsePostsSync(responseString, -1, postFilter, null);
+                if (newPosts == null) {
+                    return new LoadResult.Error<>(new Exception("Error parsing posts"));
+                } else {
+
+                    if (newPosts.size() < 25)
+                    {
+                        return new LoadResult.Page<>(new ArrayList<>(newPosts), null, null);
+                    }
+                    return new LoadResult.Page<>(new ArrayList<>(newPosts), null, Long.toString(lastItem));
+                }
+            } else {
+                return new LoadResult.Error<>(new Exception("Response failed"));
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+            return new LoadResult.Error<>(new Exception("Response failed"));
+        }
+    }
+
+    private ListenableFuture<LoadResult<String, Post>> loadHomePosts(@NonNull LoadParams<String> loadParams, RedditDataRoomDatabase redditDataRoomDatabase) {
+        String after = loadParams.getKey();
+        ListenableFuture<List<ReadPost>> readPosts = redditDataRoomDatabase.readPostDao().getAllReadPostsListenableFuture(username, Long.parseLong(after == null ? "0" : after));
+
+        ListenableFuture<LoadResult<String, Post>> pageFuture = Futures.transform(readPosts, this::transformData, executor);
+
+        ListenableFuture<LoadResult<String, Post>> partialLoadResultFuture =
+                Futures.catching(pageFuture, HttpException.class,
+                        LoadResult.Error::new, executor);
+
+        return Futures.catching(partialLoadResultFuture,
+                IOException.class, LoadResult.Error::new, executor);
+    }
+}

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/post/LocalPostPagingSource.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/post/LocalPostPagingSource.java
@@ -33,7 +33,6 @@ import retrofit2.Retrofit;
 
 public class LocalPostPagingSource extends ListenableFuturePagingSource<String, Post> {
     public static final int TYPE_READ_POSTS = 100;
-
     private Retrofit retrofit;
     private Executor executor;
     private RedditDataRoomDatabase redditDataRoomDatabase;
@@ -70,11 +69,7 @@ public class LocalPostPagingSource extends ListenableFuturePagingSource<String, 
     @NonNull
     @Override
     public ListenableFuture<LoadResult<String, Post>> loadFuture(@NonNull LoadParams<String> loadParams) {
-        if (postType == TYPE_READ_POSTS) {
-            return loadHomePosts(loadParams, redditDataRoomDatabase);
-        } else {
-            return loadHomePosts(loadParams, redditDataRoomDatabase);
-        }
+        return loadHomePosts(loadParams, redditDataRoomDatabase);
     }
 
     public LoadResult<String, Post> transformData(List<ReadPost> readPosts) {
@@ -90,15 +85,15 @@ public class LocalPostPagingSource extends ListenableFuturePagingSource<String, 
             ids.deleteCharAt(ids.length() - 1);
         }
 
-        Call<String> historyPosts;
+        Call<String> localPosts;
         if (accessToken != null && !accessToken.isEmpty()) {
-            historyPosts = retrofit.create(RedditAPI.class).getInfoOauth(ids.toString(), APIUtils.getOAuthHeader(accessToken));
+            localPosts = retrofit.create(RedditAPI.class).getInfoOauth(ids.toString(), APIUtils.getOAuthHeader(accessToken));
         } else {
-            historyPosts = retrofit.create(RedditAPI.class).getInfo(ids.toString());
+            localPosts = retrofit.create(RedditAPI.class).getInfo(ids.toString());
         }
 
         try {
-            Response<String> response = historyPosts.execute();
+            Response<String> response = localPosts.execute();
             if (response.isSuccessful()) {
                 String responseString = response.body();
                 LinkedHashSet<Post> newPosts = ParsePost.parsePostsSync(responseString, -1, postFilter, null);

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/post/LocalPostViewModel.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/post/LocalPostViewModel.java
@@ -1,0 +1,115 @@
+package ml.docilealligator.infinityforreddit.post;
+
+import android.content.SharedPreferences;
+
+import androidx.annotation.NonNull;
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MutableLiveData;
+import androidx.lifecycle.Transformations;
+import androidx.lifecycle.ViewModel;
+import androidx.lifecycle.ViewModelKt;
+import androidx.lifecycle.ViewModelProvider;
+import androidx.paging.Pager;
+import androidx.paging.PagingConfig;
+import androidx.paging.PagingData;
+import androidx.paging.PagingLiveData;
+
+import java.util.concurrent.Executor;
+
+import ml.docilealligator.infinityforreddit.RedditDataRoomDatabase;
+import ml.docilealligator.infinityforreddit.postfilter.PostFilter;
+import retrofit2.Retrofit;
+
+public class LocalPostViewModel extends ViewModel {
+    private Executor executor;
+    private Retrofit retrofit;
+    private RedditDataRoomDatabase redditDataRoomDatabase;
+    private String accessToken;
+    private String accountName;
+    private SharedPreferences sharedPreferences;
+    private int postType;
+    private PostFilter postFilter;
+
+    private LiveData<PagingData<Post>> posts;
+
+    private MutableLiveData<PostFilter> postFilterLiveData;
+
+    public LocalPostViewModel(Executor executor, Retrofit retrofit, RedditDataRoomDatabase redditDataRoomDatabase,
+                              String accessToken, String accountName, SharedPreferences sharedPreferences,
+                              int postType, PostFilter postFilter) {
+        this.executor = executor;
+        this.retrofit = retrofit;
+        this.redditDataRoomDatabase = redditDataRoomDatabase;
+        this.accessToken = accessToken;
+        this.accountName = accountName;
+        this.sharedPreferences = sharedPreferences;
+        this.postType = postType;
+        this.postFilter = postFilter;
+
+        postFilterLiveData = new MutableLiveData<>();
+        postFilterLiveData.postValue(postFilter);
+
+        Pager<String, Post> pager = new Pager<>(new PagingConfig(25, 25, false), this::returnPagingSoruce);
+
+        posts = Transformations.switchMap(postFilterLiveData, postFilterValue -> PagingLiveData.cachedIn(PagingLiveData.getLiveData(pager), ViewModelKt.getViewModelScope(this)));
+    }
+
+    public LiveData<PagingData<Post>> getPosts() {
+        return posts;
+    }
+
+    public LocalPostPagingSource returnPagingSoruce() {
+        LocalPostPagingSource paging3PagingSource;
+        switch (postType) {
+            case LocalPostPagingSource.TYPE_READ_POSTS:
+                paging3PagingSource = new LocalPostPagingSource(retrofit, executor, redditDataRoomDatabase, accessToken, accountName,
+                        sharedPreferences, accountName, postType, postFilter);
+                break;
+            default:
+                paging3PagingSource = new LocalPostPagingSource(retrofit, executor, redditDataRoomDatabase, accessToken, accountName,
+                        sharedPreferences, accountName, postType, postFilter);
+                break;
+        }
+        return paging3PagingSource;
+    }
+
+    public void changePostFilter(PostFilter postFilter) {
+        postFilterLiveData.postValue(postFilter);
+    }
+
+    public static class Factory extends ViewModelProvider.NewInstanceFactory {
+        private Executor executor;
+        private Retrofit retrofit;
+        private RedditDataRoomDatabase redditDataRoomDatabase;
+        private String accessToken;
+        private String accountName;
+        private SharedPreferences sharedPreferences;
+        private int postType;
+        private PostFilter postFilter;
+
+        public Factory(Executor executor, Retrofit retrofit, RedditDataRoomDatabase redditDataRoomDatabase,
+                       String accessToken, String accountName, SharedPreferences sharedPreferences, int postType,
+                       PostFilter postFilter) {
+            this.executor = executor;
+            this.retrofit = retrofit;
+            this.redditDataRoomDatabase = redditDataRoomDatabase;
+            this.accessToken = accessToken;
+            this.accountName = accountName;
+            this.sharedPreferences = sharedPreferences;
+            this.postType = postType;
+            this.postFilter = postFilter;
+        }
+
+        @NonNull
+        @Override
+        public <T extends ViewModel> T create(@NonNull Class<T> modelClass) {
+            if (postType == LocalPostPagingSource.TYPE_READ_POSTS) {
+                return (T) new LocalPostViewModel(executor, retrofit, redditDataRoomDatabase, accessToken, accountName, sharedPreferences,
+                        postType, postFilter);
+            } else {
+                return (T) new LocalPostViewModel(executor, retrofit, redditDataRoomDatabase, accessToken, accountName, sharedPreferences,
+                        postType, postFilter);
+            }
+        }
+    }
+}

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/post/PostPagingSource.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/post/PostPagingSource.java
@@ -17,6 +17,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.concurrent.Executor;
 
+import ml.docilealligator.infinityforreddit.LocalSave;
 import ml.docilealligator.infinityforreddit.SortType;
 import ml.docilealligator.infinityforreddit.apis.RedditAPI;
 import ml.docilealligator.infinityforreddit.postfilter.PostFilter;
@@ -189,6 +190,12 @@ public class PostPagingSource extends ListenableFuturePagingSource<String, Post>
             } else {
                 int currentPostsSize = postLinkedHashSet.size();
                 postLinkedHashSet.addAll(newPosts);
+
+                if(LocalSave.cacheSaved && postType == TYPE_USER && userWhere == USER_WHERE_SAVED)
+                {
+                    LocalSave.CachePosts(newPosts);
+                }
+
                 if (currentPostsSize == postLinkedHashSet.size()) {
                     return new LoadResult.Page<>(new ArrayList<>(), null, lastItem);
                 } else {

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/settings/PostLocalFragment.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/settings/PostLocalFragment.java
@@ -1,0 +1,143 @@
+package ml.docilealligator.infinityforreddit.settings;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.graphics.drawable.Drawable;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.fragment.app.Fragment;
+
+import com.google.android.material.materialswitch.MaterialSwitch;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import butterknife.BindView;
+import butterknife.ButterKnife;
+import ml.docilealligator.infinityforreddit.Infinity;
+import ml.docilealligator.infinityforreddit.R;
+import ml.docilealligator.infinityforreddit.activities.SettingsActivity;
+import ml.docilealligator.infinityforreddit.utils.SharedPreferencesUtils;
+import ml.docilealligator.infinityforreddit.utils.Utils;
+
+public class PostLocalFragment extends Fragment {
+
+    public static final String EXTRA_ACCOUNT_NAME = "EAN";
+
+    @BindView(R.id.info_text_view_post_local_fragment)
+    TextView infoTextView;
+    @BindView(R.id.mark_posts_as_read_linear_layout_post_local_fragment)
+    LinearLayout markPostsAsReadLinearLayout;
+    @BindView(R.id.mark_posts_as_read_text_view_post_local_fragment)
+    TextView markPostsAsReadTextView;
+    @BindView(R.id.mark_posts_as_read_switch_post_local_fragment)
+    MaterialSwitch markPostsAsReadSwitch;
+    @BindView(R.id.mark_posts_as_read_after_voting_linear_layout_post_local_fragment)
+    LinearLayout markPostsAsReadAfterVotingLinearLayout;
+    @BindView(R.id.mark_posts_as_read_after_voting_text_view_post_local_fragment)
+    TextView markPostsAsReadAfterVotingTextView;
+    @BindView(R.id.mark_posts_as_read_after_voting_switch_post_local_fragment)
+    MaterialSwitch markPostsAsReadAfterVotingSwitch;
+    @BindView(R.id.mark_posts_as_read_on_scroll_linear_layout_post_local_fragment)
+    LinearLayout markPostsAsReadOnScrollLinearLayout;
+    @BindView(R.id.mark_posts_as_read_on_scroll_text_view_post_local_fragment)
+    TextView markPostsAsReadOnScrollTextView;
+    @BindView(R.id.mark_posts_as_read_on_scroll_switch_post_local_fragment)
+    MaterialSwitch markPostsAsReadOnScrollSwitch;
+    @BindView(R.id.hide_read_posts_automatically_linear_layout_post_local_fragment)
+    LinearLayout hideReadPostsAutomaticallyLinearLayout;
+    @BindView(R.id.hide_read_posts_automatically_text_view_post_local_fragment)
+    TextView hideReadPostsAutomaticallyTextView;
+    @BindView(R.id.hide_read_posts_automatically_switch_post_local_fragment)
+    MaterialSwitch hideReadPostsAutomaticallySwitch;
+    @Inject
+    @Named("post_local")
+    SharedPreferences postLocalSharedPreferences;
+    private SettingsActivity activity;
+
+    public PostLocalFragment() {
+        // Required empty public constructor
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        // Inflate the layout for this fragment
+        View rootView = inflater.inflate(R.layout.fragment_post_local, container, false);
+
+        ((Infinity) activity.getApplication()).getAppComponent().inject(this);
+
+        ButterKnife.bind(this, rootView);
+
+        rootView.setBackgroundColor(activity.customThemeWrapper.getBackgroundColor());
+        applyCustomTheme();
+
+        if (activity.typeface != null) {
+            Utils.setFontToAllTextViews(rootView, activity.typeface);
+        }
+
+        String accountName = getArguments().getString(EXTRA_ACCOUNT_NAME);
+        if (accountName == null) {
+            infoTextView.setText(R.string.only_for_logged_in_user);
+            markPostsAsReadLinearLayout.setVisibility(View.GONE);
+            markPostsAsReadAfterVotingLinearLayout.setVisibility(View.GONE);
+            markPostsAsReadOnScrollLinearLayout.setVisibility(View.GONE);
+            hideReadPostsAutomaticallyLinearLayout.setVisibility(View.GONE);
+            return rootView;
+        }
+
+        markPostsAsReadSwitch.setChecked(postLocalSharedPreferences.getBoolean(
+                accountName + SharedPreferencesUtils.MARK_POSTS_AS_READ_BASE, false));
+        markPostsAsReadAfterVotingSwitch.setChecked(postLocalSharedPreferences.getBoolean(
+                accountName + SharedPreferencesUtils.MARK_POSTS_AS_READ_AFTER_VOTING_BASE, false));
+        markPostsAsReadOnScrollSwitch.setChecked(postLocalSharedPreferences.getBoolean(
+                accountName + SharedPreferencesUtils.MARK_POSTS_AS_READ_ON_SCROLL_BASE, false));
+        hideReadPostsAutomaticallySwitch.setChecked(postLocalSharedPreferences.getBoolean(
+                accountName + SharedPreferencesUtils.HIDE_READ_POSTS_AUTOMATICALLY_BASE, false));
+
+        markPostsAsReadLinearLayout.setOnClickListener(view -> {
+            markPostsAsReadSwitch.performClick();
+        });
+
+        markPostsAsReadSwitch.setOnCheckedChangeListener((compoundButton, b) ->
+                postLocalSharedPreferences.edit().putBoolean(accountName + SharedPreferencesUtils.MARK_POSTS_AS_READ_BASE, b).apply());
+
+        markPostsAsReadAfterVotingLinearLayout.setOnClickListener(view -> markPostsAsReadAfterVotingSwitch.performClick());
+
+        markPostsAsReadAfterVotingSwitch.setOnCheckedChangeListener((compoundButton, b) ->
+                postLocalSharedPreferences.edit().putBoolean(accountName + SharedPreferencesUtils.MARK_POSTS_AS_READ_AFTER_VOTING_BASE, b).apply());
+
+        markPostsAsReadOnScrollLinearLayout.setOnClickListener(view -> markPostsAsReadOnScrollSwitch.performClick());
+
+        markPostsAsReadOnScrollSwitch.setOnCheckedChangeListener((compoundButton, b) -> postLocalSharedPreferences.edit().putBoolean(accountName + SharedPreferencesUtils.MARK_POSTS_AS_READ_ON_SCROLL_BASE, b).apply());
+
+        hideReadPostsAutomaticallyLinearLayout.setOnClickListener(view -> hideReadPostsAutomaticallySwitch.performClick());
+
+        hideReadPostsAutomaticallySwitch.setOnCheckedChangeListener((compoundButton, b) -> postLocalSharedPreferences.edit().putBoolean(accountName + SharedPreferencesUtils.HIDE_READ_POSTS_AUTOMATICALLY_BASE, b).apply());
+
+        return rootView;
+    }
+
+    private void applyCustomTheme() {
+        infoTextView.setTextColor(activity.customThemeWrapper.getSecondaryTextColor());
+        Drawable infoDrawable = Utils.getTintedDrawable(activity, R.drawable.ic_info_preference_24dp, activity.customThemeWrapper.getPrimaryIconColor());
+        infoTextView.setCompoundDrawablesWithIntrinsicBounds(infoDrawable, null, null, null);
+        int primaryTextColor = activity.customThemeWrapper.getPrimaryTextColor();
+        markPostsAsReadTextView.setTextColor(primaryTextColor);
+        markPostsAsReadAfterVotingTextView.setTextColor(primaryTextColor);
+        markPostsAsReadOnScrollTextView.setTextColor(primaryTextColor);
+        hideReadPostsAutomaticallyTextView.setTextColor(primaryTextColor);
+    }
+
+    @Override
+    public void onAttach(@NonNull Context context) {
+        super.onAttach(context);
+        this.activity = (SettingsActivity) context;
+    }
+}

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/utils/SharedPreferencesUtils.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/utils/SharedPreferencesUtils.java
@@ -75,6 +75,8 @@ public class SharedPreferencesUtils {
     public static final int POST_LAYOUT_GALLERY = 2;
     public static final int POST_LAYOUT_CARD_2 = 3;
 
+    public static final String LOCAL_POST_LAYOUT = "local_post_layout";
+
     public static final String FRONT_PAGE_SCROLLED_POSITION_SHARED_PREFERENCES_FILE = "ml.docilealligator.infinityforreddit.front_page_scrolled_position";
     public static final String FRONT_PAGE_SCROLLED_POSITION_FRONT_PAGE_BASE = "_front_page";
     public static final String FRONT_PAGE_SCROLLED_POSITION_ANONYMOUS = ".anonymous";
@@ -334,6 +336,7 @@ public class SharedPreferencesUtils {
     public static final String BLUR_SPOILER_BASE = "_blur_spoiler";
 
     public static final String POST_HISTORY_SHARED_PREFERENCES_FILE = "ml.docilealligator.infinityforreddit.post_history";
+    public static final String POST_LOCAL_POSTS_SHARED_PREFERENCES_FILE = "ml.docilealligator.infinityforreddit.post_local_posts";
     public static final String MARK_POSTS_AS_READ_BASE = "_mark_posts_as_read";
     public static final String MARK_POSTS_AS_READ_AFTER_VOTING_BASE = "_mark_posts_as_read_after_voting";
     public static final String MARK_POSTS_AS_READ_ON_SCROLL_BASE = "_mark_posts_as_read_on_scroll";

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/utils/SharedPreferencesUtils.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/utils/SharedPreferencesUtils.java
@@ -76,6 +76,9 @@ public class SharedPreferencesUtils {
     public static final int POST_LAYOUT_CARD_2 = 3;
 
     public static final String LOCAL_POST_LAYOUT = "local_post_layout";
+    public static final String LOCAL_POST_SORTING= "local_post_sorting";
+    public static final String LOCAL_POST_CACHE_SAVED = "local_post_cache_saved";
+    public static final String LOCAL_POST_CACHE_HISTORY = "local_post_cache_history";
 
     public static final String FRONT_PAGE_SCROLLED_POSITION_SHARED_PREFERENCES_FILE = "ml.docilealligator.infinityforreddit.front_page_scrolled_position";
     public static final String FRONT_PAGE_SCROLLED_POSITION_FRONT_PAGE_BASE = "_front_page";

--- a/app/src/main/res/layout/activity_local_posts.xml
+++ b/app/src/main/res/layout/activity_local_posts.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:id="@+id/coordinator_layout_local_posts_activity"
+    tools:context=".activities.LocalPostsActivity">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appbar_layout_local_posts_activity"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:theme="@style/AppTheme.AppBarOverlay">
+
+        <com.google.android.material.appbar.CollapsingToolbarLayout
+            android:id="@+id/collapsing_toolbar_layout_local_posts_activity"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            app:layout_scrollFlags="scroll|enterAlways"
+            app:titleEnabled="false"
+            app:toolbarId="@+id/toolbar_local_posts_activity">
+
+            <androidx.appcompat.widget.Toolbar
+                android:id="@+id/toolbar_local_posts_activity"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:minHeight="?attr/actionBarSize"
+                app:layout_collapseMode="pin"
+                app:layout_scrollFlags="scroll|enterAlways"
+                app:popupTheme="@style/AppTheme.PopupOverlay"
+                app:navigationIcon="?attr/homeAsUpIndicator" />
+
+        </com.google.android.material.appbar.CollapsingToolbarLayout>
+
+        <com.google.android.material.tabs.TabLayout
+            android:id="@+id/tab_layout_tab_layout_local_posts_activity_activity"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="bottom"
+            app:layout_scrollFlags="scroll|enterAlways"
+            app:tabGravity="fill"
+            app:tabIndicatorHeight="3dp"
+            app:tabMode="fixed"
+            app:tabRippleColor="?attr/colorControlHighlight"
+            app:tabUnboundedRipple="false" />
+
+        <SearchView
+            android:id="@+id/local_posts_searchbar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:queryHint="Filter"
+            android:iconifiedByDefault="false"/>
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <androidx.viewpager2.widget.ViewPager2
+        android:id="@+id/view_pager_local_posts_activity"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior" />
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/fragment_local_post.xml
+++ b/app/src/main/res/layout/fragment_local_post.xml
@@ -1,0 +1,46 @@
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:application="ml.docilealligator.infinityforreddit.fragments.LocalPostFragment">
+
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+        android:id="@+id/swipe_refresh_layout_local_post_fragment"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <ml.docilealligator.infinityforreddit.customviews.CustomToroContainer
+            android:id="@+id/recycler_view_local_post_fragment"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:clipToPadding="false" />
+
+    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+
+    <LinearLayout
+        android:id="@+id/fetch_post_info_linear_layout_local_post_fragment"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_marginTop="48dp"
+        android:layout_marginBottom="48dp"
+        android:gravity="center"
+        android:orientation="vertical"
+        android:visibility="gone">
+
+        <ImageView
+            android:id="@+id/fetch_post_info_image_view_local_post_fragment"
+            android:layout_width="150dp"
+            android:layout_height="wrap_content" />
+
+        <TextView
+            android:id="@+id/fetch_post_info_text_view_local_post_fragment"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:gravity="center"
+            android:textSize="?attr/font_default"
+            android:fontFamily="?attr/font_family" />
+
+    </LinearLayout>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/fragment_post_local.xml
+++ b/app/src/main/res/layout/fragment_post_local.xml
@@ -1,0 +1,161 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    tools:context=".settings.PostLocalFragment">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/info_text_view_post_local_fragment"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:padding="16dp"
+            android:drawablePadding="32dp"
+            android:text="@string/restart_app_see_changes"
+            android:gravity="center_vertical"
+            android:textSize="?attr/font_default"
+            android:fontFamily="?attr/font_family" />
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:background="@color/dividerColor" />
+
+        <LinearLayout
+            android:id="@+id/mark_posts_as_read_linear_layout_post_local_fragment"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingTop="4dp"
+            android:paddingBottom="4dp"
+            android:paddingStart="72dp"
+            android:paddingEnd="16dp"
+            android:clickable="true"
+            android:focusable="true"
+            android:background="?attr/selectableItemBackground">
+
+            <TextView
+                android:id="@+id/mark_posts_as_read_text_view_post_local_fragment"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:layout_marginEnd="16dp"
+                android:layout_gravity="center_vertical"
+                android:drawablePadding="32dp"
+                android:text="@string/settings_mark_posts_as_read_title"
+                android:textColor="?attr/primaryTextColor"
+                android:textSize="?attr/font_16"
+                android:fontFamily="?attr/font_family" />
+
+            <com.google.android.material.materialswitch.MaterialSwitch
+                android:id="@+id/mark_posts_as_read_switch_post_local_fragment"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical" />
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/mark_posts_as_read_after_voting_linear_layout_post_local_fragment"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingTop="4dp"
+            android:paddingBottom="4dp"
+            android:paddingStart="72dp"
+            android:paddingEnd="16dp"
+            android:clickable="true"
+            android:focusable="true"
+            android:background="?attr/selectableItemBackground">
+
+            <TextView
+                android:id="@+id/mark_posts_as_read_after_voting_text_view_post_local_fragment"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:layout_marginEnd="16dp"
+                android:layout_gravity="center_vertical"
+                android:text="@string/settings_mark_posts_as_read_after_voting_title"
+                android:textColor="?attr/primaryTextColor"
+                android:textSize="?attr/font_16"
+                android:fontFamily="?attr/font_family" />
+
+            <com.google.android.material.materialswitch.MaterialSwitch
+                android:id="@+id/mark_posts_as_read_after_voting_switch_post_local_fragment"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical" />
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/mark_posts_as_read_on_scroll_linear_layout_post_local_fragment"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingTop="4dp"
+            android:paddingBottom="4dp"
+            android:paddingStart="72dp"
+            android:paddingEnd="16dp"
+            android:clickable="true"
+            android:focusable="true"
+            android:background="?attr/selectableItemBackground">
+
+            <TextView
+                android:id="@+id/mark_posts_as_read_on_scroll_text_view_post_local_fragment"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:layout_marginEnd="16dp"
+                android:layout_gravity="center_vertical"
+                android:text="@string/settings_mark_posts_as_read_on_scroll_title"
+                android:textColor="?attr/primaryTextColor"
+                android:textSize="?attr/font_16"
+                android:fontFamily="?attr/font_family" />
+
+            <com.google.android.material.materialswitch.MaterialSwitch
+                android:id="@+id/mark_posts_as_read_on_scroll_switch_post_local_fragment"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical" />
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/hide_read_posts_automatically_linear_layout_post_local_fragment"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingTop="4dp"
+            android:paddingBottom="4dp"
+            android:paddingStart="72dp"
+            android:paddingEnd="16dp"
+            android:clickable="true"
+            android:focusable="true"
+            android:background="?attr/selectableItemBackground">
+
+            <TextView
+                android:id="@+id/hide_read_posts_automatically_text_view_post_local_fragment"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:layout_marginEnd="16dp"
+                android:layout_gravity="center_vertical"
+                android:text="@string/settings_hide_read_posts_automatically_title"
+                android:textColor="?attr/primaryTextColor"
+                android:textSize="?attr/font_16"
+                android:fontFamily="?attr/font_family" />
+
+            <com.google.android.material.materialswitch.MaterialSwitch
+                android:id="@+id/hide_read_posts_automatically_switch_post_local_fragment"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical" />
+
+        </LinearLayout>
+
+    </LinearLayout>
+
+</androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/layout/fragment_share_link_bottom_sheet.xml
+++ b/app/src/main/res/layout/fragment_share_link_bottom_sheet.xml
@@ -11,6 +11,62 @@
         android:orientation="vertical">
 
         <TextView
+            android:id="@+id/manage_tags"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center_vertical"
+            android:paddingTop="16dp"
+            android:paddingBottom="16dp"
+            android:paddingStart="32dp"
+            android:paddingEnd="32dp"
+            android:text="Local Tags"
+            android:textColor="?attr/primaryTextColor"
+            android:textSize="?attr/font_default"
+            android:fontFamily="?attr/font_family"
+            android:drawableStart="@drawable/ic_search_24dp"
+            android:drawablePadding="48dp"
+            android:clickable="true"
+            android:focusable="true"
+            android:background="?attr/selectableItemBackground" />
+
+        <TextView
+            android:id="@+id/add_local_post"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center_vertical"
+            android:paddingTop="16dp"
+            android:paddingBottom="16dp"
+            android:paddingStart="32dp"
+            android:paddingEnd="32dp"
+            android:text="Save Local Post"
+            android:textColor="?attr/primaryTextColor"
+            android:textSize="?attr/font_default"
+            android:fontFamily="?attr/font_family"
+            android:drawableStart="@drawable/ic_import_day_night_24dp"
+            android:drawablePadding="48dp"
+            android:clickable="true"
+            android:focusable="true"
+            android:background="?attr/selectableItemBackground" />
+        <TextView
+            android:id="@+id/remove_local_post"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center_vertical"
+            android:paddingTop="16dp"
+            android:paddingBottom="16dp"
+            android:paddingStart="32dp"
+            android:paddingEnd="32dp"
+            android:text="Remove Local Post"
+            android:textColor="?attr/primaryTextColor"
+            android:textSize="?attr/font_default"
+            android:fontFamily="?attr/font_family"
+            android:drawableStart="@drawable/ic_delete_24dp"
+            android:drawablePadding="48dp"
+            android:clickable="true"
+            android:focusable="true"
+            android:background="?attr/selectableItemBackground" />
+
+        <TextView
             android:id="@+id/post_link_text_view_share_link_bottom_sheet_fragment"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/app/src/main/res/layout/local_posts_settings.xml
+++ b/app/src/main/res/layout/local_posts_settings.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <CheckBox
+            android:id="@+id/cache_saved_checkbox"
+            android:text="Cache Saved Posts"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"/>
+
+        <CheckBox
+            android:id="@+id/cache_history_checkbox"
+            android:text="Cache History Posts"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"/>
+
+        <Button
+            android:id="@+id/save_cached_btn"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Save Cached Posts"/>
+
+        <Button
+            android:id="@+id/clear_cached_btn"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Clear Cached Posts"/>
+
+        <Button
+            android:id="@+id/remove_all_saved_btn"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Remove All Saved Posts"/>
+
+    </LinearLayout>
+
+</RelativeLayout>

--- a/app/src/main/res/layout/local_posts_settings.xml
+++ b/app/src/main/res/layout/local_posts_settings.xml
@@ -23,8 +23,7 @@
         <Button
             android:id="@+id/save_cached_btn"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="Save Cached Posts"/>
+            android:layout_height="wrap_content"/>
 
         <Button
             android:id="@+id/clear_cached_btn"

--- a/app/src/main/res/menu/local_posts_activity.xml
+++ b/app/src/main/res/menu/local_posts_activity.xml
@@ -22,7 +22,7 @@
     <item
         android:id="@+id/local_settings"
         android:orderInCategory="4"
-        android:title="Settings"
+        android:title="@string/settings"
         app:showAsAction="never" />
 
     <item

--- a/app/src/main/res/menu/local_posts_activity.xml
+++ b/app/src/main/res/menu/local_posts_activity.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/action_refresh_local_posts_activity"
+        android:orderInCategory="1"
+        android:title="@string/action_refresh"
+        app:showAsAction="never" />
+
+    <item
+        android:id="@+id/action_change_post_layout_local_posts_activity"
+        android:orderInCategory="2"
+        android:title="@string/action_change_post_layout"
+        app:showAsAction="never" />
+
+    <item
+        android:id="@+id/change_sort_type"
+        android:orderInCategory="3"
+        android:title="@string/action_sort"
+        app:showAsAction="never" />
+
+    <item
+        android:id="@+id/local_settings"
+        android:orderInCategory="4"
+        android:title="Settings"
+        app:showAsAction="never" />
+
+    <item
+        android:id="@+id/manual_save"
+        android:orderInCategory="5"
+        android:title="Manually Save Posts"
+        app:showAsAction="never" />
+
+    <item
+        android:id="@+id/backup_save"
+        android:orderInCategory="6"
+        android:title="Save Backup"
+        app:showAsAction="never" />
+
+    <item
+        android:id="@+id/backup_load"
+        android:orderInCategory="7"
+        android:title="Load Backup"
+        app:showAsAction="never" />
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -45,6 +45,7 @@
     <string name="edit_profile_activity_label">Edit Profile</string>
     <string name="post_poll_activity_label">Poll Post</string>
     <string name="history_activity_label">History</string>
+    <string name="local_post_activity_label">Local Posts</string>
 
     <string name="navigation_drawer_open">Open navigation drawer</string>
     <string name="navigation_drawer_close">Close navigation drawer</string>
@@ -136,6 +137,7 @@
     <string name="subscriptions">Subscriptions</string>
     <string name="multi_reddit">Multireddit</string>
     <string name="history">History</string>
+    <string name="local_posts">Local Posts</string>
     <string name="inbox">Inbox</string>
     <string name="inbox_with_count">Inbox (%1$,d)</string>
     <string name="trending">Trending</string>


### PR DESCRIPTION
Not sure if this fits in the official repo. I created this because I was annoyed with the lack of features of saved posts.



I just hacked this together from the History so the code may need to be cleaned up a bit.
The LocalSave class is entirely static because that was the fastest way I could think of to add History and Saved post caching,
but it can probably almost entirely be moved into LocalPostPagingSource and made non-static.

All the features I added ( if I didn't forget anything ):
- Added locally saved posts to bypass the default limit of 1000 saved posts.
- Added the ability to sort locally saved posts by random, added-date and upload-date.
- Added the ability to filter by title, subreddit, flair and tags that can be added to locally saved posts.
- Locally saved posts can be backed up in json files.
- History and Saved posts can be cached and bulk added to the locally saved posts.
- Local posts can be accessed from the navigation bar above History.
- Posts can be saved by long pressing on the bookmark icon or in the share menu.
- Tags can be edited from the share menu.
- Multiple search filters can be applied by separating keywords by whitespaces and using underscores in place of spaces in keywords. It will find posts matching any keyword.