### PR TITLE
fix: Remove F-Droid link from `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,11 @@ A Reddit client on Android written in Java. It does not have any ads and it feat
 
 <div align="center">
 
-Infinity for Reddit is available on Google Play and F-Droid
+Infinity for Reddit is available on Google Play
 
   <a href="https://play.google.com/store/apps/details?id=ml.docilealligator.infinityforreddit">
       <img alt="Get it on Google Play" height="80" src="https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png" />
-      </a>  
-      <a href="https://f-droid.org/packages/ml.docilealligator.infinityforreddit/">
-          <img alt="Get it on F-Droid" height="80" src="https://f-droid.org/badge/get-it-on.png" />
+      </a>
   </a>
 
 </div>


### PR DESCRIPTION
https://github.com/Docile-Alligator/Infinity-For-Reddit/issues/1568 discusses the removal of the app from F-Droid.

F-Droid is still in the [bug report template](https://github.com/Docile-Alligator/Infinity-For-Reddit/blob/bd7f0f506ebb7adae24711abc8b6fe6bef0634ea/.github/ISSUE_TEMPLATE/BUG_REPORT.yml?plain=1#L39) in case users encounter bugs when using the app from F-Droid.