### PR TITLE
Delete oldest read posts first

### DIFF
--- a/app/src/main/java/ml/docilealligator/infinityforreddit/readpost/ReadPostDao.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/readpost/ReadPostDao.java
@@ -29,7 +29,7 @@ public interface ReadPostDao {
     @Query("SELECT COUNT(id) FROM read_posts")
     int getReadPostsCount();
 
-    @Query("DELETE FROM read_posts WHERE rowid IN (SELECT rowid FROM read_posts LIMIT 100) AND username = :username")
+    @Query("DELETE FROM read_posts WHERE rowid IN (SELECT rowid FROM read_posts ORDER BY time ASC LIMIT 100) AND username = :username")
     void deleteOldestReadPosts(String username);
 
     @Query("DELETE FROM read_posts")


### PR DESCRIPTION
## Context 
- Read posts are limited to 500
- Once that limit is reached, 100 read posts are deleted 
- The selection of the 100 read posts to delete is random because it is not ordered

This can cause an inconsistent experience for the user if the deletion happens to delete recently read posts.
My opinion is that deleting the oldest read posts is the expected behavior.

## Changes
- Add order by read time ascending to the selection query
