### PR TITLE
Add hide spoiler filter option

### DIFF
--- a/app/src/main/java/ml/docilealligator/infinityforreddit/RedditDataRoomDatabase.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/RedditDataRoomDatabase.java
@@ -320,7 +320,7 @@ public abstract class RedditDataRoomDatabase extends RoomDatabase {
             database.execSQL("CREATE TABLE post_filter"
                     + "(name TEXT NOT NULL PRIMARY KEY, max_vote INTEGER NOT NULL, min_vote INTEGER NOT NULL, " +
                     "max_comments INTEGER NOT NULL, min_comments INTEGER NOT NULL, max_awards INTEGER NOT NULL, " +
-                    "min_awards INTEGER NOT NULL, only_nsfw INTEGER NOT NULL, only_spoiler INTEGER NOT NULL, " +
+                    "min_awards INTEGER NOT NULL, only_nsfw INTEGER NOT NULL, only_spoiler INTEGER NOT NULL, hide_spoilers INTEGER NOT NULL, " +
                     "post_title_excludes_regex TEXT, post_title_excludes_strings TEXT, exclude_subreddits TEXT, " +
                     "exclude_users TEXT, contain_flairs TEXT, exclude_flairs TEXT, contain_text_type INTEGER NOT NULL, " +
                     "contain_link_type INTEGER NOT NULL, contain_image_type INTEGER NOT NULL, " +

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/activities/CustomizePostFilterActivity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/activities/CustomizePostFilterActivity.java
@@ -171,6 +171,22 @@ public class CustomizePostFilterActivity extends BaseActivity {
             binding.onlySpoilerSwitchCustomizePostFilterActivity.performClick();
         });
 
+        binding.onlySpoilerSwitchCustomizePostFilterActivity.setOnCheckedChangeListener((buttonView, isChecked) -> {
+            if (isChecked) {
+                binding.hideSpoilersSwitchCustomizePostFilterActivity.setChecked(false);
+            }
+        });
+
+        binding.hideSpoilersLinearLayoutCustomizePostFilterActivity.setOnClickListener(view -> {
+            binding.hideSpoilersSwitchCustomizePostFilterActivity.performClick();
+        });
+
+        binding.hideSpoilersSwitchCustomizePostFilterActivity.setOnCheckedChangeListener((buttonView, isChecked) -> {
+            if (isChecked) {
+                binding.onlySpoilerSwitchCustomizePostFilterActivity.setChecked(false);
+            }
+        });
+
         binding.excludeAddSubredditsImageViewCustomizePostFilterActivity.setOnClickListener(view -> {
             Intent intent = new Intent(this, SubredditMultiselectionActivity.class);
             startActivityForResult(intent, ADD_EXCLUDE_SUBREDDITS_REQUEST_CODE);
@@ -221,6 +237,7 @@ public class CustomizePostFilterActivity extends BaseActivity {
         binding.postTypeGallerySwitchCustomizePostFilterActivity.setChecked(postFilter.containGalleryType);
         binding.onlyNsfwSwitchCustomizePostFilterActivity.setChecked(postFilter.onlyNSFW);
         binding.onlySpoilerSwitchCustomizePostFilterActivity.setChecked(postFilter.onlySpoiler);
+        binding.hideSpoilersSwitchCustomizePostFilterActivity.setChecked(postFilter.hideSpoilers);
         binding.titleExcludesStringsTextInputEditTextCustomizePostFilterActivity.setText(postFilter.postTitleExcludesStrings);
         binding.titleContainsStringsTextInputEditTextCustomizePostFilterActivity.setText(postFilter.postTitleContainsStrings);
         binding.titleExcludesRegexTextInputEditTextCustomizePostFilterActivity.setText(postFilter.postTitleExcludesRegex);
@@ -350,6 +367,8 @@ public class CustomizePostFilterActivity extends BaseActivity {
         binding.onlyNsfwTextViewCustomizePostFilterActivity.setTextColor(primaryTextColor);
         binding.onlySpoilerTextViewCustomizePostFilterActivity.setCompoundDrawablesWithIntrinsicBounds(Utils.getTintedDrawable(this, R.drawable.ic_spoiler_black_24dp, primaryIconColor), null, null, null);
         binding.onlySpoilerTextViewCustomizePostFilterActivity.setTextColor(primaryTextColor);
+        binding.hideSpoilersTextViewCustomizePostFilterActivity.setCompoundDrawablesWithIntrinsicBounds(Utils.getTintedDrawable(this, R.drawable.ic_unmark_spoiler_24dp, primaryIconColor), null, null, null);
+        binding.hideSpoilersTextViewCustomizePostFilterActivity.setTextColor(primaryTextColor);
 
         binding.titleStringsCardViewCustomizePostFilterActivity.setCardBackgroundColor(filledCardViewBackgroundColor);
         binding.titleExcludeStringsExplanationTextViewCustomizePostFilterActivity.setTextColor(primaryTextColor);
@@ -656,6 +675,7 @@ public class CustomizePostFilterActivity extends BaseActivity {
         postFilter.containGalleryType = binding.postTypeGallerySwitchCustomizePostFilterActivity.isChecked();
         postFilter.onlyNSFW = binding.onlyNsfwSwitchCustomizePostFilterActivity.isChecked();
         postFilter.onlySpoiler = binding.onlySpoilerSwitchCustomizePostFilterActivity.isChecked();
+        postFilter.hideSpoilers = binding.hideSpoilersSwitchCustomizePostFilterActivity.isChecked();
     }
 
     @Override

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/postfilter/PostFilter.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/postfilter/PostFilter.java
@@ -41,6 +41,8 @@ public class PostFilter implements Parcelable {
     public boolean onlyNSFW;
     @ColumnInfo(name = "only_spoiler")
     public boolean onlySpoiler;
+    @ColumnInfo(name = "hide_spoilers")
+    public boolean hideSpoilers;
     @ColumnInfo(name = "post_title_excludes_regex")
     public String postTitleExcludesRegex;
     @ColumnInfo(name = "post_title_contains_regex")
@@ -97,6 +99,7 @@ public class PostFilter implements Parcelable {
         allowNSFW = in.readByte() != 0;
         onlyNSFW = in.readByte() != 0;
         onlySpoiler = in.readByte() != 0;
+        hideSpoilers = in.readByte() != 0;
         postTitleExcludesRegex = in.readString();
         postTitleContainsRegex = in.readString();
         postTitleExcludesStrings = in.readString();
@@ -162,6 +165,9 @@ public class PostFilter implements Parcelable {
             if (postFilter.onlyNSFW) {
                 return post.isNSFW();
             }
+            return false;
+        }
+        if (postFilter.hideSpoilers && post.isSpoiler()) {
             return false;
         }
         if (!postFilter.containTextType && post.getPostType() == Post.TEXT_TYPE) {
@@ -360,6 +366,7 @@ public class PostFilter implements Parcelable {
 
             postFilter.onlyNSFW = p.onlyNSFW ? p.onlyNSFW : postFilter.onlyNSFW;
             postFilter.onlySpoiler = p.onlySpoiler ? p.onlySpoiler : postFilter.onlySpoiler;
+            postFilter.hideSpoilers = p.hideSpoilers ? p.hideSpoilers : postFilter.hideSpoilers;
 
             if (p.postTitleExcludesRegex != null && !p.postTitleExcludesRegex.isEmpty()) {
                 postFilter.postTitleExcludesRegexes.add(p.postTitleExcludesRegex);
@@ -459,6 +466,7 @@ public class PostFilter implements Parcelable {
         parcel.writeByte((byte) (allowNSFW ? 1 : 0));
         parcel.writeByte((byte) (onlyNSFW ? 1 : 0));
         parcel.writeByte((byte) (onlySpoiler ? 1 : 0));
+        parcel.writeByte((byte) (hideSpoilers ? 1 : 0));
         parcel.writeString(postTitleExcludesRegex);
         parcel.writeString(postTitleContainsRegex);
         parcel.writeString(postTitleExcludesStrings);

--- a/app/src/main/res/layout-land/activity_customize_post_filter.xml
+++ b/app/src/main/res/layout-land/activity_customize_post_filter.xml
@@ -409,6 +409,37 @@
 
                         </LinearLayout>
 
+                        <LinearLayout
+                            android:id="@+id/hide_spoilers_linear_layout_customize_post_filter_activity"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:paddingTop="4dp"
+                            android:paddingBottom="4dp"
+                            android:paddingStart="16dp"
+                            android:paddingEnd="16dp"
+                            android:clickable="true"
+                            android:focusable="true"
+                            android:background="?attr/selectableItemBackground">
+
+                            <TextView
+                                android:id="@+id/hide_spoilers_text_view_customize_post_filter_activity"
+                                android:layout_width="0dp"
+                                android:layout_height="wrap_content"
+                                android:layout_weight="1"
+                                android:layout_gravity="center_vertical"
+                                android:drawablePadding="32dp"
+                                android:text="@string/hide_spoilers"
+                                android:fontFamily="?attr/font_default"
+                                android:textSize="?attr/font_default" />
+
+                            <ml.docilealligator.infinityforreddit.customviews.ThemedMaterialSwitch
+                                android:id="@+id/hide_spoilers_switch_customize_post_filter_activity"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_gravity="center_vertical" />
+
+                        </LinearLayout>
+
                     </LinearLayout>
 
                 </com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/layout-sw600dp/activity_customize_post_filter.xml
+++ b/app/src/main/res/layout-sw600dp/activity_customize_post_filter.xml
@@ -409,6 +409,37 @@
 
                         </LinearLayout>
 
+                        <LinearLayout
+                            android:id="@+id/hide_spoilers_linear_layout_customize_post_filter_activity"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:paddingTop="4dp"
+                            android:paddingBottom="4dp"
+                            android:paddingStart="16dp"
+                            android:paddingEnd="16dp"
+                            android:clickable="true"
+                            android:focusable="true"
+                            android:background="?attr/selectableItemBackground">
+
+                            <TextView
+                                android:id="@+id/hide_spoilers_text_view_customize_post_filter_activity"
+                                android:layout_width="0dp"
+                                android:layout_height="wrap_content"
+                                android:layout_weight="1"
+                                android:layout_gravity="center_vertical"
+                                android:drawablePadding="32dp"
+                                android:text="@string/hide_spoilers"
+                                android:fontFamily="?attr/font_default"
+                                android:textSize="?attr/font_default" />
+
+                            <ml.docilealligator.infinityforreddit.customviews.ThemedMaterialSwitch
+                                android:id="@+id/hide_spoilers_switch_customize_post_filter_activity"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_gravity="center_vertical" />
+
+                        </LinearLayout>
+
                     </LinearLayout>
 
                 </com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/layout/activity_customize_post_filter.xml
+++ b/app/src/main/res/layout/activity_customize_post_filter.xml
@@ -409,6 +409,37 @@
 
                     </LinearLayout>
 
+                    <LinearLayout
+                        android:id="@+id/hide_spoilers_linear_layout_customize_post_filter_activity"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:paddingTop="4dp"
+                        android:paddingBottom="4dp"
+                        android:paddingStart="16dp"
+                        android:paddingEnd="16dp"
+                        android:clickable="true"
+                        android:focusable="true"
+                        android:background="?attr/selectableItemBackground">
+
+                        <TextView
+                            android:id="@+id/hide_spoilers_text_view_customize_post_filter_activity"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:layout_gravity="center_vertical"
+                            android:drawablePadding="32dp"
+                            android:text="@string/hide_spoilers"
+                            android:fontFamily="?attr/font_default"
+                            android:textSize="?attr/font_default" />
+
+                        <ml.docilealligator.infinityforreddit.customviews.ThemedMaterialSwitch
+                            android:id="@+id/hide_spoilers_switch_customize_post_filter_activity"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_gravity="center_vertical" />
+
+                    </LinearLayout>
+
                 </LinearLayout>
 
             </com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1179,6 +1179,7 @@
 
     <string name="only_sensitive_content">Only Sensitive Content</string>
     <string name="only_spoiler">Only Spoiler</string>
+    <string name="hide_spoilers">Hide Spoilers</string>
     <string name="title_excludes_strings_hint">Title: excludes keywords (key1,key2)</string>
     <string name="title_contains_strings_hint">Title: contains keywords (key1,key2)</string>
     <string name="title_excludes_regex_hint">Title: excludes regex</string>


### PR DESCRIPTION
Added a new "Hide spoilers" option to post filters.

Changes:

- Added a "Hide spoilers" toggle below the existing "Only spoiler" option in the post filter screen.
- Prevented "Only spoiler" and "Hide spoilers" from being enabled simultaneously by automatically disabling the opposite option when one is enabled.

Enabling the "Hide spoilers" slider will simply prevent any spoiler content from showing up wherever the specific post filter is applied.