### PR TITLE
Adds Firefox Focus in getChromeCustomTabPackageName

### DIFF
--- a/app/src/main/java/ml/docilealligator/infinityforreddit/utils/UtilsKt.kt
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/utils/UtilsKt.kt
@@ -6,6 +6,6 @@ import androidx.browser.customtabs.CustomTabsClient
 
 fun getChromeCustomTabPackageName(context: Context): String? {
     return CustomTabsClient.getPackageName(
-        context, listOf("com.android.chrome", "com.chrome.beta", "com.chrome.dev", "com.chrome.canary"), true
+        context, listOf("com.android.chrome", "com.chrome.beta", "com.chrome.dev", "com.chrome.canary", "org.mozilla.focus"), true
     )
 }


### PR DESCRIPTION
⚠️ Disclaimer : I'm not an Android/Java Developper.
It's a small change, I'm quite confident that it should work. It did compile and it did work on my device.
I did not use AI in any way.
---

There's no real reason not to support other WebViews.

On my device, I have Firefox Focus configured as the main default browser. WebViews are then done by Firefox Focus.

I also have Google Chrome disabled, since I prefer to use Firefox.

So when I tried to login, it didn't quite work. I tried the "Custom Tab" button, but it complained that Chrome wasn't installed. So I enabled it, and tried again. That time, the custom tab did work, and it used my Firefox Focus for the WebView.

So I did a quick fork of the code to try adding Firefox Focus to the list.

And it worked better then I expected. Now the login page is shown, I don't have to select "Custom Tab", the login page just loads, and the login is also successful :)