### PR TITLE
Remove unnecessary `tools:replace` attribute from AndroidManifest.xml

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -33,8 +33,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
-        android:usesCleartextTraffic="true"
-        tools:replace="android:label">
+        android:usesCleartextTraffic="true">
         <activity
             android:name=".activities.LoginChromeCustomTabActivity"
             android:label="@string/login_activity_label"


### PR DESCRIPTION
### Description:
This PR addresses a warning in the `AndroidManifest.xml` file regarding the `tools:replace` attribute used on the `android:label` of the `<application>` element. The warning indicated that there were no other declarations of `android:label` in any merged manifest files, making the `tools:replace` attribute unnecessary.
Details: https://github.com/Docile-Alligator/Infinity-For-Reddit/actions/runs/10067294236/job/27830465944#step:4:77

### Changes Made:
- Removed the `tools:replace="android:label"` attribute from the `<application>` element in the `AndroidManifest.xml` file.

### Impact:
- This change should have no functional impact on the application.
- It removes a build warning, making the build process cleaner.

Please review and merge this PR to resolve the manifest warning.