### PR TITLE
Add x.com to nitter.net link rewriting feature

### DIFF
--- a/app/src/main/java/ml/docilealligator/infinityforreddit/activities/LinkResolverActivity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/activities/LinkResolverActivity.java
@@ -28,6 +28,7 @@ import javax.inject.Named;
 import ml.docilealligator.infinityforreddit.Infinity;
 import ml.docilealligator.infinityforreddit.R;
 import ml.docilealligator.infinityforreddit.customtheme.CustomThemeWrapper;
+import ml.docilealligator.infinityforreddit.utils.ExternalBrowserDomainUtils;
 import ml.docilealligator.infinityforreddit.utils.SharedPreferencesUtils;
 import okhttp3.Call;
 import okhttp3.Callback;
@@ -416,6 +417,12 @@ public class LinkResolverActivity extends AppCompatActivity {
         String authority = uri.getAuthority();
         if(authority != null && (authority.contains("reddit.com") || authority.contains("redd.it") || authority.contains("reddit.app.link"))) {
             openInCustomTabs(uri, pm, false);
+            return;
+        }
+
+        // Check if domain should always open in external browser
+        if (authority != null && ExternalBrowserDomainUtils.isExternalBrowserDomain(mSharedPreferences, authority)) {
+            openInBrowser(uri, pm, true);
             return;
         }
 

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/activities/WebViewActivity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/activities/WebViewActivity.java
@@ -34,6 +34,7 @@ import ml.docilealligator.infinityforreddit.Infinity;
 import ml.docilealligator.infinityforreddit.R;
 import ml.docilealligator.infinityforreddit.customtheme.CustomThemeWrapper;
 import ml.docilealligator.infinityforreddit.databinding.ActivityWebViewBinding;
+import ml.docilealligator.infinityforreddit.utils.ExternalBrowserDomainUtils;
 import ml.docilealligator.infinityforreddit.utils.SharedPreferencesUtils;
 import ml.docilealligator.infinityforreddit.utils.Utils;
 
@@ -205,6 +206,18 @@ public class WebViewActivity extends BaseActivity {
             } catch (ActivityNotFoundException e) {
                 Toast.makeText(this, R.string.no_activity_found_for_external_browser, Toast.LENGTH_SHORT).show();
             }
+        } else if (item.getItemId() == R.id.action_always_open_domain_external_web_view_activity) {
+            Uri uri = Uri.parse(url);
+            String domain = uri.getAuthority();
+            if (domain != null && !domain.isEmpty()) {
+                ExternalBrowserDomainUtils.addDomain(mSharedPreferences, domain);
+                String normalizedDomain = ExternalBrowserDomainUtils.extractDomain(domain);
+                Toast.makeText(this, getString(R.string.domain_added_to_external_browser, normalizedDomain),
+                        Toast.LENGTH_SHORT).show();
+            } else {
+                Toast.makeText(this, R.string.invalid_domain, Toast.LENGTH_SHORT).show();
+            }
+            return true;
         }
         return false;
     }

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/settings/MiscellaneousPreferenceFragment.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/settings/MiscellaneousPreferenceFragment.java
@@ -1,14 +1,20 @@
 package ml.docilealligator.infinityforreddit.settings;
 
+import android.app.AlertDialog;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.widget.Toast;
 
 import androidx.preference.EditTextPreference;
 import androidx.preference.ListPreference;
+import androidx.preference.Preference;
 import androidx.preference.SwitchPreference;
 
 import org.greenrobot.eventbus.EventBus;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -19,6 +25,7 @@ import ml.docilealligator.infinityforreddit.customviews.preference.CustomFontPre
 import ml.docilealligator.infinityforreddit.events.ChangePostFeedMaxResolutionEvent;
 import ml.docilealligator.infinityforreddit.events.ChangeSavePostFeedScrolledPositionEvent;
 import ml.docilealligator.infinityforreddit.events.RecreateActivityEvent;
