### PR TITLE
Fix for broken comments

### DIFF
--- a/app/src/main/java/ml/docilealligator/infinityforreddit/comment/ParseComment.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/comment/ParseComment.java
@@ -257,7 +257,13 @@ public class ParseComment {
         String id = singleCommentData.getString(JSONUtils.ID_KEY);
         String fullName = singleCommentData.getString(JSONUtils.NAME_KEY);
         String author = singleCommentData.getString(JSONUtils.AUTHOR_KEY);
-        String authorFullname = singleCommentData.getString(JSONUtils.AUTHOR_FULLNAME_KEY);
+
+        String authorFullname = "";
+
+        if (singleCommentData.has(JSONUtils.AUTHOR_FULLNAME_KEY)) {
+            authorFullname = singleCommentData.getString(JSONUtils.AUTHOR_FULLNAME_KEY);
+        }
+
         StringBuilder authorFlairHTMLBuilder = new StringBuilder();
         if (singleCommentData.has(JSONUtils.AUTHOR_FLAIR_RICHTEXT_KEY)) {
             JSONArray flairArray = singleCommentData.getJSONArray(JSONUtils.AUTHOR_FLAIR_RICHTEXT_KEY);


### PR DESCRIPTION
This fixes the loading of comments in some posts.

Example link:
https://old.reddit.com/r/entertainment/comments/1jstykj/snl_mocks_morgan_wallens_walkoff_from_the_show_in/

Error:
```
04-06 18:33:00.233 31317 31380 W System.err: org.json.JSONException: No value for author_fullname
04-06 18:33:00.233 31317 31380 W System.err:     at org.json.JSONObject.get(JSONObject.java:398)
04-06 18:33:00.233 31317 31380 W System.err:     at org.json.JSONObject.getString(JSONObject.java:559)
04-06 18:33:00.233 31317 31380 W System.err:     at ml.docilealligator.infinityforreddit.comment.ParseComment.parseSingleComment(ParseComment.java:263)
04-06 18:33:00.233 31317 31380 W System.err:     at ml.docilealligator.infinityforreddit.comment.ParseComment.parseCommentRecursion(ParseComment.java:193)
04-06 18:33:00.233 31317 31380 W System.err:     at ml.docilealligator.infinityforreddit.comment.ParseComment.lambda$parseComment$1(ParseComment.java:42)
04-06 18:33:00.233 31317 31380 W System.err:     at ml.docilealligator.infinityforreddit.comment.ParseComment$$ExternalSyntheticLambda4.run(D8$$SyntheticClass:0)
04-06 18:33:00.233 31317 31380 W System.err:     at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
04-06 18:33:00.233 31317 31380 W System.err:     at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:644)
04-06 18:33:00.233 31317 31380 W System.err:     at java.lang.Thread.run(Thread.java:1012)
```