### PR TITLE
Fix issue 1959 by deferring DNS resolution to actual connection time

### DIFF
--- a/app/src/main/java/ml/docilealligator/infinityforreddit/NetworkModule.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/NetworkModule.java
@@ -65,7 +65,7 @@ abstract class NetworkModule {
                 String proxyHost = mProxySharedPreferences.getString(SharedPreferencesUtils.PROXY_HOSTNAME, "127.0.0.1");
                 int proxyPort = Integer.parseInt(mProxySharedPreferences.getString(SharedPreferencesUtils.PROXY_PORT, "1080"));
 
-                InetSocketAddress proxyAddr = new InetSocketAddress(proxyHost, proxyPort);
+                InetSocketAddress proxyAddr = InetSocketAddress.createUnresolved(proxyHost, proxyPort);
                 Proxy proxy = new Proxy(proxyType, proxyAddr);
                 builder.proxy(proxy);
             }

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/ProxyEnabledGlideModule.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/ProxyEnabledGlideModule.java
@@ -36,7 +36,7 @@ public class ProxyEnabledGlideModule extends AppGlideModule {
                 String proxyHost = mProxySharedPreferences.getString(SharedPreferencesUtils.PROXY_HOSTNAME, "127.0.0.1");
                 int proxyPort = Integer.parseInt(mProxySharedPreferences.getString(SharedPreferencesUtils.PROXY_PORT, "1080"));
 
-                InetSocketAddress proxyAddr = new InetSocketAddress(proxyHost, proxyPort);
+                InetSocketAddress proxyAddr = InetSocketAddress.createUnresolved(proxyHost, proxyPort);
                 Proxy proxy = new Proxy(proxyType, proxyAddr);
                 builder.proxy(proxy);
             }


### PR DESCRIPTION
Hello,

This should fix #1959.

It is a minor change : instead of resolving hostname at the creation of the MainActivity, it is now deferred to actual connection time.

It should allow users to launch the app and change their proxy settings if they were incorrect instead of locking them out.

Tested and working on my old phone.