### PR TITLE
Inline gif support for comment section

### DIFF
--- a/app/src/main/res/layout/item_comment.xml
+++ b/app/src/main/res/layout/item_comment.xml
@@ -144,6 +144,29 @@
             android:layout_marginEnd="8dp"
             android:nestedScrollingEnabled="false" />
 
+        <ImageView
+            android:id="@+id/comment_gif"
+            android:layout_width="match_parent"
+            android:layout_height="175dp"
+            android:layout_marginTop="8dp"
+            android:layout_marginBottom="8dp"
+            android:layout_marginStart="16dp"
+            android:layout_marginEnd="16dp"
+            android:scaleType="fitStart"
+            android:visibility="gone"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintStart_toStartOf="parent" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/comment_markdown_view_item_post_comment2"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_marginTop="8dp"
+            android:layout_marginStart="8dp"
+            android:layout_marginEnd="8dp"
+            android:visibility="gone"
+            android:nestedScrollingEnabled="false" />
+
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/bottom_constraint_layout_item_post_comment"
             android:layout_width="match_parent"


### PR DESCRIPTION
Hello there :wave: ! First time opening a PR in this project so sorry if I am not keeping the right etiquette here. 

This feature has been something that I thought was missing in this app (tapping links just to see a gif has been a bit of annoyance to me) and it looks like I am not the only one (See https://github.com/Docile-Alligator/Infinity-For-Reddit/discussions/935). So I spent my Saturday hacking together something that looks like it works ok. My Java skills are quite rusty so bear with me on this (and do point me to better ways for doing things).

## Design

- I checked how inline gifs look like in the web and it looks like they always have a height of 175 and then as much width as they want so they can keep their aspect ratio. So tried to follow that.
- Looks like Reddit atm only allows for one Giphy gif to be inlined. Might change at some point but thought I would make it easier and just do that.
- I chose to only inline Giphy gifs. It seems like Reddit considers some other sources (like internal websites) as trusted and inlines them but thought that these were quite more rare (most people just tap the gif button when composing a comment) and also required some more investigation. My initial inclination though was to only include the Giphy ones as these are more safe in general (no pornography etc.).

## Other decisions
-  Upon checking the code I saw that for comments there is a Markdown parser that parses and outputs the Spannables (?) in a list that gets placed inside a `RecyclerView`. This made it a bit awkward for me as it looks like the gif can be inlined even in between text lines. My proposed solution is: 

	1. There are now 2 new views (both default as GONE) in the comment xml. An ` ImageView` that plays the GIF and another `RecyclerView` below that for the markdown text that should go below the gif (if any).
	2. During the binding of the view the message is parsed, splitted and then the relevant views get hidden or shown etc.

- I had to cater for the case that the gif part of the message (`[gif](...)`) is inside a code block. It seems like Reddit does not inline those. I thought of two cases for this:

	1. The line with the gif part is indented 4 spaces in (which looks like makes it a code block)
	2. There is an odd number of backticks before the gif part which means we are in a code block as well.

- It is worth noting the performance aspect of the thing. Now all this code sits inside `onBindViewHolder` so all this parsing might slow down scrolling. Did not want to refactor large parts of the app but could be moved to a structure like a ViewModel or something. Also one thing to consider is whether a setting for this is needed that disables it for people that do not care and/or are on old devices.

## Screen captures

[before.webm](https://github.com/Docile-Alligator/Infinity-For-Reddit/assets/5406640/2346823b-75a3-44ef-abc8-8d38b85b95e4)

[after.webm](https://github.com/Docile-Alligator/Infinity-For-Reddit/assets/5406640/de778d83-e321-4bc3-84e4-9d180bf2ccb5)
