### PR TITLE
Update deprecated upload-artifacts version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
         arguments: build -x lint
 
     - name: Upload apk
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: Infinity-${{github.sha}}
         path: app/build/outputs/apk/


### PR DESCRIPTION
> Fixes #1757 

Ah, the package was renamed. In any case, keeping this open as the build.yml still fails on this afaik.