+import ml.docilealligator.infinityforreddit.utils.ExternalBrowserDomainUtils;
 import ml.docilealligator.infinityforreddit.utils.SharedPreferencesUtils;
 
 public class MiscellaneousPreferenceFragment extends CustomFontPreferenceFragmentCompat {
@@ -41,6 +48,7 @@ public class MiscellaneousPreferenceFragment extends CustomFontPreferenceFragmen
         SwitchPreference savePostFeedScrolledPositionSwitch = findPreference(SharedPreferencesUtils.SAVE_FRONT_PAGE_SCROLLED_POSITION);
         ListPreference languageListPreference = findPreference(SharedPreferencesUtils.LANGUAGE);
         EditTextPreference postFeedMaxResolution = findPreference(SharedPreferencesUtils.POST_FEED_MAX_RESOLUTION);
+        Preference manageExternalBrowserDomainsPreference = findPreference("manage_external_browser_domains");
 
         if (mainPageBackButtonActionListPreference != null) {
             mainPageBackButtonActionListPreference.setOnPreferenceChangeListener((preference, newValue) -> {
@@ -82,5 +90,41 @@ public class MiscellaneousPreferenceFragment extends CustomFontPreferenceFragmen
                 return true;
             });
         }
+
+        if (manageExternalBrowserDomainsPreference != null) {
+            manageExternalBrowserDomainsPreference.setOnPreferenceClickListener(preference -> {
+                showManageExternalBrowserDomainsDialog();
+                return true;
+            });
+        }
+    }
+
+    private void showManageExternalBrowserDomainsDialog() {
+        SharedPreferences sharedPreferences = getPreferenceManager().getSharedPreferences();
+        Set<String> domains = ExternalBrowserDomainUtils.getExternalBrowserDomains(sharedPreferences);
+        List<String> domainList = new ArrayList<>(domains);
+
+        if (domainList.isEmpty()) {
+            Toast.makeText(activity, R.string.no_external_browser_domains, Toast.LENGTH_SHORT).show();
+            return;
+        }
+
+        boolean[] checkedItems = new boolean[domainList.size()];
+        new AlertDialog.Builder(activity)
+                .setTitle(R.string.external_browser_domains_dialog_title)
+                .setMultiChoiceItems(domainList.toArray(new String[0]), checkedItems,
+                        (dialog, which, isChecked) -> {
+                            checkedItems[which] = isChecked;
+                        })
+                .setNegativeButton(android.R.string.cancel, null)
+                .setPositiveButton(R.string.remove_selected, (dialog, which) -> {
+                    for (int i = 0; i < checkedItems.length; i++) {
+                        if (checkedItems[i]) {
+                            ExternalBrowserDomainUtils.removeDomain(sharedPreferences, domainList.get(i));
+                        }
+                    }
+                    Toast.makeText(activity, R.string.domains_removed, Toast.LENGTH_SHORT).show();
+                })
+                .show();
     }
 }

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/utils/ExternalBrowserDomainUtils.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/utils/ExternalBrowserDomainUtils.java
@@ -1,0 +1,113 @@
+package ml.docilealligator.infinityforreddit.utils;
+
+import android.content.SharedPreferences;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Utility class to manage domains that should always open in external browser
+ */
+public class ExternalBrowserDomainUtils {
+
+    /**
+     * Get all domains that should open in external browser
+     */
+    public static Set<String> getExternalBrowserDomains(SharedPreferences sharedPreferences) {
+        Set<String> domains = new HashSet<>();
+        String domainsJson = sharedPreferences.getString(SharedPreferencesUtils.EXTERNAL_BROWSER_DOMAINS, "[]");
+
+        try {
+            JSONArray jsonArray = new JSONArray(domainsJson);
+            for (int i = 0; i < jsonArray.length(); i++) {
+                domains.add(jsonArray.getString(i));
+            }
+        } catch (JSONException e) {
+            e.printStackTrace();
+        }
+
+        return domains;
+    }
+
+    /**
+     * Check if a domain should open in external browser
+     */
+    public static boolean isExternalBrowserDomain(SharedPreferences sharedPreferences, String domain) {
+        if (domain == null || domain.isEmpty()) {
+            return false;
+        }
+
+        // Normalize domain (remove www prefix)
+        String normalizedDomain = normalizeDomain(domain);
+        Set<String> domains = getExternalBrowserDomains(sharedPreferences);
+
+        return domains.contains(normalizedDomain);
+    }
+
+    /**
+     * Add a domain to external browser list
+     */
+    public static void addDomain(SharedPreferences sharedPreferences, String domain) {
+        if (domain == null || domain.isEmpty()) {
+            return;
+        }
+
+        String normalizedDomain = normalizeDomain(domain);
+
+        // Don't add duplicate
+        if (isExternalBrowserDomain(sharedPreferences, normalizedDomain)) {
+            return;
+        }
+
+        Set<String> domains = getExternalBrowserDomains(sharedPreferences);
+        domains.add(normalizedDomain);
+        saveDomains(sharedPreferences, domains);
+    }
+
+    /**
+     * Remove a domain from external browser list
+     */
+    public static void removeDomain(SharedPreferences sharedPreferences, String domain) {
+        if (domain == null || domain.isEmpty()) {
+            return;
+        }
+
+        String normalizedDomain = normalizeDomain(domain);
+        Set<String> domains = getExternalBrowserDomains(sharedPreferences);
+        domains.remove(normalizedDomain);
+        saveDomains(sharedPreferences, domains);
+    }
+
+    /**
+     * Save domains to SharedPreferences as JSON
+     */
+    private static void saveDomains(SharedPreferences sharedPreferences, Set<String> domains) {
+        JSONArray jsonArray = new JSONArray(domains);
+        sharedPreferences.edit()
+                .putString(SharedPreferencesUtils.EXTERNAL_BROWSER_DOMAINS, jsonArray.toString())
+                .apply();
+    }
+
+    /**
+     * Normalize domain by removing www prefix for consistent comparison
+     */
+    private static String normalizeDomain(String domain) {
+        if (domain.startsWith("www.")) {
+            return domain.substring(4);
+        }
+        return domain;
+    }
+
+    /**
+     * Get domain from URL authority (handles www prefix)
+     */
+    public static String extractDomain(String authority) {
+        if (authority == null) {
+            return null;
+        }
+        return normalizeDomain(authority);
+    }
+}

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/utils/SharedPreferencesUtils.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/utils/SharedPreferencesUtils.java
@@ -105,6 +105,7 @@ public class SharedPreferencesUtils {
     public static final String MUTE_VIDEO = "mute_video";
     public static final String LINK_HANDLER = "link_handler";
     public static final String REWRITE_TWITTER_LINKS = "rewrite_twitter_links";
+    public static final String EXTERNAL_BROWSER_DOMAINS = "external_browser_domains";
     public static final String VIDEO_AUTOPLAY = "video_autoplay";
     public static final String VIDEO_AUTOPLAY_VALUE_ALWAYS_ON = "2";
     public static final String VIDEO_AUTOPLAY_VALUE_ON_WIFI = "1";

--- a/app/src/main/res/menu/web_view_activity.xml
+++ b/app/src/main/res/menu/web_view_activity.xml
@@ -23,4 +23,10 @@
         android:orderInCategory="4"
         android:title="@string/action_open_external_browser"
         app:showAsAction="never" />
+
+    <item
+        android:id="@+id/action_always_open_domain_external_web_view_activity"
+        android:orderInCategory="5"
+        android:title="@string/action_always_open_domain_external"
+        app:showAsAction="never" />
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -91,6 +91,7 @@
     <string name="action_share_link">Share Link</string>
     <string name="action_copy_link">Copy Link</string>
     <string name="action_open_external_browser">Open in browser</string>
+    <string name="action_always_open_domain_external">Always open domain in browser</string>
     <string name="action_add_to_post_filter">Add to Post Filter</string>
     <string name="action_delete_logs">Delete Logs</string>
     <string name="action_create_github_issue">Create GitHub Issue</string>
@@ -299,6 +300,12 @@
 
     <string name="no_activity_found_for_share">There is no app that can handle the share action</string>
     <string name="no_activity_found_for_external_browser">There is no app that can handle the open in external app action</string>
+    <string name="domain_added_to_external_browser">%1$s will always open in external browser</string>
+    <string name="invalid_domain">Could not extract domain from URL</string>
+    <string name="no_external_browser_domains">No domains configured to always open in external browser</string>
+    <string name="external_browser_domains_dialog_title">External Browser Domains</string>
+    <string name="remove_selected">Remove Selected</string>
+    <string name="domains_removed">Selected domains removed</string>
 
     <string name="archived_post_vote_unavailable">Archived post. Vote unavailable.</string>
     <string name="archived_post_comment_unavailable">Archived post. Comment unavailable.</string>
@@ -389,6 +396,8 @@
     <string name="settings_link_handler_title">Link Handler</string>
     <string name="settings_rewrite_twitter_links_title">Rewrite Twitter/X Links</string>
     <string name="settings_rewrite_twitter_links_summary">Rewrite x.com/twitter.com links to nitter.net</string>
+    <string name="settings_manage_external_browser_domains_title">Manage External Browser Domains</string>
+    <string name="settings_manage_external_browser_domains_summary">View and remove domains that always open in external browser</string>
     <string name="settigns_video_title">Video</string>
     <string name="settings_video_autoplay_title">Video Autoplay</string>
     <string name="settings_simultaneous_autoplay_limit_title">Simultaneous Autoplay Limit</string>

--- a/app/src/main/res/xml/miscellaneous_preferences.xml
+++ b/app/src/main/res/xml/miscellaneous_preferences.xml
@@ -22,6 +22,11 @@
         app:title="@string/settings_rewrite_twitter_links_title"
         app:summary="@string/settings_rewrite_twitter_links_summary" />
 
+    <ml.docilealligator.infinityforreddit.customviews.preference.CustomFontPreference
+        app:key="manage_external_browser_domains"
+        app:title="@string/settings_manage_external_browser_domains_title"
+        app:summary="@string/settings_manage_external_browser_domains_summary" />
+
     <ml.docilealligator.infinityforreddit.customviews.preference.CustomFontListPreference
         app:defaultValue="0"
         app:entries="@array/main_page_back_button_action"


### PR DESCRIPTION
- Add REWRITE_TWITTER_LINKS preference key
- Add toggle setting in Miscellaneous preferences
- Implement link rewriting in LinkResolverActivity
- Supports both x.com and twitter.com domains
- Preserves path, query parameters, and fragments