### PR TITLE
Changed the way read posts are handled to support an arbitrary 'read …

### DIFF
--- a/app/src/main/java/ml/docilealligator/infinityforreddit/FetchPostFilterAndConcatenatedSubredditNames.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/FetchPostFilterAndConcatenatedSubredditNames.java
@@ -14,31 +14,26 @@ import ml.docilealligator.infinityforreddit.postfilter.PostFilter;
 import ml.docilealligator.infinityforreddit.readpost.ReadPost;
 import ml.docilealligator.infinityforreddit.subscribedsubreddit.SubscribedSubredditData;
 
-public class FetchPostFilterReadPostsAndConcatenatedSubredditNames {
+public class FetchPostFilterAndConcatenatedSubredditNames {
     public interface FetchPostFilterAndReadPostsListener {
         void success(PostFilter postFilter, ArrayList<String> readPostList);
+    }
+
+    public interface FetchPostFilterListerner {
+        void success(PostFilter postFilter);
     }
 
     public interface FetchPostFilterAndConcatenatecSubredditNamesListener {
         void success(PostFilter postFilter, String concatenatedSubredditNames);
     }
 
-    public static void fetchPostFilterAndReadPosts(RedditDataRoomDatabase redditDataRoomDatabase, Executor executor,
-                                                   Handler handler, @NonNull String accountName, int postFilterUsage,
-                                                   String nameOfUsage, FetchPostFilterAndReadPostsListener fetchPostFilterAndReadPostsListener) {
+    public static void fetchPostFilter(RedditDataRoomDatabase redditDataRoomDatabase, Executor executor,
+                                                   Handler handler, int postFilterUsage,
+                                                   String nameOfUsage, FetchPostFilterListerner fetchPostFilterListerner) {
         executor.execute(() -> {
             List<PostFilter> postFilters = redditDataRoomDatabase.postFilterDao().getValidPostFilters(postFilterUsage, nameOfUsage);
             PostFilter mergedPostFilter = PostFilter.mergePostFilter(postFilters);
-            if (accountName.equals(Account.ANONYMOUS_ACCOUNT)) {
-                handler.post(() -> fetchPostFilterAndReadPostsListener.success(mergedPostFilter, null));
-            } else {
-                List<ReadPost> readPosts = redditDataRoomDatabase.readPostDao().getAllReadPosts(accountName);
-                ArrayList<String> readPostStrings = new ArrayList<>();
-                for (ReadPost readPost : readPosts) {
-                    readPostStrings.add(readPost.getId());
-                }
-                handler.post(() -> fetchPostFilterAndReadPostsListener.success(mergedPostFilter, readPostStrings));
-            }
+            handler.post(() -> fetchPostFilterListerner.success(mergedPostFilter));
         });
     }
 

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/activities/AccountSavedThingActivity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/activities/AccountSavedThingActivity.java
@@ -19,6 +19,7 @@ import androidx.viewpager2.widget.ViewPager2;
 
 import com.google.android.material.tabs.TabLayoutMediator;
 
+import ml.docilealligator.infinityforreddit.readpost.ReadPostsUtils;
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
 
@@ -57,6 +58,9 @@ public class AccountSavedThingActivity extends BaseActivity implements ActivityT
     @Inject
     @Named("default")
     SharedPreferences mSharedPreferences;
+    @Inject
+    @Named("post_history")
+    SharedPreferences mPostHistorySharedPreferences;
     @Inject
     @Named("post_layout")
     SharedPreferences mPostLayoutSharedPreferences;
@@ -251,7 +255,8 @@ public class AccountSavedThingActivity extends BaseActivity implements ActivityT
 
     @Override
     public void markPostAsRead(Post post) {
-        InsertReadPost.insertReadPost(mRedditDataRoomDatabase, mExecutor, accountName, post.getId());
+        int readPostsLimit = ReadPostsUtils.GetReadPostsLimit(accountName, mPostHistorySharedPreferences);
+        InsertReadPost.insertReadPost(mRedditDataRoomDatabase, mExecutor, accountName, post.getId(), readPostsLimit);
     }
 
     private class SectionsPagerAdapter extends FragmentStateAdapter {

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/activities/FilteredPostsActivity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/activities/FilteredPostsActivity.java
@@ -15,6 +15,7 @@ import androidx.annotation.Nullable;
 import androidx.coordinatorlayout.widget.CoordinatorLayout;
 import androidx.lifecycle.ViewModelProvider;
 
+import ml.docilealligator.infinityforreddit.readpost.ReadPostsUtils;
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
 
@@ -72,6 +73,9 @@ public class FilteredPostsActivity extends BaseActivity implements SortTypeSelec
     @Inject
     @Named("default")
     SharedPreferences mSharedPreferences;
+    @Inject
+    @Named("post_history")
+    SharedPreferences mPostHistorySharedPreferences;
     @Inject
     @Named("post_layout")
     SharedPreferences mPostLayoutSharedPreferences;
@@ -459,7 +463,8 @@ public class FilteredPostsActivity extends BaseActivity implements SortTypeSelec
 
     @Override
     public void markPostAsRead(Post post) {
-        InsertReadPost.insertReadPost(mRedditDataRoomDatabase, mExecutor, accountName, post.getId());
+        int readPostsLimit = ReadPostsUtils.GetReadPostsLimit(accountName, mPostHistorySharedPreferences);
+        InsertReadPost.insertReadPost(mRedditDataRoomDatabase, mExecutor, accountName, post.getId(), readPostsLimit);
     }
 
     @Override

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/activities/MainActivity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/activities/MainActivity.java
@@ -52,6 +52,7 @@ import com.google.android.material.tabs.TabLayout;
 import com.google.android.material.tabs.TabLayoutMediator;
 import com.google.android.material.textfield.TextInputEditText;
 
+import ml.docilealligator.infinityforreddit.readpost.ReadPostsUtils;
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
@@ -153,6 +154,9 @@ public class MainActivity extends BaseActivity implements SortTypeSelectionCallb
     @Inject
     @Named("sort_type")
     SharedPreferences mSortTypeSharedPreferences;
+    @Inject
+    @Named("post_history")
+    SharedPreferences mPostHistorySharedPreferences;
     @Inject
     @Named("post_layout")
     SharedPreferences mPostLayoutSharedPreferences;
@@ -1598,7 +1602,8 @@ public class MainActivity extends BaseActivity implements SortTypeSelectionCallb
 
     @Override
     public void markPostAsRead(Post post) {
-        InsertReadPost.insertReadPost(mRedditDataRoomDatabase, mExecutor, accountName, post.getId());
+        int readPostsLimit = ReadPostsUtils.GetReadPostsLimit(accountName, mPostHistorySharedPreferences);
+        InsertReadPost.insertReadPost(mRedditDataRoomDatabase, mExecutor, accountName, post.getId(), readPostsLimit);
     }
 
     public void doNotShowRedditAPIInfoAgain() {

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/activities/ViewMultiRedditDetailActivity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/activities/ViewMultiRedditDetailActivity.java
@@ -25,6 +25,7 @@ import androidx.recyclerview.widget.RecyclerView;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.android.material.textfield.TextInputEditText;
 
+import ml.docilealligator.infinityforreddit.readpost.ReadPostsUtils;
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
 
@@ -97,6 +98,9 @@ public class ViewMultiRedditDetailActivity extends BaseActivity implements SortT
     @Inject
     @Named("sort_type")
     SharedPreferences mSortTypeSharedPreferences;
+    @Inject
+    @Named("post_history")
+    SharedPreferences mPostHistorySharedPreferences;
     @Inject
     @Named("post_layout")
     SharedPreferences mPostLayoutSharedPreferences;
@@ -877,7 +881,8 @@ public class ViewMultiRedditDetailActivity extends BaseActivity implements SortT
 
     @Override
     public void markPostAsRead(Post post) {
-        InsertReadPost.insertReadPost(mRedditDataRoomDatabase, mExecutor, accountName, post.getId());
+        int readPostsLimit = ReadPostsUtils.GetReadPostsLimit(accountName, mPostHistorySharedPreferences);
+        InsertReadPost.insertReadPost(mRedditDataRoomDatabase, mExecutor, accountName, post.getId(), readPostsLimit);
     }
 
     @Override

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/activities/ViewPostDetailActivity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/activities/ViewPostDetailActivity.java
@@ -36,6 +36,8 @@ import com.github.piasy.biv.loader.glide.GlideImageLoader;
 import com.google.android.material.snackbar.Snackbar;
 import com.livefront.bridge.Bridge;
 
+import ml.docilealligator.infinityforreddit.readpost.NullReadPostsList;
+import ml.docilealligator.infinityforreddit.readpost.ReadPostsListInterface;
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
 
@@ -141,8 +143,6 @@ public class ViewPostDetailActivity extends BaseActivity implements SortTypeSele
     @State
     SortType.Time sortTime;
     @State
-    ArrayList<String> readPostList;
-    @State
     Post post;
     @State
     @LoadingMorePostsStatus
@@ -156,6 +156,7 @@ public class ViewPostDetailActivity extends BaseActivity implements SortTypeSele
     private boolean mVolumeKeysNavigateComments;
     private boolean isNsfwSubreddit;
     private ActivityViewPostDetailBinding binding;
+    ReadPostsListInterface readPostsList;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -581,7 +582,7 @@ public class ViewPostDetailActivity extends BaseActivity implements SortTypeSele
                     Response<String> response = call.execute();
                     if (response.isSuccessful()) {
                         String responseString = response.body();
-                        LinkedHashSet<Post> newPosts = ParsePost.parsePostsSync(responseString, -1, postFilter, readPostList);
+                        LinkedHashSet<Post> newPosts = ParsePost.parsePostsSync(responseString, -1, postFilter, readPostsList);
                         if (newPosts == null) {
                             handler.post(() -> {
                                 loadingMorePostsStatus = LoadingMorePostsStatus.NO_MORE_POSTS;
@@ -663,7 +664,7 @@ public class ViewPostDetailActivity extends BaseActivity implements SortTypeSele
                     Response<String> response = historyPosts.execute();
                     if (response.isSuccessful()) {
                         String responseString = response.body();
-                        LinkedHashSet<Post> newPosts = ParsePost.parsePostsSync(responseString, -1, postFilter, null);
+                        LinkedHashSet<Post> newPosts = ParsePost.parsePostsSync(responseString, -1, postFilter, NullReadPostsList.getInstance());
                         if (newPosts == null || newPosts.isEmpty()) {
                             handler.post(() -> {
                                 loadingMorePostsStatus = LoadingMorePostsStatus.NO_MORE_POSTS;
@@ -744,7 +745,7 @@ public class ViewPostDetailActivity extends BaseActivity implements SortTypeSele
             this.postFilter = event.postFilter;
             this.sortType = event.sortType.getType();
             this.sortTime = event.sortType.getTime();
-            this.readPostList = event.readPostList;
+            this.readPostsList = event.readPostsList;
 
             if (sectionsPagerAdapter != null) {
                 if (postListPosition > 0)

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/activities/ViewSubredditDetailActivity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/activities/ViewSubredditDetailActivity.java
@@ -48,6 +48,7 @@ import com.google.android.material.snackbar.Snackbar;
 import com.google.android.material.tabs.TabLayoutMediator;
 import com.google.android.material.textfield.TextInputEditText;
 
+import ml.docilealligator.infinityforreddit.readpost.ReadPostsUtils;
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
 
@@ -151,6 +152,9 @@ public class ViewSubredditDetailActivity extends BaseActivity implements SortTyp
     @Inject
     @Named("nsfw_and_spoiler")
     SharedPreferences mNsfwAndSpoilerSharedPreferences;
+    @Inject()
+    @Named("post_history")
+    SharedPreferences mPostHistorySharedPreferences;
     @Inject
     @Named("post_layout")
     SharedPreferences mPostLayoutSharedPreferences;
@@ -1537,7 +1541,8 @@ public class ViewSubredditDetailActivity extends BaseActivity implements SortTyp
 
     @Override
     public void markPostAsRead(Post post) {
-        InsertReadPost.insertReadPost(mRedditDataRoomDatabase, mExecutor, accountName, post.getId());
+        int readPostsLimit = ReadPostsUtils.GetReadPostsLimit(accountName, mPostHistorySharedPreferences);
+        InsertReadPost.insertReadPost(mRedditDataRoomDatabase, mExecutor, accountName, post.getId(), readPostsLimit);
     }
 
     @Override

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/activities/ViewUserDetailActivity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/activities/ViewUserDetailActivity.java
@@ -44,6 +44,7 @@ import com.google.android.material.snackbar.Snackbar;
 import com.google.android.material.tabs.TabLayoutMediator;
 import com.google.android.material.textfield.TextInputEditText;
 
+import ml.docilealligator.infinityforreddit.readpost.ReadPostsUtils;
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
 
@@ -146,6 +147,9 @@ public class ViewUserDetailActivity extends BaseActivity implements SortTypeSele
     @Inject
     @Named("sort_type")
     SharedPreferences mSortTypeSharedPreferences;
+    @Inject
+    @Named("post_history")
+    SharedPreferences mPostHistorySharedPreferences;
     @Inject
     @Named("post_layout")
     SharedPreferences mPostLayoutSharedPreferences;
@@ -1550,7 +1554,8 @@ public class ViewUserDetailActivity extends BaseActivity implements SortTypeSele
 
     @Override
     public void markPostAsRead(Post post) {
-        InsertReadPost.insertReadPost(mRedditDataRoomDatabase, mExecutor, accountName, post.getId());
+        int readPostsLimit = ReadPostsUtils.GetReadPostsLimit(accountName, mPostHistorySharedPreferences);
+        InsertReadPost.insertReadPost(mRedditDataRoomDatabase, mExecutor, accountName, post.getId(), readPostsLimit);
     }
 
     @Override

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/events/ProvidePostListToViewPostDetailActivityEvent.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/events/ProvidePostListToViewPostDetailActivityEvent.java
@@ -2,6 +2,7 @@ package ml.docilealligator.infinityforreddit.events;
 
 import java.util.ArrayList;
 
+import ml.docilealligator.infinityforreddit.readpost.ReadPostsListInterface;
 import ml.docilealligator.infinityforreddit.thing.SortType;
 import ml.docilealligator.infinityforreddit.post.Post;
 import ml.docilealligator.infinityforreddit.postfilter.PostFilter;
@@ -19,14 +20,13 @@ public class ProvidePostListToViewPostDetailActivityEvent {
     public String trendingSource;
     public PostFilter postFilter;
     public SortType sortType;
-    public ArrayList<String> readPostList;
+    public ReadPostsListInterface readPostsList;
 
     public ProvidePostListToViewPostDetailActivityEvent(long postFragmentId, ArrayList<Post> posts, int postType,
                                                         String subredditName, String concatenatedSubredditNames,
                                                         String username, String userWhere,
                                                         String multiPath, String query, String trendingSource,
-                                                        PostFilter postFilter, SortType sortType,
-                                                        ArrayList<String> readPostList) {
+                                                        PostFilter postFilter, SortType sortType, ReadPostsListInterface readPostsList) {
         this.postFragmentId = postFragmentId;
         this.posts = posts;
         this.postType = postType;
@@ -39,6 +39,6 @@ public class ProvidePostListToViewPostDetailActivityEvent {
         this.trendingSource = trendingSource;
         this.postFilter = postFilter;
         this.sortType = sortType;
-        this.readPostList = readPostList;
+        this.readPostsList = readPostsList;
     }
 }

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/fragments/HistoryPostFragment.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/fragments/HistoryPostFragment.java
@@ -57,7 +57,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Provider;
 
-import ml.docilealligator.infinityforreddit.FetchPostFilterReadPostsAndConcatenatedSubredditNames;
+import ml.docilealligator.infinityforreddit.FetchPostFilterAndConcatenatedSubredditNames;
 import ml.docilealligator.infinityforreddit.Infinity;
 import ml.docilealligator.infinityforreddit.R;
 import ml.docilealligator.infinityforreddit.RecyclerViewContentScrollingInterface;
@@ -206,7 +206,6 @@ public class HistoryPostFragment extends Fragment implements FragmentCommunicato
     private boolean vibrateWhenActionTriggered;
     private float swipeActionThreshold;
     private ItemTouchHelper touchHelper;
-    private ArrayList<String> readPosts;
     private final Map<String, String> subredditOrUserIcons = new HashMap<>();
     private int historyType;
     private FragmentHistoryPostBinding binding;
@@ -314,7 +313,6 @@ public class HistoryPostFragment extends Fragment implements FragmentCommunicato
             recyclerViewPosition = savedInstanceState.getInt(RECYCLER_VIEW_POSITION_STATE);
 
             isInLazyMode = savedInstanceState.getBoolean(IS_IN_LAZY_MODE_STATE);
-            readPosts = savedInstanceState.getStringArrayList(READ_POST_LIST_STATE);
             postFilter = savedInstanceState.getParcelable(POST_FILTER_STATE);
             historyPostFragmentId = savedInstanceState.getLong(POST_FRAGMENT_ID_STATE);
         } else {
@@ -416,8 +414,8 @@ public class HistoryPostFragment extends Fragment implements FragmentCommunicato
         }
 
         if (postFilter == null) {
-            FetchPostFilterReadPostsAndConcatenatedSubredditNames.fetchPostFilterAndReadPosts(mRedditDataRoomDatabase, mExecutor,
-                    new Handler(), activity.accountName, PostFilterUsage.HISTORY_TYPE, PostFilterUsage.HISTORY_TYPE_USAGE_READ_POSTS, (postFilter, readPostList) -> {
+            FetchPostFilterAndConcatenatedSubredditNames.fetchPostFilter(mRedditDataRoomDatabase, mExecutor,
+                    new Handler(), PostFilterUsage.HISTORY_TYPE, PostFilterUsage.HISTORY_TYPE_USAGE_READ_POSTS, (postFilter) -> {
                         if (activity != null && !activity.isFinishing() && !activity.isDestroyed() && !isDetached()) {
                             this.postFilter = postFilter;
                             postFilter.allowNSFW = !mSharedPreferences.getBoolean(SharedPreferencesUtils.DISABLE_NSFW_FOREVER, false) && mNsfwAndSpoilerSharedPreferences.getBoolean(activity.accountName + SharedPreferencesUtils.NSFW_BASE, false);
@@ -710,7 +708,6 @@ public class HistoryPostFragment extends Fragment implements FragmentCommunicato
     public void onSaveInstanceState(@NonNull Bundle outState) {
         super.onSaveInstanceState(outState);
         outState.putBoolean(IS_IN_LAZY_MODE_STATE, isInLazyMode);
-        outState.putStringArrayList(READ_POST_LIST_STATE, readPosts);
         if (mLinearLayoutManager != null) {
             outState.putInt(RECYCLER_VIEW_POSITION_STATE, mLinearLayoutManager.findFirstVisibleItemPosition());
         } else if (mStaggeredGridLayoutManager != null) {

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/fragments/ViewPostDetailFragment.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/fragments/ViewPostDetailFragment.java
@@ -48,6 +48,7 @@ import com.evernote.android.state.State;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.livefront.bridge.Bridge;
 
+import ml.docilealligator.infinityforreddit.readpost.ReadPostsUtils;
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
 
@@ -1156,7 +1157,8 @@ public class ViewPostDetailFragment extends Fragment implements FragmentCommunic
     private void tryMarkingPostAsRead() {
         if (mMarkPostsAsRead && mPost != null && !mPost.isRead()) {
             mPost.markAsRead();
-            InsertReadPost.insertReadPost(mRedditDataRoomDatabase, mExecutor, activity.accountName, mPost.getId());
+            int readPostsLimit = ReadPostsUtils.GetReadPostsLimit(activity.accountName, mPostHistorySharedPreferences);
+            InsertReadPost.insertReadPost(mRedditDataRoomDatabase, mExecutor, activity.accountName, mPost.getId(), readPostsLimit);
             EventBus.getDefault().post(new PostUpdateEventToPostList(mPost, postListPosition));
         }
     }

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/post/HistoryPostPagingSource.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/post/HistoryPostPagingSource.java
@@ -20,7 +20,9 @@ import ml.docilealligator.infinityforreddit.RedditDataRoomDatabase;
 import ml.docilealligator.infinityforreddit.account.Account;
 import ml.docilealligator.infinityforreddit.apis.RedditAPI;
 import ml.docilealligator.infinityforreddit.postfilter.PostFilter;
+import ml.docilealligator.infinityforreddit.readpost.NullReadPostsList;
 import ml.docilealligator.infinityforreddit.readpost.ReadPost;
+import ml.docilealligator.infinityforreddit.readpost.ReadPostsListInterface;
 import ml.docilealligator.infinityforreddit.utils.APIUtils;
 import retrofit2.Call;
 import retrofit2.HttpException;
@@ -92,7 +94,7 @@ public class HistoryPostPagingSource extends ListenableFuturePagingSource<String
             Response<String> response = historyPosts.execute();
             if (response.isSuccessful()) {
                 String responseString = response.body();
-                LinkedHashSet<Post> newPosts = ParsePost.parsePostsSync(responseString, -1, postFilter, null);
+                LinkedHashSet<Post> newPosts = ParsePost.parsePostsSync(responseString, -1, postFilter, NullReadPostsList.getInstance());
                 if (newPosts == null) {
                     return new LoadResult.Error<>(new Exception("Error parsing posts"));
                 } else {

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/post/HistoryPostViewModel.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/post/HistoryPostViewModel.java
@@ -19,6 +19,7 @@ import java.util.concurrent.Executor;
 
 import ml.docilealligator.infinityforreddit.RedditDataRoomDatabase;
 import ml.docilealligator.infinityforreddit.postfilter.PostFilter;
+import ml.docilealligator.infinityforreddit.readpost.ReadPostsListInterface;
 import retrofit2.Retrofit;
 
 public class HistoryPostViewModel extends ViewModel {

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/post/PostPagingSource.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/post/PostPagingSource.java
@@ -16,6 +16,8 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.concurrent.Executor;
 
+import ml.docilealligator.infinityforreddit.RedditDataRoomDatabase;
+import ml.docilealligator.infinityforreddit.readpost.ReadPostsListInterface;
 import ml.docilealligator.infinityforreddit.thing.SortType;
 import ml.docilealligator.infinityforreddit.account.Account;
 import ml.docilealligator.infinityforreddit.apis.RedditAPI;
@@ -53,7 +55,7 @@ public class PostPagingSource extends ListenableFuturePagingSource<String, Post>
     private final int postType;
     private final SortType sortType;
     private final PostFilter postFilter;
-    private final List<String> readPostList;
+    private final ReadPostsListInterface readPostsList;
     private String userWhere;
     private String multiRedditPath;
     private final LinkedHashSet<Post> postLinkedHashSet;
@@ -62,7 +64,7 @@ public class PostPagingSource extends ListenableFuturePagingSource<String, Post>
     PostPagingSource(Executor executor, Retrofit retrofit, @Nullable String accessToken, @NonNull String accountName,
                      SharedPreferences sharedPreferences,
                      SharedPreferences postFeedScrolledPositionSharedPreferences, int postType,
-                     SortType sortType, PostFilter postFilter, List<String> readPostList) {
+                     SortType sortType, PostFilter postFilter, ReadPostsListInterface readPostsList) {
         this.executor = executor;
         this.retrofit = retrofit;
         this.accessToken = accessToken;
@@ -72,7 +74,7 @@ public class PostPagingSource extends ListenableFuturePagingSource<String, Post>
         this.postType = postType;
         this.sortType = sortType == null ? new SortType(SortType.Type.BEST) : sortType;
         this.postFilter = postFilter;
-        this.readPostList = readPostList;
+        this.readPostsList = readPostsList;
         postLinkedHashSet = new LinkedHashSet<>();
     }
 
@@ -80,7 +82,7 @@ public class PostPagingSource extends ListenableFuturePagingSource<String, Post>
     PostPagingSource(Executor executor, Retrofit retrofit, @Nullable String accessToken, @NonNull String accountName,
                      SharedPreferences sharedPreferences, SharedPreferences postFeedScrolledPositionSharedPreferences,
                      String name, int postType, SortType sortType, PostFilter postFilter,
-                     List<String> readPostList) {
+                     ReadPostsListInterface readPostsList) {
         this.executor = executor;
         this.retrofit = retrofit;
         this.accessToken = accessToken;
@@ -102,7 +104,7 @@ public class PostPagingSource extends ListenableFuturePagingSource<String, Post>
             this.sortType = sortType;
         }
         this.postFilter = postFilter;
-        this.readPostList = readPostList;
+        this.readPostsList = readPostsList;
         postLinkedHashSet = new LinkedHashSet<>();
     }
 
@@ -110,7 +112,7 @@ public class PostPagingSource extends ListenableFuturePagingSource<String, Post>
     PostPagingSource(Executor executor, Retrofit retrofit, @Nullable String accessToken, @NonNull String accountName,
                      SharedPreferences sharedPreferences, SharedPreferences postFeedScrolledPositionSharedPreferences,
                      String path, String query, int postType, SortType sortType, PostFilter postFilter,
-                     List<String> readPostList) {
+                     ReadPostsListInterface readPostsList) {
         this.executor = executor;
         this.retrofit = retrofit;
         this.accessToken = accessToken;
@@ -130,14 +132,14 @@ public class PostPagingSource extends ListenableFuturePagingSource<String, Post>
             this.sortType = sortType;
         }
         this.postFilter = postFilter;
-        this.readPostList = readPostList;
+        this.readPostsList = readPostsList;
         postLinkedHashSet = new LinkedHashSet<>();
     }
 
     PostPagingSource(Executor executor, Retrofit retrofit, @Nullable String accessToken, @NonNull String accountName,
                      SharedPreferences sharedPreferences, SharedPreferences postFeedScrolledPositionSharedPreferences,
                      String subredditOrUserName, int postType, SortType sortType, PostFilter postFilter,
-                     String where, List<String> readPostList) {
+                     String where, ReadPostsListInterface readPostsList) {
         this.executor = executor;
         this.retrofit = retrofit;
         this.accessToken = accessToken;
@@ -149,14 +151,14 @@ public class PostPagingSource extends ListenableFuturePagingSource<String, Post>
         this.sortType = sortType == null ? new SortType(SortType.Type.NEW) : sortType;
         this.postFilter = postFilter;
         userWhere = where;
-        this.readPostList = readPostList;
+        this.readPostsList = readPostsList;
         postLinkedHashSet = new LinkedHashSet<>();
     }
 
     PostPagingSource(Executor executor, Retrofit retrofit, @Nullable String accessToken, @NonNull String accountName,
                      SharedPreferences sharedPreferences, SharedPreferences postFeedScrolledPositionSharedPreferences,
                      String subredditOrUserName, String query, String trendingSource, int postType,
-                     SortType sortType, PostFilter postFilter, List<String> readPostList) {
+                     SortType sortType, PostFilter postFilter, ReadPostsListInterface readPostsList) {
         this.executor = executor;
         this.retrofit = retrofit;
         this.accessToken = accessToken;
@@ -170,7 +172,7 @@ public class PostPagingSource extends ListenableFuturePagingSource<String, Post>
         this.sortType = sortType == null ? new SortType(SortType.Type.RELEVANCE) : sortType;
         this.postFilter = postFilter;
         postLinkedHashSet = new LinkedHashSet<>();
-        this.readPostList = readPostList;
+        this.readPostsList = readPostsList;
     }
 
     @Nullable
@@ -202,7 +204,7 @@ public class PostPagingSource extends ListenableFuturePagingSource<String, Post>
     public LoadResult<String, Post> transformData(Response<String> response) {
         if (response.isSuccessful()) {
             String responseString = response.body();
-            LinkedHashSet<Post> newPosts = ParsePost.parsePostsSync(responseString, -1, postFilter, readPostList);
+            LinkedHashSet<Post> newPosts = ParsePost.parsePostsSync(responseString, -1, postFilter, readPostsList);
             String lastItem = ParsePost.getLastItem(responseString);
             if (newPosts == null) {
                 return new LoadResult.Error<>(new Exception("Error parsing posts"));

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/post/PostViewModel.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/post/PostViewModel.java
@@ -18,9 +18,10 @@ import androidx.paging.PagingData;
 import androidx.paging.PagingDataTransforms;
 import androidx.paging.PagingLiveData;
 
-import java.util.List;
 import java.util.concurrent.Executor;
 
+import ml.docilealligator.infinityforreddit.RedditDataRoomDatabase;
+import ml.docilealligator.infinityforreddit.readpost.ReadPostsListInterface;
 import ml.docilealligator.infinityforreddit.thing.SortType;
 import ml.docilealligator.infinityforreddit.account.Account;
 import ml.docilealligator.infinityforreddit.postfilter.PostFilter;
@@ -41,7 +42,7 @@ public class PostViewModel extends ViewModel {
     private SortType sortType;
     private PostFilter postFilter;
     private String userWhere;
-    private final List<String> readPostList;
+    private ReadPostsListInterface readPostsList;
     private final MutableLiveData<Boolean> currentlyReadPostIdsLiveData = new MutableLiveData<>();
 
     private final LiveData<PagingData<Post>> posts;
@@ -55,7 +56,7 @@ public class PostViewModel extends ViewModel {
     public PostViewModel(Executor executor, Retrofit retrofit, @Nullable String accessToken, @NonNull String accountName,
                          SharedPreferences sharedPreferences, SharedPreferences postFeedScrolledPositionSharedPreferences,
                          @Nullable SharedPreferences postHistorySharedPreferences, int postType,
-                         SortType sortType, PostFilter postFilter, List<String> readPostList) {
+                         SortType sortType, PostFilter postFilter, ReadPostsListInterface readPostsList) {
         this.executor = executor;
         this.retrofit = retrofit;
         this.accessToken = accessToken;
@@ -65,7 +66,7 @@ public class PostViewModel extends ViewModel {
         this.postType = postType;
         this.sortType = sortType;
         this.postFilter = postFilter;
-        this.readPostList = readPostList;
+        this.readPostsList = readPostsList;
 
         sortTypeLiveData = new MutableLiveData<>(sortType);
         postFilterLiveData = new MutableLiveData<>(postFilter);
@@ -95,7 +96,7 @@ public class PostViewModel extends ViewModel {
     public PostViewModel(Executor executor, Retrofit retrofit, @Nullable String accessToken, @NonNull String accountName,
                          SharedPreferences sharedPreferences, SharedPreferences postFeedScrolledPositionSharedPreferences,
                          @Nullable SharedPreferences postHistorySharedPreferences, String subredditName, int postType,
-                         SortType sortType, PostFilter postFilter, List<String> readPostList) {
+                         SortType sortType, PostFilter postFilter, ReadPostsListInterface readPostsList) {
         this.executor = executor;
         this.retrofit = retrofit;
         this.accessToken = accessToken;
@@ -105,7 +106,7 @@ public class PostViewModel extends ViewModel {
         this.postType = postType;
         this.sortType = sortType;
         this.postFilter = postFilter;
-        this.readPostList = readPostList;
+        this.readPostsList = readPostsList;
         this.name = subredditName;
 
         sortTypeLiveData = new MutableLiveData<>(sortType);
@@ -136,7 +137,7 @@ public class PostViewModel extends ViewModel {
     public PostViewModel(Executor executor, Retrofit retrofit, @Nullable String accessToken, @NonNull String accountName,
                          SharedPreferences sharedPreferences, SharedPreferences postFeedScrolledPositionSharedPreferences,
                          @Nullable SharedPreferences postHistorySharedPreferences, String multiredditPath, String query, int postType,
-                         SortType sortType, PostFilter postFilter, List<String> readPostList) {
+                         SortType sortType, PostFilter postFilter, ReadPostsListInterface readPostsList) {
         this.executor = executor;
         this.retrofit = retrofit;
         this.accessToken = accessToken;
@@ -146,7 +147,7 @@ public class PostViewModel extends ViewModel {
         this.postType = postType;
         this.sortType = sortType;
         this.postFilter = postFilter;
-        this.readPostList = readPostList;
+        this.readPostsList = readPostsList;
         this.name = multiredditPath;
         this.query = query;
 
@@ -179,7 +180,7 @@ public class PostViewModel extends ViewModel {
                          SharedPreferences postFeedScrolledPositionSharedPreferences,
                          @Nullable SharedPreferences postHistorySharedPreferences, String username,
                          int postType, SortType sortType, PostFilter postFilter, String userWhere,
-                         List<String> readPostList) {
+                         ReadPostsListInterface readPostsList) {
         this.executor = executor;
         this.retrofit = retrofit;
         this.accessToken = accessToken;
@@ -189,7 +190,7 @@ public class PostViewModel extends ViewModel {
         this.postType = postType;
         this.sortType = sortType;
         this.postFilter = postFilter;
-        this.readPostList = readPostList;
+        this.readPostsList = readPostsList;
         this.name = username;
         this.userWhere = userWhere;
 
@@ -222,7 +223,7 @@ public class PostViewModel extends ViewModel {
                          SharedPreferences sharedPreferences, SharedPreferences postFeedScrolledPositionSharedPreferences,
                          @Nullable SharedPreferences postHistorySharedPreferences, String subredditName, String query,
                          String trendingSource, int postType, SortType sortType, PostFilter postFilter,
-                         List<String> readPostList) {
+                         ReadPostsListInterface readPostsList) {
         this.executor = executor;
         this.retrofit = retrofit;
         this.accessToken = accessToken;
@@ -232,7 +233,7 @@ public class PostViewModel extends ViewModel {
         this.postType = postType;
         this.sortType = sortType;
         this.postFilter = postFilter;
-        this.readPostList = readPostList;
+        this.readPostsList = readPostsList;
         this.name = subredditName;
         this.query = query;
         this.trendingSource = trendingSource;
@@ -275,30 +276,30 @@ public class PostViewModel extends ViewModel {
             case PostPagingSource.TYPE_FRONT_PAGE:
                 paging3PagingSource = new PostPagingSource(executor, retrofit, accessToken, accountName,
                         sharedPreferences, postFeedScrolledPositionSharedPreferences, postType, sortType,
-                        postFilter, readPostList);
+                        postFilter, readPostsList);
                 break;
             case PostPagingSource.TYPE_SUBREDDIT:
             case PostPagingSource.TYPE_ANONYMOUS_FRONT_PAGE:
             case PostPagingSource.TYPE_ANONYMOUS_MULTIREDDIT:
                 paging3PagingSource = new PostPagingSource(executor, retrofit, accessToken, accountName,
                         sharedPreferences, postFeedScrolledPositionSharedPreferences, name, postType,
-                        sortType, postFilter, readPostList);
+                        sortType, postFilter, readPostsList);
                 break;
             case PostPagingSource.TYPE_MULTI_REDDIT:
                 paging3PagingSource = new PostPagingSource(executor, retrofit, accessToken, accountName,
                         sharedPreferences, postFeedScrolledPositionSharedPreferences, name, query, postType,
-                        sortType, postFilter, readPostList);
+                        sortType, postFilter, readPostsList);
                 break;
             case PostPagingSource.TYPE_SEARCH:
                 paging3PagingSource = new PostPagingSource(executor, retrofit, accessToken, accountName,
                         sharedPreferences, postFeedScrolledPositionSharedPreferences, name, query, trendingSource,
-                        postType, sortType, postFilter, readPostList);
+                        postType, sortType, postFilter, readPostsList);
                 break;
             default:
                 //User
                 paging3PagingSource = new PostPagingSource(executor, retrofit, accessToken, accountName,
                         sharedPreferences, postFeedScrolledPositionSharedPreferences, name, postType,
-                        sortType, postFilter, userWhere, readPostList);
+                        sortType, postFilter, userWhere, readPostsList);
                 break;
         }
         return paging3PagingSource;
@@ -332,13 +333,13 @@ public class PostViewModel extends ViewModel {
         private final SortType sortType;
         private final PostFilter postFilter;
         private String userWhere;
-        private List<String> readPostList;
+        private final ReadPostsListInterface readPostsList;
 
         // Front page
         public Factory(Executor executor, Retrofit retrofit, @Nullable String accessToken, @NonNull String accountName,
                        SharedPreferences sharedPreferences, SharedPreferences postFeedScrolledPositionSharedPreferences,
                        SharedPreferences postHistorySharedPreferences, int postType, SortType sortType,
-                       PostFilter postFilter, List<String> readPostList) {
+                       PostFilter postFilter, ReadPostsListInterface readPostsList) {
             this.executor = executor;
             this.retrofit = retrofit;
             this.accessToken = accessToken;
@@ -349,14 +350,14 @@ public class PostViewModel extends ViewModel {
             this.postType = postType;
             this.sortType = sortType;
             this.postFilter = postFilter;
-            this.readPostList = readPostList;
+            this.readPostsList = readPostsList;
         }
 
         // PostPagingSource.TYPE_SUBREDDIT
         public Factory(Executor executor, Retrofit retrofit, @Nullable String accessToken, @NonNull String accountName,
                        SharedPreferences sharedPreferences, SharedPreferences postFeedScrolledPositionSharedPreferences,
                        SharedPreferences postHistorySharedPreferences, String name, int postType, SortType sortType,
-                       PostFilter postFilter, List<String> readPostList) {
+                       PostFilter postFilter, ReadPostsListInterface readPostsList) {
             this.executor = executor;
             this.retrofit = retrofit;
             this.accessToken = accessToken;
@@ -368,14 +369,14 @@ public class PostViewModel extends ViewModel {
             this.postType = postType;
             this.sortType = sortType;
             this.postFilter = postFilter;
-            this.readPostList = readPostList;
+            this.readPostsList = readPostsList;
         }
 
         // PostPagingSource.TYPE_MULTI_REDDIT
         public Factory(Executor executor, Retrofit retrofit, @Nullable String accessToken, @NonNull String accountName,
                        SharedPreferences sharedPreferences, SharedPreferences postFeedScrolledPositionSharedPreferences,
                        SharedPreferences postHistorySharedPreferences, String name, String query, int postType, SortType sortType,
-                       PostFilter postFilter, List<String> readPostList) {
+                       PostFilter postFilter, ReadPostsListInterface readPostsList) {
             this.executor = executor;
             this.retrofit = retrofit;
             this.accessToken = accessToken;
@@ -388,14 +389,14 @@ public class PostViewModel extends ViewModel {
             this.postType = postType;
             this.sortType = sortType;
             this.postFilter = postFilter;
-            this.readPostList = readPostList;
+            this.readPostsList = readPostsList;
         }
 
         //User posts
         public Factory(Executor executor, Retrofit retrofit, @Nullable String accessToken, @NonNull String accountName,
                        SharedPreferences sharedPreferences, SharedPreferences postFeedScrolledPositionSharedPreferences,
                        SharedPreferences postHistorySharedPreferences, String username, int postType,
-                       SortType sortType, PostFilter postFilter, String where, List<String> readPostList) {
+                       SortType sortType, PostFilter postFilter, String where, ReadPostsListInterface readPostsList) {
             this.executor = executor;
             this.retrofit = retrofit;
             this.accessToken = accessToken;
@@ -408,14 +409,14 @@ public class PostViewModel extends ViewModel {
             this.sortType = sortType;
             this.postFilter = postFilter;
             userWhere = where;
-            this.readPostList = readPostList;
+            this.readPostsList = readPostsList;
         }
 
         // PostPagingSource.TYPE_SEARCH
         public Factory(Executor executor, Retrofit retrofit, @Nullable String accessToken, @NonNull String accountName,
                        SharedPreferences sharedPreferences, SharedPreferences postFeedScrolledPositionSharedPreferences,
                        SharedPreferences postHistorySharedPreferences, String name, String query, String trendingSource,
-                       int postType, SortType sortType, PostFilter postFilter, List<String> readPostList) {
+                       int postType, SortType sortType, PostFilter postFilter, ReadPostsListInterface readPostsList) {
             this.executor = executor;
             this.retrofit = retrofit;
             this.accessToken = accessToken;
@@ -429,12 +430,12 @@ public class PostViewModel extends ViewModel {
             this.postType = postType;
             this.sortType = sortType;
             this.postFilter = postFilter;
-            this.readPostList = readPostList;
+            this.readPostsList = readPostsList;
         }
 
         //Anonymous Front Page
         public Factory(Executor executor, Retrofit retrofit, SharedPreferences sharedPreferences,
-                       String concatenatedSubredditNames, int postType, SortType sortType, PostFilter postFilter) {
+                       String concatenatedSubredditNames, int postType, SortType sortType, PostFilter postFilter, ReadPostsListInterface readPostsList) {
             this.executor = executor;
             this.retrofit = retrofit;
             this.sharedPreferences = sharedPreferences;
@@ -442,6 +443,7 @@ public class PostViewModel extends ViewModel {
             this.postType = postType;
             this.sortType = sortType;
             this.postFilter = postFilter;
+            this.readPostsList = readPostsList;
         }
 
         @NonNull
@@ -450,19 +452,19 @@ public class PostViewModel extends ViewModel {
             if (postType == PostPagingSource.TYPE_FRONT_PAGE) {
                 return (T) new PostViewModel(executor, retrofit, accessToken, accountName, sharedPreferences,
                         postFeedScrolledPositionSharedPreferences, postHistorySharedPreferences, postType,
-                        sortType, postFilter, readPostList);
+                        sortType, postFilter, readPostsList);
             } else if (postType == PostPagingSource.TYPE_SEARCH) {
                 return (T) new PostViewModel(executor, retrofit, accessToken, accountName, sharedPreferences,
                         postFeedScrolledPositionSharedPreferences, postHistorySharedPreferences, name, query,
-                        trendingSource, postType, sortType, postFilter, readPostList);
+                        trendingSource, postType, sortType, postFilter, readPostsList);
             } else if (postType == PostPagingSource.TYPE_SUBREDDIT) {
                 return (T) new PostViewModel(executor, retrofit, accessToken, accountName, sharedPreferences,
                         postFeedScrolledPositionSharedPreferences, postHistorySharedPreferences, name,
-                        postType, sortType, postFilter, readPostList);
+                        postType, sortType, postFilter, readPostsList);
             } else if (postType == PostPagingSource.TYPE_MULTI_REDDIT) {
                 return (T) new PostViewModel(executor, retrofit, accessToken, accountName, sharedPreferences,
                         postFeedScrolledPositionSharedPreferences, postHistorySharedPreferences, name, query,
-                        postType, sortType, postFilter, readPostList);
+                        postType, sortType, postFilter, readPostsList);
             } else if (postType == PostPagingSource.TYPE_ANONYMOUS_FRONT_PAGE || postType == PostPagingSource.TYPE_ANONYMOUS_MULTIREDDIT) {
                 return (T) new PostViewModel(executor, retrofit, null, null, sharedPreferences,
                         null, null, name, postType, sortType,
@@ -470,7 +472,7 @@ public class PostViewModel extends ViewModel {
             } else {
                 return (T) new PostViewModel(executor, retrofit, accessToken, accountName, sharedPreferences,
                         postFeedScrolledPositionSharedPreferences, postHistorySharedPreferences, name,
-                        postType, sortType, postFilter, userWhere, readPostList);
+                        postType, sortType, postFilter, userWhere, readPostsList);
             }
         }
     }

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/readpost/InsertReadPost.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/readpost/InsertReadPost.java
@@ -6,10 +6,12 @@ import ml.docilealligator.infinityforreddit.RedditDataRoomDatabase;
 
 public class InsertReadPost {
     public static void insertReadPost(RedditDataRoomDatabase redditDataRoomDatabase, Executor executor,
-                                      String username, String postId) {
+                                      String username, String postId, int readPostsLimit) {
         executor.execute(() -> {
             ReadPostDao readPostDao = redditDataRoomDatabase.readPostDao();
-            if (readPostDao.getReadPostsCount() > 500) {
+            int limit = Math.max(readPostsLimit, 100);
+            boolean isReadPostLimit = readPostsLimit != -1;
+            while (readPostDao.getReadPostsCount(username) > limit && isReadPostLimit) {
                 readPostDao.deleteOldestReadPosts(username);
             }
             if (username != null && !username.equals("")) {

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/readpost/NullReadPostsList.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/readpost/NullReadPostsList.java
@@ -1,0 +1,21 @@
+package ml.docilealligator.infinityforreddit.readpost;
+
+import ml.docilealligator.infinityforreddit.RedditDataRoomDatabase;
+
+import java.util.Collections;
+import java.util.List;
+
+public class NullReadPostsList implements ReadPostsListInterface {
+    public static NullReadPostsList getInstance() {
+        return InstanceHolder.instance;
+    }
+
+    @Override
+    public List<ReadPost> getReadPostsByIds(List<String> ids) {
+        return Collections.emptyList();
+    }
+
+    private static class InstanceHolder {
+        private static final NullReadPostsList instance = new NullReadPostsList();
+    }
+}

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/readpost/ReadPostDao.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/readpost/ReadPostDao.java
@@ -7,6 +7,7 @@ import androidx.room.Query;
 
 import com.google.common.util.concurrent.ListenableFuture;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Dao
@@ -26,12 +27,15 @@ public interface ReadPostDao {
     @Query("SELECT * FROM read_posts WHERE id = :id LIMIT 1")
     ReadPost getReadPost(String id);
 
-    @Query("SELECT COUNT(id) FROM read_posts")
-    int getReadPostsCount();
+    @Query("SELECT COUNT(id) FROM read_posts WHERE username = :username")
+    int getReadPostsCount(String username);
 
     @Query("DELETE FROM read_posts WHERE rowid IN (SELECT rowid FROM read_posts ORDER BY time ASC LIMIT 100) AND username = :username")
     void deleteOldestReadPosts(String username);
 
     @Query("DELETE FROM read_posts")
     void deleteAllReadPosts();
+
+    @Query("SELECT * FROM read_posts WHERE id IN (:ids) AND username = :username")
+    List<ReadPost> getReadPostsByIds(List<String> ids, String username);
 }

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/readpost/ReadPostDao.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/readpost/ReadPostDao.java
@@ -38,4 +38,10 @@ public interface ReadPostDao {
 
     @Query("SELECT * FROM read_posts WHERE id IN (:ids) AND username = :username")
     List<ReadPost> getReadPostsByIds(List<String> ids, String username);
+
+    default int getMaxReadPostEntrySize() { // in bytes
+        return  20 + // max username size
+                10 + // id size
+                8;   // time size
+    }
 }

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/readpost/ReadPostsList.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/readpost/ReadPostsList.java
@@ -1,0 +1,18 @@
+package ml.docilealligator.infinityforreddit.readpost;
+
+import java.util.List;
+
+public class ReadPostsList implements ReadPostsListInterface {
+    private final ReadPostDao readPostDao;
+    private final String accountName;
+
+    public ReadPostsList(ReadPostDao readPostDao, String accountName) {
+        this.accountName = accountName;
+        this.readPostDao = readPostDao;
+    }
+
+    @Override
+    public List<ReadPost> getReadPostsByIds(List<String> ids) {
+        return this.readPostDao.getReadPostsByIds(ids, accountName);
+    }
+}

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/readpost/ReadPostsListInterface.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/readpost/ReadPostsListInterface.java
@@ -1,0 +1,8 @@
+package ml.docilealligator.infinityforreddit.readpost;
+
+
+import java.util.List;
+
+public interface ReadPostsListInterface {
+    List<ReadPost> getReadPostsByIds(List<String> ids);
+}

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/readpost/ReadPostsUtils.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/readpost/ReadPostsUtils.java
@@ -1,0 +1,15 @@
+package ml.docilealligator.infinityforreddit.readpost;
+
+import android.content.SharedPreferences;
+import ml.docilealligator.infinityforreddit.utils.SharedPreferencesUtils;
+
+public class ReadPostsUtils {
+    public static int GetReadPostsLimit(String accountName, SharedPreferences mPostHistorySharedPreferences) {
+        if (mPostHistorySharedPreferences.getBoolean(accountName + SharedPreferencesUtils.READ_POSTS_LIMIT_ENABLED, true)) {
+            return mPostHistorySharedPreferences.getInt(accountName + SharedPreferencesUtils.READ_POSTS_LIMIT, 500);
+        }
+        else {
+            return -1;
+        }
+    }
+}

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/settings/PostHistoryFragment.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/settings/PostHistoryFragment.java
@@ -79,7 +79,8 @@ public class PostHistoryFragment extends Fragment {
         mExecutor.execute(() -> {
             ReadPostDao readPostDao = mRedditDataRoomDatabase.readPostDao();
             int tableCount = readPostDao.getReadPostsCount(activity.accountName);
-            int tableSize = 38 * tableCount / 1024 / 1024; // 38 bytes is the maximum size of a row in read_posts table
+            long tableEntrySize = readPostDao.getMaxReadPostEntrySize();
+            long tableSize = tableEntrySize * tableCount / 1024;
             binding.readPostsInDbTextViewPostHistoryFragment.setText(getString(R.string.settings_read_posts_db_summary, tableSize, tableCount));
         });
 

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/utils/SharedPreferencesUtils.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/utils/SharedPreferencesUtils.java
@@ -386,6 +386,8 @@ public class SharedPreferencesUtils {
 
     public static final String POST_HISTORY_SHARED_PREFERENCES_FILE = "ml.docilealligator.infinityforreddit.post_history";
     public static final String MARK_POSTS_AS_READ_BASE = "_mark_posts_as_read";
+    public static final String READ_POSTS_LIMIT_ENABLED = "_read_posts_limit_enabled";
+    public static final String READ_POSTS_LIMIT = "_read_posts_limit";
     public static final String MARK_POSTS_AS_READ_AFTER_VOTING_BASE = "_mark_posts_as_read_after_voting";
     public static final String MARK_POSTS_AS_READ_ON_SCROLL_BASE = "_mark_posts_as_read_on_scroll";
     public static final String HIDE_READ_POSTS_AUTOMATICALLY_BASE = "_hide_read_posts_automatically";

--- a/app/src/main/res/layout/fragment_post_history.xml
+++ b/app/src/main/res/layout/fragment_post_history.xml
@@ -60,6 +60,77 @@
         </LinearLayout>
 
         <LinearLayout
+                android:id="@+id/read_posts_limit_linear_layout_post_history_fragment"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:paddingTop="4dp"
+                android:paddingBottom="4dp"
+                android:paddingStart="72dp"
+                android:paddingEnd="16dp"
+                android:clickable="true"
+                android:focusable="true"
+                android:background="?attr/selectableItemBackground">
+            <TextView
+                    android:id="@+id/read_posts_limit_text_view_post_history_fragment"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:layout_marginEnd="16dp"
+                    android:layout_gravity="center_vertical"
+                    android:drawablePadding="32dp"
+                    android:text="@string/settings_read_posts_limit_title"
+                    android:textColor="?attr/primaryTextColor"
+                    android:textSize="?attr/font_16"
+                    android:fontFamily="?attr/font_family"/>
+            <com.google.android.material.materialswitch.MaterialSwitch
+                    android:id="@+id/read_posts_limit_switch_post_history_fragment"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_vertical" />
+        </LinearLayout>
+        <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/read_posts_limit_input_layout_post_history_fragment"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingTop="4dp"
+                android:paddingBottom="4dp"
+                android:paddingStart="72dp"
+                android:paddingEnd="16dp">
+            <EditText
+                    android:id="@+id/read_posts_limit_edit_text_post_history_fragment"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:inputType="number"
+                    android:hint="@string/settings_read_posts_limit_hint"
+                    android:text="500"
+                    android:enabled="true"/>
+        </com.google.android.material.textfield.TextInputLayout>
+        <LinearLayout
+                android:id="@+id/read_posts_in_db_linear_layout_post_history_fragment"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingTop="4dp"
+                android:paddingBottom="4dp"
+                android:paddingStart="72dp"
+                android:paddingEnd="16dp"
+                android:clickable="true"
+                android:focusable="true"
+                android:background="?attr/selectableItemBackground" android:minHeight="48dp">
+            <TextView
+                    android:id="@+id/read_posts_in_db_text_view_post_history_fragment"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:layout_marginEnd="16dp"
+                    android:layout_gravity="center_vertical"
+                    android:text=""
+                    android:textColor="?attr/primaryTextColor"
+                    android:textSize="?attr/font_16"
+                    android:fontFamily="?attr/font_family"/>
+        </LinearLayout>
+
+        <LinearLayout
             android:id="@+id/mark_posts_as_read_after_voting_linear_layout_post_history_fragment"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -570,6 +570,9 @@
     <string name="settings_enable_search_history_title">Enable Search History</string>
     <string name="settings_post_history_title">Post History</string>
     <string name="settings_mark_posts_as_read_title">Mark Posts as Read</string>
+    <string name="settings_read_posts_limit_title">Limit Read Posts</string>
+    <string name="settings_read_posts_limit_hint">Set read posts limit</string>
+    <string name="settings_read_posts_db_summary">Read Posts Data Base \nSize: %1$d(MB) \nCount: %2$d</string>
     <string name="settings_mark_posts_as_read_after_voting_title">Mark Posts as Read After Voting</string>
     <string name="settings_mark_posts_as_read_on_scroll_title">Mark Posts as Read on Scroll</string>
     <string name="settings_hide_read_posts_automatically_title">Hide Read Posts Automatically</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -572,7 +572,7 @@
     <string name="settings_mark_posts_as_read_title">Mark Posts as Read</string>
     <string name="settings_read_posts_limit_title">Limit Read Posts</string>
     <string name="settings_read_posts_limit_hint">Set read posts limit</string>
-    <string name="settings_read_posts_db_summary">Read Posts Data Base \nSize: %1$d(MB) \nCount: %2$d</string>
+    <string name="settings_read_posts_db_summary">Read Posts DB Table \nSize: %1$d(KB) \nCount: %2$d</string>
     <string name="settings_mark_posts_as_read_after_voting_title">Mark Posts as Read After Voting</string>
     <string name="settings_mark_posts_as_read_on_scroll_title">Mark Posts as Read on Scroll</string>
     <string name="settings_hide_read_posts_automatically_title">Hide Read Posts Automatically</string>

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,3 @@
-// Top-level build file where you can add configuration options common to all sub-projects/modules.
-
 buildscript {
     repositories {
         google()


### PR DESCRIPTION
## Context
Currently, read posts are loaded from the room database to memory in a `List<ReadPost>` during usage. The list is used to mark posts being loaded as read during post parsing. Due to performance reasons (saving the state of the list), the read posts database is limited to 500 entries.

## Changes
### Change how we handle read posts when new posts are loaded.
We can instead mark loaded posts as read directly from the db.
- Instead of using a `List<ReadPost>` to handle read posts, we use `ReadPostsListInterface`, which contains the necessary methods for marking loaded posts as read.
- The implementation of `ReadPostsListInterface` (called `ReadPostsList`) just uses `ReadPostDao`.
- We change `parsePostSync()` to work with the new `ReadPostsListInterface` instead.

Since read posts are not loaded to memory anymore, we can now set an arbitrary read posts limit.

### Add a setting to customize the read post limit
- A switch that lets you choose whether you even want a read post limit
- An input for setting a custom read post limit (default is 500, minimum is 100)
- A summary of the read post db, so you can monitor its size.

![image](https://github.com/user-attachments/assets/ea760fc5-bf80-46c9-ad1e-e8cbee8ac240)