### PR TITLE
fix: clear ViewBinding references in BottomSheetFragments to mitigate…

### DIFF
--- a/app/src/main/java/ml/docilealligator/infinityforreddit/bottomsheetfragments/CommentMoreBottomSheetFragment.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/bottomsheetfragments/CommentMoreBottomSheetFragment.java
@@ -252,4 +252,10 @@ public class CommentMoreBottomSheetFragment extends LandscapeExpandedRoundedBott
         super.onAttach(context);
         activity = (BaseActivity) context;
     }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        binding = null;
+    }
 }

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/bottomsheetfragments/FlairBottomSheetFragment.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/bottomsheetfragments/FlairBottomSheetFragment.java
@@ -128,6 +128,12 @@ public class FlairBottomSheetFragment extends LandscapeExpandedRoundedBottomShee
         mActivity = (BaseActivity) context;
     }
 
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        binding = null;
+    }
+
     public interface FlairSelectionCallback {
         void flairSelected(Flair flair);
     }

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/bottomsheetfragments/PostLayoutBottomSheetFragment.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/bottomsheetfragments/PostLayoutBottomSheetFragment.java
@@ -71,6 +71,12 @@ public class PostLayoutBottomSheetFragment extends LandscapeExpandedRoundedBotto
         this.activity = (BaseActivity) context;
     }
 
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        binding = null;
+    }
+
     public interface PostLayoutSelectionCallback {
         void postLayoutSelected(int postLayout);
     }

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/bottomsheetfragments/PostOptionsBottomSheetFragment.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/bottomsheetfragments/PostOptionsBottomSheetFragment.java
@@ -369,4 +369,10 @@ public class PostOptionsBottomSheetFragment extends LandscapeExpandedRoundedBott
         super.onAttach(context);
         mBaseActivity = (BaseActivity) context;
     }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        binding = null;
+    }
 }


### PR DESCRIPTION
## Description
This PR implements a focused mitigation for memory leaks related to `ViewBinding` lifecycle management, as identified in issue #1909.

In Android Fragments, the view's lifecycle is shorter than the fragment's lifecycle. By holding a reference to the `binding` object in a class field without clearing it in `onDestroyView()`, the entire view hierarchy is retained in memory even when the view is no longer visible or needed. This change ensures that these references are properly released.

## Changes
The following fragments have been updated to include a proper `onDestroyView()` override that sets the binding reference to `null`:
- `PostOptionsBottomSheetFragment`
- `CommentMoreBottomSheetFragment`
- `FlairBottomSheetFragment`
- `PostLayoutBottomSheetFragment`

## Technical Rationale
- **Memory Efficiency**: Prevents the retention of potentially large view hierarchies in the Garbage Collector's root set after the fragment's view destruction.
- **Safety**: These modifications are limited to `BottomSheet` fragments which are relatively isolated components, minimizing the risk of impacting the core navigation or complex business logic.
- **Stability**: The project compiles successfully, and no architectural changes were made.

## Related Issues
Addresses parts of #1909