### PR TITLE
Order history reverse chronologically

### DIFF
--- a/app/src/main/java/ml/docilealligator/infinityforreddit/post/HistoryPostPagingSource.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/post/HistoryPostPagingSource.java
@@ -111,8 +111,8 @@ public class HistoryPostPagingSource extends ListenableFuturePagingSource<String
     }
 
     private ListenableFuture<LoadResult<String, Post>> loadHomePosts(@NonNull LoadParams<String> loadParams, RedditDataRoomDatabase redditDataRoomDatabase) {
-        String after = loadParams.getKey();
-        ListenableFuture<List<ReadPost>> readPosts = redditDataRoomDatabase.readPostDao().getAllReadPostsListenableFuture(username, Long.parseLong(after == null ? "0" : after));
+        Long before = loadParams.getKey() != null ? Long.parseLong(loadParams.getKey()) : null;
+        ListenableFuture<List<ReadPost>> readPosts = redditDataRoomDatabase.readPostDao().getAllReadPostsListenableFuture(username, before);
 
         ListenableFuture<LoadResult<String, Post>> pageFuture = Futures.transform(readPosts, this::transformData, executor);
 

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/post/HistoryPostViewModel.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/post/HistoryPostViewModel.java
@@ -49,7 +49,7 @@ public class HistoryPostViewModel extends ViewModel {
 
         postFilterLiveData = new MutableLiveData<>(postFilter);
 
-        Pager<String, Post> pager = new Pager<>(new PagingConfig(25, 4, false, 10), this::returnPagingSoruce);
+        Pager<String, Post> pager = new Pager<>(new PagingConfig(25, 4, false, 10), this::returnPagingSource);
 
         posts = Transformations.switchMap(postFilterLiveData, postFilterValue -> PagingLiveData.cachedIn(PagingLiveData.getLiveData(pager), ViewModelKt.getViewModelScope(this)));
     }
@@ -58,19 +58,19 @@ public class HistoryPostViewModel extends ViewModel {
         return posts;
     }
 
-    public HistoryPostPagingSource returnPagingSoruce() {
-        HistoryPostPagingSource paging3PagingSource;
+    public HistoryPostPagingSource returnPagingSource() {
+        HistoryPostPagingSource historyPostPagingSource;
         switch (postType) {
             case HistoryPostPagingSource.TYPE_READ_POSTS:
-                paging3PagingSource = new HistoryPostPagingSource(retrofit, executor, redditDataRoomDatabase, accessToken, accountName,
+                historyPostPagingSource = new HistoryPostPagingSource(retrofit, executor, redditDataRoomDatabase, accessToken, accountName,
                         sharedPreferences, accountName, postType, postFilter);
                 break;
             default:
-                paging3PagingSource = new HistoryPostPagingSource(retrofit, executor, redditDataRoomDatabase, accessToken, accountName,
+                historyPostPagingSource = new HistoryPostPagingSource(retrofit, executor, redditDataRoomDatabase, accessToken, accountName,
                         sharedPreferences, accountName, postType, postFilter);
                 break;
         }
-        return paging3PagingSource;
+        return historyPostPagingSource;
     }
 
     public void changePostFilter(PostFilter postFilter) {

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/readpost/ReadPostDao.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/readpost/ReadPostDao.java
@@ -14,11 +14,11 @@ public interface ReadPostDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     void insert(ReadPost readPost);
 
-    @Query("SELECT * FROM read_posts WHERE username = :username AND time > :after ORDER BY time LIMIT 25")
-    ListenableFuture<List<ReadPost>> getAllReadPostsListenableFuture(String username, long after);
+    @Query("SELECT * FROM read_posts WHERE username = :username AND (:before IS NULL OR time < :before) ORDER BY time DESC LIMIT 25")
+    ListenableFuture<List<ReadPost>> getAllReadPostsListenableFuture(String username, Long before);
 
-    @Query("SELECT * FROM read_posts WHERE username = :username AND time > :after ORDER BY time LIMIT 25")
-    List<ReadPost> getAllReadPosts(String username, long after);
+    @Query("SELECT * FROM read_posts WHERE username = :username AND (:before IS NULL OR time < :before) ORDER BY time DESC LIMIT 25")
+    List<ReadPost> getAllReadPosts(String username, Long before);
 
     @Query("SELECT * FROM read_posts WHERE username = :username")
     List<ReadPost> getAllReadPosts(String username);


### PR DESCRIPTION
## Context
The history page is ordered chronologically. As in, the posts the most anciently read appear first.
My opinion is that this is not intuitive and makes that page less useful. 

## Changes
- Order read posts reverse chronologically so that the most recently read posts appear first
- Some code cleanup (typo in function name and clearer variable name)